### PR TITLE
Fixed method call examples to be async

### DIFF
--- a/docs/references/client-websocket-apis/csharp-client-websocket-apis.md
+++ b/docs/references/client-websocket-apis/csharp-client-websocket-apis.md
@@ -44,7 +44,7 @@ namespace subscriber
     {
         static async Task Main(string[] args)
         {
-            using (var client = new WebsocketClient("<Client_URL_From_Portal>"))
+            using (var client = new WebsocketClient(new Uri("<Client_URL_From_Portal>")))
             {
                 client.MessageReceived.Subscribe(msg => Console.WriteLine($"Message received: {msg}"));
                 await client.Start();
@@ -71,7 +71,7 @@ namespace subscriber
     {
         static async Task Main(string[] args)
         {
-            using (var client = new WebsocketClient("<Client_URL_From_Portal>", () =>
+            using (var client = new WebsocketClient(new Uri("<Client_URL_From_Portal>"), () =>
             {
                 var inner = new ClientWebSocket();
                 inner.Options.AddSubProtocol("json.webpubsub.azure.v1");

--- a/docs/references/server-sdks/csharp-server-sdks.md
+++ b/docs/references/server-sdks/csharp-server-sdks.md
@@ -74,14 +74,14 @@ Using this library, you can send messages to the client connections. A message c
 
 ```csharp
 var serviceClient = new WebPubSubServiceClient(new Uri("<endpoint>"), "<hub>", new AzureKeyCredential("<access-key>"));
-await serviceClient.SendToAll("Hello world!");
+await serviceClient.SendToAllAsync("Hello world!");
 ```
 
 ### Broadcast a JSON message to all clients
 
 ```csharp
 var serviceClient = new WebPubSubServiceClient(new Uri("<endpoint>"), "<hub>", new AzureKeyCredential("<access-key>"));
-await serviceClient.SendToAll(
+await serviceClient.SendToAllAsync(
     RequestContent.Create(
         new {
             Foo = "Hello World!",
@@ -94,7 +94,7 @@ await serviceClient.SendToAll(
 ```csharp
 var serviceClient = new WebPubSubServiceClient(new Uri("<endpoint>"), "<hub>", new AzureKeyCredential("<access-key>"));
 
-client.SendToAll(
+await serviceClient.SendToAllAsync(
     RequestContent.Create(new byte[] {0x1, 0x2, 0x3}), 
     HttpHeader.Common.OctetStreamContentType.Value
 );


### PR DESCRIPTION
Going to the demo examples, I found some calls on WebPubSubServiceClient service should be Async in order to keep the example consistent.

Thanks.