### PR TITLE
Remove path in both wps option and Socket.IO option

### DIFF
--- a/experimental/sdk/webpubsub-socketio-extension/.env.test.example
+++ b/experimental/sdk/webpubsub-socketio-extension/.env.test.example
@@ -1,4 +1,3 @@
 WebPubSubConnectionString="<web-pubsub-connection-string>"
 WebPubSubHub="eio_hub"
-WebPubSubPath="/eventhandler/"
 SocketIoPort=3000

--- a/experimental/sdk/webpubsub-socketio-extension/README.md
+++ b/experimental/sdk/webpubsub-socketio-extension/README.md
@@ -25,26 +25,22 @@ Create a AWPS resource, create a hub and configure it, copy connection string, .
 Assuming your server-side code is:
 
 ```typescript
-const options = { pingInterval: 15000 };
-const io = require("socket.io")(options);
+const io = require("socket.io")();
 ```
 
 With some minor changes, your Socket.IO server will supported by Azure Web PubSub Service:
 
 ```javascript
-// Add an path option in Socket.IO Server options
-const options = { pingInterval: 15000, path: "/eventhandler/" };
 // Import this package
 const wpsExt = require("@azure/web-pubsub-socket.io");
 
 // Add an Web PubSub Option
 const webPubSubOptions = {
   hub: "eio_hub",
-  path: "/eventhandler/",
   connectionString: "<web-pubsub-connection-string>",
 };
 
-const io = await require("socket.io")(options).useAzureSocketIO(webPubSubOptions);
+const io = await require("socket.io")().useAzureSocketIO(webPubSubOptions);
 ```
 
 You can also authenticate with Web PubSub service using an endpoint and an `AzureKeyCredential`.
@@ -55,7 +51,6 @@ const key = new AzureKeyCredential("<Key>");
 
 const webPubSubOptions = {
   hub: "eio_hub",
-  path: "/eventhandler/",
   endpoint: "<web-pubsub-endpoint>",
   credential: key,
 };
