### PR TITLE
Ensure Socket.IO adapter broadcast binary packets in one request

### DIFF
--- a/experimental/sdk/webpubsub-socketio-extension/src/EIO/components/constants.ts
+++ b/experimental/sdk/webpubsub-socketio-extension/src/EIO/components/constants.ts
@@ -5,6 +5,9 @@ export const WEBPUBSUB_TRANSPORT_NAME = "webpubsub";
 export const WEBPUBSUB_CLIENT_CONNECTION_FILED_NAME = "webPubSubClientConnection";
 export const WEBPUBSUB_CONNECT_RESPONSE_FIELD_NAME = "socketio";
 
+// Reference: https://github.com/socketio/engine.io-parser/blob/5.1.0/lib/index.ts#L7
+export const EIO_PACKET_SEPARATOR = String.fromCharCode(30);
+
 // Reference: https://github.com/socketio/engine.io/blob/123b68c04f9e971f59b526e0f967a488ee6b0116/README.md?plain=1#L219
 export const CONNECTION_ERROR_EVENT_NAME = "connection_error";
 export const CONNECTION_ERROR_WEBPUBSUB_CODE = 6;

--- a/experimental/sdk/webpubsub-socketio-extension/src/EIO/components/constants.ts
+++ b/experimental/sdk/webpubsub-socketio-extension/src/EIO/components/constants.ts
@@ -5,9 +5,6 @@ export const WEBPUBSUB_TRANSPORT_NAME = "webpubsub";
 export const WEBPUBSUB_CLIENT_CONNECTION_FILED_NAME = "webPubSubClientConnection";
 export const WEBPUBSUB_CONNECT_RESPONSE_FIELD_NAME = "socketio";
 
-// Reference: https://github.com/socketio/engine.io-parser/blob/5.1.0/lib/index.ts#L7
-export const EIO_PACKET_SEPARATOR = String.fromCharCode(30);
-
 // Reference: https://github.com/socketio/engine.io/blob/123b68c04f9e971f59b526e0f967a488ee6b0116/README.md?plain=1#L219
 export const CONNECTION_ERROR_EVENT_NAME = "connection_error";
 export const CONNECTION_ERROR_WEBPUBSUB_CODE = 6;

--- a/experimental/sdk/webpubsub-socketio-extension/src/SIO/components/encoder.ts
+++ b/experimental/sdk/webpubsub-socketio-extension/src/SIO/components/encoder.ts
@@ -1,0 +1,23 @@
+import { toAsync } from "../../common/utils";
+import { Packet as SioPacket } from "socket.io-parser";
+import { Packet as EioPacket, encodePayload as encodeEioPayload, PacketType as EioPacketType } from "engine.io-parser";
+import { Encoder as SioEncoder } from "socket.io-parser";
+
+const encodeEioPayloadAsync = toAsync<string>(encodeEioPayload);
+const sioEncoder: SioEncoder = new SioEncoder();
+
+// Modified from https://github.com/socketio/socket.io-adapter/blob/2.5.2/lib/index.ts#L233
+export function getSingleEioEncodedPayload(packet: SioPacket): Promise<string> {
+  // if `packet` owns binary attachements, `sioEncoder.encode` returns [string, ...buffers].
+  // Otherwise, it returns a single element of string which is the encoded SIO packet.
+  let encodedSioPackets = sioEncoder.encode(packet);
+
+  // Ensure `encodedSioPackets` is an array
+  encodedSioPackets = Array.isArray(encodedSioPackets) ? encodedSioPackets : [encodedSioPackets];
+
+  const eioPackets: EioPacket[] = encodedSioPackets.map((item) => {
+    return { type: "message" as EioPacketType, data: item } as EioPacket;
+  });
+
+  return encodeEioPayloadAsync(eioPackets);
+}

--- a/experimental/sdk/webpubsub-socketio-extension/src/SIO/components/encoder.ts
+++ b/experimental/sdk/webpubsub-socketio-extension/src/SIO/components/encoder.ts
@@ -1,7 +1,6 @@
 import { toAsync } from "../../common/utils";
-import { Packet as SioPacket } from "socket.io-parser";
 import { Packet as EioPacket, encodePayload as encodeEioPayload, PacketType as EioPacketType } from "engine.io-parser";
-import { Encoder as SioEncoder } from "socket.io-parser";
+import { Packet as SioPacket, Encoder as SioEncoder } from "socket.io-parser";
 
 const encodeEioPayloadAsync = toAsync<string>(encodeEioPayload);
 const sioEncoder: SioEncoder = new SioEncoder();

--- a/experimental/sdk/webpubsub-socketio-extension/src/SIO/components/web-pubsub-adapter.ts
+++ b/experimental/sdk/webpubsub-socketio-extension/src/SIO/components/web-pubsub-adapter.ts
@@ -104,6 +104,8 @@ export class WebPubSubAdapterInternal extends NativeInMemoryAdapter {
 
       await this.service.group(groupName).addConnection(eioSid);
     }
