### PR TITLE
Rename Socket.IO extension package and entry function

### DIFF
--- a/experimental/sdk/webpubsub-socketio-extension/README.md
+++ b/experimental/sdk/webpubsub-socketio-extension/README.md
@@ -35,7 +35,7 @@ With some minor changes, your Socket.IO server will supported by Azure Web PubSu
 // Add an path option in Socket.IO Server options
 const options = { pingInterval: 15000, path: "/eventhandler/" };
 // Import this package
-const wpsExt = require("webpubsub-socketio-extension");
+const wpsExt = require("@azure/web-pubsub-socket.io");
 
 // Add an Web PubSub Option
 const webPubSubOptions = {
@@ -44,7 +44,7 @@ const webPubSubOptions = {
   connectionString: "<web-pubsub-connection-string>",
 };
 
-const io = require("socket.io")(options).useAzureWebPubSub(webPubSubOptions);
+const io = require("socket.io")(options).useAzureSocketIO(webPubSubOptions);
 ```
 
 ## 3. Set up client

--- a/experimental/sdk/webpubsub-socketio-extension/examples/chat/index.js
+++ b/experimental/sdk/webpubsub-socketio-extension/examples/chat/index.js
@@ -1,4 +1,4 @@
-const wpsExt = require("@azure/socketio");
+const wpsExt = require("@azure/web-pubsub-socket.io");
 // Setup basic express server
 const express = require('express');
 const app = express();
@@ -17,7 +17,7 @@ const opts = {
     path: "/eventhandler/"
 }
 
-const io = require('socket.io')(server, opts).useAzureWebPubSub(wpsOptions);
+const io = require('socket.io')(server, opts).useAzureSocketIO(wpsOptions);
 
 app.use(express.static(path.join(__dirname, 'public')));
 

--- a/experimental/sdk/webpubsub-socketio-extension/examples/chat/package.json
+++ b/experimental/sdk/webpubsub-socketio-extension/examples/chat/package.json
@@ -9,7 +9,7 @@
     "dependencies": {
       "express": "~4.17.1",
       "socket.io": "^4.6.1",
-      "@azure/socketio": "../../dist-esm"
+      "@azure/web-pubsub-socket.io": "../../dist-esm"
     },
     "scripts": {
       "start": "node index.js"

--- a/experimental/sdk/webpubsub-socketio-extension/examples/whiteboard/index.js
+++ b/experimental/sdk/webpubsub-socketio-extension/examples/whiteboard/index.js
@@ -1,4 +1,4 @@
-const wpsExt = require("@azure/socketio");
+const wpsExt = require("@azure/web-pubsub-socket.io");
 const express = require('express');
 const app = express();
 const http = require('http').Server(app);
@@ -14,7 +14,7 @@ const eioOptions = {
   path: "/eventhandler/",
 }
 
-const io = require('socket.io')(http, eioOptions).useAzureWebPubSub(wpsOptions);
+const io = require('socket.io')(http, eioOptions).useAzureSocketIO(wpsOptions);
 const port = process.env.PORT || 3000;
 
 app.use(express.static(__dirname + '/public'));

--- a/experimental/sdk/webpubsub-socketio-extension/examples/whiteboard/package.json
+++ b/experimental/sdk/webpubsub-socketio-extension/examples/whiteboard/package.json
@@ -10,7 +10,7 @@
     "dependencies": {
       "express": "~4.17.1",
       "socket.io": "^4.6.1",
-      "@azure/socketio": "../../dist-esm"
+      "@azure/web-pubsub-socket.io": "../../dist-esm"
     },
     "scripts": {
       "start": "node index"

--- a/experimental/sdk/webpubsub-socketio-extension/package.json
+++ b/experimental/sdk/webpubsub-socketio-extension/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "socketio-webpubsub-extension",
+  "name": "@azure/web-pubsub-socket.io",
   "version": "1.0.0",
   "socketio-version": "4.6.1",
   "description": "Enable Socket.IO server support Azure Web PubSub Service",
   "main": "./dist-esm/index.js",
   "types": "./dist-esm/index.d.ts",
   "author": "Microsoft",
-  "private": true,
+  "private": false,
   "license": "MIT",
   "directories": {
     "lib": "src",

--- a/experimental/sdk/webpubsub-socketio-extension/review/socketio-webpubsub-extension.api.md
+++ b/experimental/sdk/webpubsub-socketio-extension/review/socketio-webpubsub-extension.api.md
@@ -12,7 +12,7 @@ import { WebPubSubServiceClientOptions } from '@azure/web-pubsub';
 export function init(): void;
 
 // @public (undocumented)
-export function useAzureWebPubSub(this: SIO.Server, webPubSubOptions: WebPubSubExtensionOptions, useDefaultAdapter?: boolean): SIO.Server;
+export function useAzureSocketIO(this: SIO.Server, webPubSubOptions: WebPubSubExtensionOptions, useDefaultAdapter?: boolean): SIO.Server;
 
 // @public
 export class WebPubSubAdapterProxy {

--- a/experimental/sdk/webpubsub-socketio-extension/src/SIO/index.ts
+++ b/experimental/sdk/webpubsub-socketio-extension/src/SIO/index.ts
@@ -12,7 +12,7 @@ debug("load");
 
 declare type AdapterConstructor = typeof Adapter | ((nsp: SIO.Namespace) => Adapter);
 
-export function useAzureWebPubSub(
+export function useAzureSocketIO(
   this: SIO.Server,
   webPubSubOptions: WebPubSubExtensionOptions,
   useDefaultAdapter = false

--- a/experimental/sdk/webpubsub-socketio-extension/src/index.ts
+++ b/experimental/sdk/webpubsub-socketio-extension/src/index.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import { addProperty, WebPubSubExtensionOptions } from "./common/utils";
-import { useAzureWebPubSub } from "./SIO";
+import { useAzureSocketIO } from "./SIO";
 import * as SIO from "socket.io";
 
 /**
@@ -15,11 +15,11 @@ export function init(): void {
 
 declare module "socket.io" {
   interface Server {
-    useAzureWebPubSub(this: Server, webPubSubOptions: WebPubSubExtensionOptions): Server;
+    useAzureSocketIO(this: Server, webPubSubOptions: WebPubSubExtensionOptions): Server;
   }
 }
 
-addProperty(SIO.Server.prototype, "useAzureWebPubSub", useAzureWebPubSub);
+addProperty(SIO.Server.prototype, "useAzureSocketIO", useAzureSocketIO);
 
 export * from "./EIO";
 export * from "./SIO";

--- a/experimental/sdk/webpubsub-socketio-extension/test/SIO/index.ts
+++ b/experimental/sdk/webpubsub-socketio-extension/test/SIO/index.ts
@@ -24,7 +24,7 @@
  *      - Content:
  *        Explicitly call `userAzureWebPubSub` in unit test
  *     - Purpose:
- *        `useAzureWebPubSub` must be used after the http server is created inside Socket.IO Server.
+ *        `useAzureSocketIO` must be used after the http server is created inside Socket.IO Server.
  *        Some tests use constructors of Socket.IO Server which doesn't create http server.
  *        Then they attach an external http server to the Socket.IO Server. So the `util.Server` doesn't fit such cases.
  */

--- a/experimental/sdk/webpubsub-socketio-extension/test/SIO/server-attachment.ts
+++ b/experimental/sdk/webpubsub-socketio-extension/test/SIO/server-attachment.ts
@@ -133,7 +133,7 @@ describe("server attachment", () => {
       const io = new NativeSioServer({ path: wpsOptions.path });
       io.attach(srv);
 
-      io.useAzureWebPubSub(wpsOptions);
+      io.useAzureSocketIO(wpsOptions);
       enableFastClose(io);
 
       request(srv)
@@ -159,7 +159,7 @@ describe("server attachment", () => {
       server.attach(srv, {
         pingInterval: 24000,
       });
-      server.useAzureWebPubSub(wpsOptions);
+      server.useAzureSocketIO(wpsOptions);
       enableFastClose(server);
 
       // @ts-ignore
@@ -186,7 +186,7 @@ describe("server attachment", () => {
      */
     it("with listen", (done) => {
       const io = new NativeSioServer().listen(serverPort);
-      io.useAzureWebPubSub(wpsOptions);
+      io.useAzureSocketIO(wpsOptions);
       enableFastClose(io);
 
       request(`http://localhost:${getPort(io)}`)

--- a/experimental/sdk/webpubsub-socketio-extension/test/SIO/support/util.ts
+++ b/experimental/sdk/webpubsub-socketio-extension/test/SIO/support/util.ts
@@ -51,7 +51,7 @@ export class Server extends _Server {
       debug(`Server, srv = ${srv}, opts = ${JSON.stringify(opts)}`);
     }
     super(srv, opts);
-    this.useAzureWebPubSub(wpsOptions);
+    this.useAzureSocketIO(wpsOptions);
     // `Server.close()` will trigger `HttpServer.close()`, which costs a lot of time
     // This is a trick to shutdown http server in a short time
     enableFastClose(this);


### PR DESCRIPTION
1. Replace package name to `@azure/web-pubsub-socket.io`
2. Replace `useAzureWebPubSub` to `useAzureSocketIO`