### PR TITLE
Another quick fix to the sub-protocol example

### DIFF
--- a/docs/getting-started/using-pubsub-subprotocol/js-work-with-subprotocols.md
+++ b/docs/getting-started/using-pubsub-subprotocol/js-work-with-subprotocols.md
@@ -72,12 +72,18 @@ Now let's create a simple web application using the subprotocol.
           };
 
           let output = document.querySelector('#output');
-          ws.onmessage = event => {
-            let message = JSON.parse(event.data);
-            let d = document.createElement('p');
-            d.innerText = message.text;
-            output.appendChild(d);
-          };
+          ws.onmessage = (event) => {
+            let message = JSON.parse(event.data)
+            let text = ""
+            if (message.type === "system") {
+              text = `System message: ${message.event}`
+            } else {
+              text = message.data
+            }
+            let d = document.createElement("p")
+            d.innerText = text
+            output.appendChild(d)
+        }
         })();
       </script>
     </body>


### PR DESCRIPTION
- Handles and displays system messages such as "connected"
- `message.text` wasn't correct, should have been `message.data`, doh!