### PR TITLE
Fix the path of Web PubSub CloudEvents protocol

### DIFF
--- a/docs/getting-started/auth-and-permissions/js-auth-and-permissions.md
+++ b/docs/getting-started/auth-and-permissions/js-auth-and-permissions.md
@@ -197,7 +197,6 @@ ws.onmessage = event => {
 };
 
 let message = document.querySelector('#message');
-let send = document.querySelector('#send');
 message.addEventListener('keypress', e => {
   if (e.charCode !== 13) return;
   ws.send(JSON.stringify({

--- a/docs/getting-started/create-a-chat-app/csharp-handle-events.md
+++ b/docs/getting-started/create-a-chat-app/csharp-handle-events.md
@@ -253,7 +253,7 @@ Besides system events like `connected` or `disconnected`, client can also send m
 
     <body>
       <h1>Azure Web PubSub Chat</h1>
-      <input id="message" placeholder="Type to chat..."></input>
+      <input id="message" placeholder="Type to chat...">
       <div id="messages"></div>
       <script>
         (async function () {
@@ -267,7 +267,6 @@ Besides system events like `connected` or `disconnected`, client can also send m
           };
 
           let message = document.querySelector('#message');
-          let send = document.querySelector('#send');
           message.addEventListener('keypress', e => {
             if (e.charCode !== 13) return;
             ws.send(message.value);

--- a/docs/getting-started/create-a-chat-app/csharp-handle-events.md
+++ b/docs/getting-started/create-a-chat-app/csharp-handle-events.md
@@ -196,7 +196,7 @@ Then open Azure portal and go to the settings tab to configure the event handler
 
 1. Type the hub name (chat) and click "Add".
 
-2. Set URL Pattern to `https://<domain-name>.ngrok.io/eventhandler` and check "connected" in System Event Pattern, click "Save".
+2. Set URL Pattern to `https://<domain-name>.ngrok.io/eventhandler` and check "connected" in System Events, click "Save".
 
 ![Event Handler](./../../images/portal_event_handler.png)
 

--- a/docs/getting-started/create-a-chat-app/csharp-handle-events.md
+++ b/docs/getting-started/create-a-chat-app/csharp-handle-events.md
@@ -129,7 +129,7 @@ In Azure Web PubSub, when there are certain activities happening at client side 
 
 Events are delivered to server in the form of Webhook. Webhook is a set of REST APIs exposed by server and registered at service side, so service will callback these APIs whenever an event happens.
 
-Azure Web PubSub follows [CloudEvents](https://cloudevents.io/) to describe event data. The format of the Web PubSub CloudEvents events follow exactly the [Web PubSub CloudEvents protocol](../references/protocol-cloudevents.md). For now, you need to implement the event handler by your own in C#, the steps are pretty straight forward following the protocol spec as well as illustrated below.
+Azure Web PubSub follows [CloudEvents](https://cloudevents.io/) to describe event data. The format of the Web PubSub CloudEvents events follow exactly the [Web PubSub CloudEvents protocol](../../references/protocol-cloudevents.md). For now, you need to implement the event handler by your own in C#, the steps are pretty straight forward following the protocol spec as well as illustrated below.
 
 1. Add event handlers inside `UseEndpoints`. Specify the endpoint path for the events, let's say `/eventhandler`. 
 

--- a/docs/getting-started/create-a-chat-app/csharp-handle-events.md
+++ b/docs/getting-started/create-a-chat-app/csharp-handle-events.md
@@ -252,7 +252,7 @@ Besides system events like `connected` or `disconnected`, client can also send m
 
     <body>
       <h1>Azure Web PubSub Chat</h1>
-      <input id="message" placeholder="Type to chat...">
+      <input id="message" placeholder="Type to chat..." />
       <div id="messages"></div>
       <script>
         (async function () {

--- a/docs/getting-started/create-a-chat-app/csharp-handle-events.md
+++ b/docs/getting-started/create-a-chat-app/csharp-handle-events.md
@@ -252,7 +252,7 @@ Besides system events like `connected` or `disconnected`, client can also send m
 
     <body>
       <h1>Azure Web PubSub Chat</h1>
-      <input id="message" placeholder="Type to chat..." />
+      <input id="message" placeholder="Type to chat...">
       <div id="messages"></div>
       <script>
         (async function () {

--- a/docs/getting-started/create-a-chat-app/java-handle-events.md
+++ b/docs/getting-started/create-a-chat-app/java-handle-events.md
@@ -217,7 +217,7 @@ Create `/public/index.html` in `resources` folder, to add the logic to send mess
 <html>
 <body>
   <h1>Azure Web PubSub Chat</h1>
-  <input id="message" placeholder="Type to chat..."></input>
+  <input id="message" placeholder="Type to chat...">
   <div id="messages"></div>
   <script>
     (async function () {
@@ -235,7 +235,6 @@ Create `/public/index.html` in `resources` folder, to add the logic to send mess
       };
 
       let message = document.querySelector('#message');
-      let send = document.querySelector('#send');
       message.addEventListener('keypress', e => {
         if (e.charCode !== 13) return;
         ws.send(message.value);

--- a/docs/getting-started/create-a-chat-app/js-handle-events.md
+++ b/docs/getting-started/create-a-chat-app/js-handle-events.md
@@ -191,7 +191,7 @@ Besides system events like connected or disconnected, client can also send messa
 
     <body>
       <h1>Azure Web PubSub Chat</h1>
-      <input id="message" placeholder="Type to chat..."></input>
+      <input id="message" placeholder="Type to chat...">
       <div id="messages"></div>
       <script>
         (async function () {
@@ -205,7 +205,6 @@ Besides system events like connected or disconnected, client can also send messa
           };
 
           let message = document.querySelector('#message');
-          let send = document.querySelector('#send');
           message.addEventListener('keypress', e => {
             if (e.charCode !== 13) return;
             ws.send(message.value);

--- a/samples/csharp/chatapp/wwwroot/index.html
+++ b/samples/csharp/chatapp/wwwroot/index.html
@@ -2,7 +2,7 @@
 
 <body>
   <h1>Azure Web PubSub Chat</h1>
-  <input id="message" placeholder="Type to chat..."></input>
+  <input id="message" placeholder="Type to chat...">
   <div id="messages"></div>
   <script>
     (async function () {
@@ -20,7 +20,6 @@
       };
 
       let message = document.querySelector('#message');
-      let send = document.querySelector('#send');
       message.addEventListener('keypress', e => {
         if (e.charCode !== 13) return;
         ws.send(message.value);

--- a/samples/java/chatapp/src/main/resources/public/index.html
+++ b/samples/java/chatapp/src/main/resources/public/index.html
@@ -2,7 +2,7 @@
 
 <body>
   <h1>Azure Web PubSub Chat</h1>
-  <input id="message" placeholder="Type to chat..."></input>
+  <input id="message" placeholder="Type to chat...">
   <div id="messages"></div>
   <script>
     (async function () {
@@ -20,7 +20,6 @@
       };
 
       let message = document.querySelector('#message');
-      let send = document.querySelector('#send');
       message.addEventListener('keypress', e => {
         if (e.charCode !== 13) return;
         ws.send(message.value);

--- a/samples/javascript/chatapp/public/index.html
+++ b/samples/javascript/chatapp/public/index.html
@@ -2,7 +2,7 @@
 
 <body>
   <h1>Azure Web PubSub Chat</h1>
-  <input id="message" placeholder="Type to chat..."></input>
+  <input id="message" placeholder="Type to chat...">
   <div id="messages"></div>
   <script>
     (async function () {
@@ -21,7 +21,6 @@
       };
 
       let message = document.querySelector('#message');
-      let send = document.querySelector('#send');
       message.addEventListener('keypress', e => {
         if (e.charCode !== 13) return;
         ws.send(message.value);

--- a/samples/javascript/githubchat/public/index.html
+++ b/samples/javascript/githubchat/public/index.html
@@ -2,7 +2,7 @@
 
 <body>
   <h1>Azure Web PubSub Chat</h1>
-  <input id="message" placeholder="Type to chat..."></input>
+  <input id="message" placeholder="Type to chat...">
   <button id="system">system message</button>
   <div id="messages"></div>
   <script>
@@ -35,7 +35,6 @@
       };
 
       let message = document.querySelector('#message');
-      let send = document.querySelector('#send');
       message.addEventListener('keypress', e => {
         if (e.charCode !== 13) return;
         ws.send(JSON.stringify({

--- a/samples/python/chatapp/public/index.html
+++ b/samples/python/chatapp/public/index.html
@@ -2,7 +2,7 @@
 
 <body>
   <h1>Azure Web PubSub Chat</h1>
-  <input id="message" placeholder="Type to chat..."></input>
+  <input id="message" placeholder="Type to chat...">
   <div id="messages"></div>
   <script>
     (async function () {
@@ -21,7 +21,6 @@
       };
 
       let message = document.querySelector('#message');
-      let send = document.querySelector('#send');
       message.addEventListener('keypress', e => {
         if (e.charCode !== 13) return;
         ws.send(message.value);


### PR DESCRIPTION
The path of Web PubSub CloudEvents protocol in getting-started page is wrong and return 404.
https://azure.github.io/azure-webpubsub/getting-started/create-a-chat-app/csharp-handle-events.html#handle-events-1