@@ -66,7 +61,7 @@ const webPubSubOptions = {
 Assuming your client-side code is:
 
 ```javascript
-var socket = io("<socket-io-server-endpoint");
+var socket = io("<socket-io-server-endpoint>");
 ```
 
 To fit new Socket.IO server, you shall update the Socket.IO client as below:
@@ -108,7 +103,6 @@ node <socket-io-application>.js
 ```
 WebPubSubConnectionString="<web-pubsub-connection-string>"
 WebPubSubHub="eio_hub"
-WebPubSubPath="/eventhandler/"
 SocketIoPort=3000
 ```
 

--- a/experimental/sdk/webpubsub-socketio-extension/examples/chat/index.js
+++ b/experimental/sdk/webpubsub-socketio-extension/examples/chat/index.js
@@ -12,12 +12,8 @@ const wpsOptions = {
     webPubSubServiceClientOptions: { allowInsecureConnection: true }
 };
 
-const opts = {
-    path: "/eventhandler/"
-}
-
 async function main() {
-    const io = await require('socket.io')(server, opts).useAzureSocketIO(wpsOptions);
+    const io = await require('socket.io')(server).useAzureSocketIO(wpsOptions);
 
     app.use(express.static(path.join(__dirname, 'public')));
 

--- a/experimental/sdk/webpubsub-socketio-extension/examples/chat/public/index.html
+++ b/experimental/sdk/webpubsub-socketio-extension/examples/chat/public/index.html
@@ -27,7 +27,7 @@
     document.querySelector('.usernameInput').value = names[idx];
   </script>
   <script src="https://code.jquery.com/jquery-1.10.2.min.js"></script>
-  <script src="https://cdn.socket.io/4.6.0/socket.io.min.js" integrity="sha384-c79GN5VsunZvi+Q/WObgk2in0CbZsHnjEqvFxC5DxHn9lTfNce2WW6h2pH6u/kF+" crossorigin="anonymous"></script>
+  <script src="/socket.io/socket.io.js"></script>
   <script src="./main.js"></script>
 </body>
 </html>

--- a/experimental/sdk/webpubsub-socketio-extension/examples/whiteboard/index.js
+++ b/experimental/sdk/webpubsub-socketio-extension/examples/whiteboard/index.js
@@ -9,12 +9,8 @@ const wpsOptions = {
   webPubSubServiceClientOptions: { allowInsecureConnection: true }
 }
 
-const eioOptions = {
-  path: "/eventhandler/",
-}
-
 async function main() {
-  const io = require('socket.io')(http, eioOptions).useAzureSocketIO(wpsOptions);
+  const io = await require('socket.io')(http).useAzureSocketIO(wpsOptions);
   const port = process.env.PORT || 3000;
 
   app.use(express.static(__dirname + '/public'));

--- a/experimental/sdk/webpubsub-socketio-extension/examples/whiteboard/public/index.html
+++ b/experimental/sdk/webpubsub-socketio-extension/examples/whiteboard/public/index.html
@@ -17,7 +17,7 @@
     <div class="color yellow"></div>
   </div>
 
-  <script src="https://cdn.socket.io/4.6.0/socket.io.min.js" integrity="sha384-c79GN5VsunZvi+Q/WObgk2in0CbZsHnjEqvFxC5DxHn9lTfNce2WW6h2pH6u/kF+" crossorigin="anonymous"></script>
+  <script src="/socket.io/socket.io.js"></script>
   <script src="/main.js"></script>
 </body>
 </html>

--- a/experimental/sdk/webpubsub-socketio-extension/src/EIO/components/constants.ts
+++ b/experimental/sdk/webpubsub-socketio-extension/src/EIO/components/constants.ts
@@ -18,3 +18,5 @@ export const EIO_CONNECTION_ERROR = {
   FORBIDDEN: 4,
   UNSUPPORTED_PROTOCOL_VERSION: 5,
 };
+
+export const TUNNEL_PATH = "/eventhandler/";

--- a/experimental/sdk/webpubsub-socketio-extension/src/EIO/components/web-pubsub-connection-manager.ts
+++ b/experimental/sdk/webpubsub-socketio-extension/src/EIO/components/web-pubsub-connection-manager.ts
@@ -13,6 +13,7 @@ import {
   CONNECTION_ERROR_WEBPUBSUB_CODE,
   CONNECTION_ERROR_WEBPUBSUB_MESSAGE,
   EIO_CONNECTION_ERROR,
+  TUNNEL_PATH,
   WEBPUBSUB_CLIENT_CONNECTION_FILED_NAME,
   WEBPUBSUB_TRANSPORT_NAME,
 } from "./constants";
@@ -69,7 +70,7 @@ export class WebPubSubConnectionManager {
     this._webPubSubOptions = options;
 
     this._webPubSubEventHandler = new WebPubSubEventHandler(this._webPubSubOptions.hub, {
-      path: "/eventhandler/",
+      path: TUNNEL_PATH,
       handleConnect: async (req, res) => {
         let timeout: NodeJS.Timeout;
         let cleanup: (error: string) => void;
@@ -226,7 +227,7 @@ export class WebPubSubConnectionManager {
       method: "GET",
       headers: req.headers,
       connection: {},
-      url: "/eventhandler/",
+      url: TUNNEL_PATH,
       _query: {},
     };
     // Preserve all queires. Each value of `req.queries` is an one-element array which is wrapped by AWPS. Just pick out the first element.

--- a/experimental/sdk/webpubsub-socketio-extension/test/SIO/server-attachment.ts
+++ b/experimental/sdk/webpubsub-socketio-extension/test/SIO/server-attachment.ts
@@ -14,7 +14,6 @@ import {
   attachmentPath,
   defaultAttachmentPath,
 } from "./support/util";
-import { TUNNEL_PATH } from "../../src/common/utils";
 
 const request = require("supertest");
 const serverPort = Number(process.env.SocketIoPort);
@@ -131,7 +130,7 @@ describe("server attachment", () => {
         res.writeHead(404);
         res.end();
       });
-      const io = new NativeSioServer({ path: TUNNEL_PATH });
+      const io = new NativeSioServer();
       io.attach(srv);
 
       io.useAzureSocketIO(wpsOptions);

--- a/experimental/sdk/webpubsub-socketio-extension/test/SIO/support/util.ts
+++ b/experimental/sdk/webpubsub-socketio-extension/test/SIO/support/util.ts
@@ -2,7 +2,7 @@
 
 import { Server as _Server, ServerOptions, Socket } from "socket.io";
 import { io as ioc, ManagerOptions, Socket as ClientSocket, SocketOptions } from "socket.io-client";
-import { debugModule, TUNNEL_PATH } from "../../../src/common/utils";
+import { debugModule } from "../../../src/common/utils";
 import { init, WebPubSubExtensionOptions } from "../../../src";
 import { Server as HttpServer } from "http";
 import { setTimeout } from "timers";
@@ -25,7 +25,8 @@ const serverPort = Number(process.env.SocketIoPort);
 debug(`SocketIO Server Port = ${serverPort}`);
 
 // e.g: /eventhandler/this-is-a-file.js
-export const attachmentPath = (filename: string): string => TUNNEL_PATH + filename;
+export const attachmentPath = (filename: string, path: string = "/socket.io/"): string =>
+  (path.endsWith("/") ? path : path + "/") + filename;
 
 // e.g. /eventhandler/socket.io.js
 export const defaultAttachmentPath = attachmentPath("socket.io.js");
@@ -41,8 +42,7 @@ export const enableFastClose = (server: _Server): void => {
 };
 
 export class Server extends _Server {
-  constructor(srv?: number | HttpServer, extraOpts?: Partial<ServerOptions>) {
-    const opts = extraOpts ? { ...extraOpts, path: TUNNEL_PATH } : { path: TUNNEL_PATH };
+  constructor(srv?: number | HttpServer, opts?: Partial<ServerOptions>) {
     if (typeof srv === "number") {
       debug(`Server, port = ${srv}, opts = ${JSON.stringify(opts)}`);
     } else {

--- a/experimental/tools/awps-server-proxy/common/yarn.lock
+++ b/experimental/tools/awps-server-proxy/common/yarn.lock
@@ -777,6 +777,13 @@
     expect "^29.0.0"
     pretty-format "^29.0.0"
 
+"@types/jsonwebtoken@^9.0.1":
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz#9eeb56c76dd555039be2a3972218de5bd3b8d83e"
+  integrity sha512-drE6uz7QBKq1fYqqoFKTDRdFCPHd5TCub75BM+D+cMx7NU9hUz7SESLfC2fSCXVFMO5Yj8sOWHuGqPgjc+fz0Q==
+  dependencies:
+    "@types/node" "*"
+
 "@types/mime@^1":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"


### PR DESCRIPTION
Customized `path` property is totally removed from wps option. So adding `path` in socket.io server option is unnecessary as well.