### PR TITLE
Add one-click deploy to three demos and fixed a minor UI issue

### DIFF
--- a/website/src/DataDemos.js
+++ b/website/src/DataDemos.js
@@ -9,6 +9,8 @@ export let DataDemos = [
     detailURL: 'demos/chat',
     thumbnailURL: 'img/thumbnails/chat_abstract.jpeg',
     githubRepo: 'https://github.com/Azure/azure-webpubsub/tree/main/samples/javascript/chatapp',
+    deployLink:
+      'https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Flivedemopackages.blob.core.windows.net%2Ftemplate%2Fchatapp-containerapp-deploy.json',
   },
   {
     id: 2,
@@ -20,6 +22,8 @@ export let DataDemos = [
     detailURL: 'demos/whiteboard',
     thumbnailURL: 'img/thumbnails/whiteboard.jpeg',
     githubRepo: 'https://github.com/Azure/azure-webpubsub/tree/main/samples/javascript/whiteboard',
+    deployLink:
+      'https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Flivedemopackages.blob.core.windows.net%2Ftemplate%2Fwhiteboard-containerapp-deploy.json',
   },
   {
     id: 3,
@@ -42,6 +46,8 @@ export let DataDemos = [
     detailURL: 'demos/code-streaming',
     thumbnailURL: 'img/thumbnails/code.png',
     githubRepo: 'https://github.com/Azure/azure-webpubsub/tree/main/samples/javascript/codestream',
+    deployLink:
+      'https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Flivedemopackages.blob.core.windows.net%2Ftemplate%2Fcodestream-containerapp-deploy.json',
   },
   {
     id: 5,

--- a/website/src/components/DemoPage/CodeStream/CodeStream.js
+++ b/website/src/components/DemoPage/CodeStream/CodeStream.js
@@ -14,13 +14,14 @@ const DataDemo = DataDemos.find(item => item.detailURL === 'demos/code-streaming
 
 const languages = DataDemo.languages
 const githubURL = DataDemo.githubRepo
+const onClickDeploy = DataDemo.deployLink
 
 function CodeStream() {
   return (
-    <>
+    <div>
       <SplitDemo
+        alert="To see streaming as you code, open the link in another tab."
         leftSrc="https://awps-demos-codestream.azurewebsites.net/"
-        rightSrc="https://awps-demos-codestream.azurewebsites.net/"
         description="Real-time chat app demo"
         width="400"
         languages={languages}
@@ -28,9 +29,9 @@ function CodeStream() {
       />
 
       <div className="max-w-full overflow-hidden">
-        <DemoTabs overview={<Overview />} local={<Local />} resources={<Resources />} />
+        <DemoTabs overview={<Overview />} local={<Local />} resources={<Resources />} deploy={<Deploy to={onClickDeploy} />} />
       </div>
-    </>
+    </div>
   )
 }
 

--- a/website/src/components/DemoPage/CollaborativeWhiteboard/CollaborativeWhiteboard.js
+++ b/website/src/components/DemoPage/CollaborativeWhiteboard/CollaborativeWhiteboard.js
@@ -14,6 +14,7 @@ const DataDemo = DataDemos.find(item => item.detailURL === 'demos/whiteboard')
 
 const languages = DataDemo.languages
 const githubURL = DataDemo.githubRepo
+const onClickDeploy = DataDemo.deployLink
 
 function CollaborativeWhiteboard() {
   return (
@@ -28,7 +29,7 @@ function CollaborativeWhiteboard() {
       />
 
       <div className="max-w-full overflow-hidden">
-        <DemoTabs overview={<Overview />} local={<Local />} resources={<Resources />} />
+        <DemoTabs overview={<Overview />} local={<Local />} resources={<Resources />} deploy={<Deploy to={onClickDeploy} />} />
       </div>
     </>
   )

--- a/website/src/components/DemoPage/SimpleChatApp/SimpleChatApp.js
+++ b/website/src/components/DemoPage/SimpleChatApp/SimpleChatApp.js
@@ -14,6 +14,7 @@ const DataDemo = DataDemos.find(item => item.detailURL === 'demos/chat')
 
 const languages = DataDemo.languages
 const githubURL = DataDemo.githubRepo
+const onClickDeploy = DataDemo.deployLink
 
 function SimpleChatApp() {
   return (
@@ -28,7 +29,7 @@ function SimpleChatApp() {
       />
 
       <div className="max-w-full overflow-hidden">
-        <DemoTabs overview={<Overview />} local={<Local />} resources={<Resources />} />
+        <DemoTabs overview={<Overview />} local={<Local />} resources={<Resources />} deploy={<Deploy to={onClickDeploy} />} />
       </div>
     </>
   )

--- a/website/src/components/DemoPage/SplitDemo.js
+++ b/website/src/components/DemoPage/SplitDemo.js
@@ -1,15 +1,16 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 
 import SourceCode from '@site/src/components/Common/SourceCode'
 import ButtonLink from '@site/src/components/Common/ButtonLink'
 import GitHub from '@site/static/logos/github_logo.svg'
 
-function SplitDemo({ leftSrc, rightSrc, description, languages, githubURL }) {
+function SplitDemo({ alert, leftSrc, rightSrc, description, languages, githubURL }) {
   return (
     <div className="pattern-dots-sm mb-10">
-      <div className="flex flex-col items-center gap-6 py-4 drop-shadow-xl xl:flex-row">
-        <iframe src={leftSrc} title={description} className="h-[400px] w-[95%] xl:h-[600px]"></iframe>
-        <iframe src={rightSrc} title={description} className="h-[400px] w-[95%] xl:h-[600px]"></iframe>
+      {alert && <p className="bg-red-100 py-2 text-center font-bold text-red-900 ">{alert}</p>}
+      <div className={`flex flex-col items-center ${leftSrc && rightSrc ? 'gap-6' : 'w-full'} py-4 drop-shadow-xl xl:flex-row`}>
+        {leftSrc && <iframe src={leftSrc} title={description} className="h-[400px] w-[95%] xl:h-[600px]"></iframe>}
+        {rightSrc && <iframe src={rightSrc} title={description} className="h-[400px] w-[95%] xl:h-[600px]"></iframe>}
       </div>
       <div className="flex flex-col items-center xl:flex-row xl:items-center xl:justify-around">
         <ButtonLink text="View source" to={githubURL}>


### PR DESCRIPTION
**What's added?**
- Support for one-click deploy for three demos. (code stream, whiteboard and simple chat)
**What's changed?**
- Removed the side-by-side view of code stream demo as it requires major change to the demo backend code. 