+
+    super.addAll(id, rooms);
   }
 
   /**
@@ -120,6 +122,8 @@ export class WebPubSubAdapterInternal extends NativeInMemoryAdapter {
       `Try to remove connection ${eioSid} from group ${groupName}, convert from ns#room = ${this.nsp.name}#${room}, SocketId = ${id}`
     );
     await this.service.group(groupName).removeConnection(eioSid);
+
+    super.del(id, room);
   }
 
   /**
@@ -131,11 +135,18 @@ export class WebPubSubAdapterInternal extends NativeInMemoryAdapter {
     debug(`delAll SocketId = ${id}`);
 
     const eioSid = this._getEioSid(id);
-    const groupName = this._getGroupName(this.nsp.name, "");
-    debug(
-      `Try to remove connection ${eioSid} from group ${groupName}, convert from ns#room = ${this.nsp.name}#, SocketId = ${id}`
-    );
-    await this.service.group(groupName).removeConnection(eioSid);
+    // To remove it from the namespace group, add a "" room
+    // Reference: https://github.com/socketio/socket.io-adapter/blob/2.5.2/lib/index.ts#L146
+    const rooms = ["", ...this.rooms.keys()];
+    for (const room of rooms) {
+      const groupName = this._getGroupName(this.nsp.name, room[0]);
+      debug(
+        `Try to remove connection ${eioSid} from group ${groupName}, convert from ns#room = ${this.nsp.name}#, SocketId = ${id}`
+      );
+      
+      await this.service.group(groupName).removeConnection(eioSid);
+    }
+    super.delAll(id);
   }
 
   /**

--- a/experimental/sdk/webpubsub-socketio-extension/src/SIO/components/web-pubsub-adapter.ts
+++ b/experimental/sdk/webpubsub-socketio-extension/src/SIO/components/web-pubsub-adapter.ts
@@ -68,10 +68,10 @@ export class WebPubSubAdapterInternal extends NativeInMemoryAdapter {
 
     const oDataFilter = this._buildODataFilter(opts.rooms, opts.except);
     const sendOptions = { filter: oDataFilter, contentType: "text/plain" };
-
-    debug(`broadcast, finish, encodedPayload = "${encodedPayload}", sendOptions = "${JSON.stringify(sendOptions)}"`);
+    debug(`broadcast, encodedPayload = "${encodedPayload}", sendOptions = "${JSON.stringify(sendOptions)}"`);
 
     await this.service.sendToAll(encodedPayload, sendOptions as HubSendTextToAllOptions);
+    debug(`broadcast, finish`);
   }
 
   /**

--- a/experimental/sdk/webpubsub-socketio-extension/src/SIO/components/web-pubsub-adapter.ts
+++ b/experimental/sdk/webpubsub-socketio-extension/src/SIO/components/web-pubsub-adapter.ts
@@ -143,7 +143,7 @@ export class WebPubSubAdapterInternal extends NativeInMemoryAdapter {
       debug(
         `Try to remove connection ${eioSid} from group ${groupName}, convert from ns#room = ${this.nsp.name}#, SocketId = ${id}`
       );
-      
+
       await this.service.group(groupName).removeConnection(eioSid);
     }
     super.delAll(id);

--- a/experimental/sdk/webpubsub-socketio-extension/src/SIO/index.ts
+++ b/experimental/sdk/webpubsub-socketio-extension/src/SIO/index.ts
@@ -15,7 +15,7 @@ declare type AdapterConstructor = typeof Adapter | ((nsp: SIO.Namespace) => Adap
 export function useAzureWebPubSub(
   this: SIO.Server,
   webPubSubOptions: WebPubSubExtensionOptions,
-  useDefaultAdapter = true
+  useDefaultAdapter = false
 ): SIO.Server {
   debug("use Azure Web PubSub For Socket.IO Server");
 

--- a/experimental/sdk/webpubsub-socketio-extension/src/common/utils.ts
+++ b/experimental/sdk/webpubsub-socketio-extension/src/common/utils.ts
@@ -32,7 +32,7 @@ export interface WebPubSubExtensionOptions {
  * @param syncFunc - a sync function with callback as its last parameter
  * @returns the async function converted from sync function `syncFunc`
  */
-export function toAsync<T>(syncFunc: (...args: unknown[]) => T): (...args: unknown[]) => Promise<T> {
+export function toAsync<T>(syncFunc: (...args: unknown[]) => unknown): (...args: unknown[]) => Promise<T> {
   return (...args: unknown[]) =>
     new Promise((resolve, reject) => {
       try {


### PR DESCRIPTION
1. Send broadcast request with all encoded packets in one request rather than multiple ones. This scenario only happen to binary packet(BINARY_EVENT / BINARY_ACK) and its attachments.
2. Bug fix: Before broadcast, add namespace property to the target packet.
3. Update group name mapping rule
4. Some renaming