### PR TITLE
Enable tunnel in Socket.IO globally

### DIFF
--- a/experimental/sdk/webpubsub-socketio-extension/src/EIO/components/client-connection-context.ts
+++ b/experimental/sdk/webpubsub-socketio-extension/src/EIO/components/client-connection-context.ts
@@ -2,12 +2,12 @@
 // Licensed under the MIT license.
 
 import { debugModule } from "../../common/utils";
-import { HubSendToConnectionOptions, WebPubSubServiceClient } from "@azure/web-pubsub";
 import {
   ConnectResponse as WebPubSubConnectResponse,
   ConnectResponseHandler as WebPubSubConnectResponseHandler,
 } from "@azure/web-pubsub-express";
 import { WEBPUBSUB_CONNECT_RESPONSE_FIELD_NAME } from "./constants";
+import { WebPubSubServiceCaller } from "awps-tunnel-proxies";
 
 const debug = debugModule("wps-sio-ext:EIO:ClientConnectionContext");
 
@@ -24,14 +24,14 @@ export interface ConnectionError {
  * It maps Engine.IO Transport behaviours to Azure Web PubSub service REST API calls.
  */
 export class ClientConnectionContext {
-  public service: WebPubSubServiceClient;
+  public service: WebPubSubServiceCaller;
   public connectionId: string;
   public connectResponded: boolean;
   private _connectResponseHandler: WebPubSubConnectResponseHandler;
   private _refusedCallback: (error: string) => void;
 
   constructor(
-    serviceClient: WebPubSubServiceClient,
+    serviceClient: WebPubSubServiceCaller,
     connectionId: string,
     connectResponseHandler: WebPubSubConnectResponseHandler,
     refusedCallback?: (error: string) => void
@@ -51,9 +51,7 @@ export class ClientConnectionContext {
   public async send(message: string, cb?: (err?: Error) => void): Promise<void> {
     debug(`send message ${message}, type = ${typeof message}`);
 
-    const options: HubSendToConnectionOptions = {
-      contentType: "text/plain",
-    } as HubSendToConnectionOptions;
+    const options = { contentType: "text/plain" };
 
     try {
       await this.service.sendToConnection(this.connectionId, message, options);

--- a/experimental/sdk/webpubsub-socketio-extension/src/EIO/components/web-pubsub-connection-manager.ts
+++ b/experimental/sdk/webpubsub-socketio-extension/src/EIO/components/web-pubsub-connection-manager.ts
@@ -5,7 +5,7 @@ import {
   WebPubSubExtensionOptions,
   WebPubSubExtensionCredentialOptions,
   debugModule,
-  getWebPubSubServiceClient,
+  getWebPubSubServiceCaller,
 } from "../../common/utils";
 import { ClientConnectionContext, ConnectionError } from "./client-connection-context";
 import {
@@ -17,9 +17,9 @@ import {
   WEBPUBSUB_CLIENT_CONNECTION_FILED_NAME,
   WEBPUBSUB_TRANSPORT_NAME,
 } from "./constants";
-import { WebPubSubServiceClient } from "@azure/web-pubsub";
 import type { BaseServer } from "engine.io";
 import { ConnectRequest as WebPubSubConnectRequest, WebPubSubEventHandler } from "@azure/web-pubsub-express";
+import { WebPubSubServiceCaller } from "awps-tunnel-proxies";
 
 const debug = debugModule("wps-sio-ext:EIO:ConnectionManager");
 
@@ -39,7 +39,7 @@ export class WebPubSubConnectionManager {
   /**
    * Client for connecting to a Web PubSub hub
    */
-  public service: WebPubSubServiceClient;
+  public service: WebPubSubServiceCaller;
 
   /**
    * Map from the `connectionId` of each client to its corresponding logical `ClientConnectionContext`.
@@ -65,7 +65,7 @@ export class WebPubSubConnectionManager {
   private _candidateSids: Array<string> = [];
 
   constructor(server: BaseServer, options: WebPubSubExtensionOptions | WebPubSubExtensionCredentialOptions) {
-    this.service = getWebPubSubServiceClient(options);
+    this.service = getWebPubSubServiceCaller(options, true);
     this.eioServer = server;
     this._webPubSubOptions = options;
 

--- a/experimental/sdk/webpubsub-socketio-extension/src/EIO/index.ts
+++ b/experimental/sdk/webpubsub-socketio-extension/src/EIO/index.ts
@@ -5,7 +5,7 @@ import { WebPubSubExtensionOptions, WebPubSubExtensionCredentialOptions, debugMo
 import { WebPubSubTransport } from "./components/web-pubsub-transport";
 import { WebPubSubConnectionManager } from "./components/web-pubsub-connection-manager";
 import * as engine from "engine.io";
-import { InprocessServerProxy, WebPubSubServiceCaller } from "awps-tunnel-proxies";
+import { InprocessServerProxy } from "awps-tunnel-proxies";
 
 const debug = debugModule("wps-sio-ext:EIO:index");
 debug("load");

--- a/experimental/sdk/webpubsub-socketio-extension/src/EIO/index.ts
+++ b/experimental/sdk/webpubsub-socketio-extension/src/EIO/index.ts
@@ -5,7 +5,8 @@ import { WebPubSubExtensionOptions, WebPubSubExtensionCredentialOptions, debugMo
 import { WebPubSubTransport } from "./components/web-pubsub-transport";
 import { WebPubSubConnectionManager } from "./components/web-pubsub-connection-manager";
 import * as engine from "engine.io";
-import { InprocessServerProxy } from "awps-tunnel-proxies";
+import { InprocessServerProxy, WebPubSubServiceCaller } from "awps-tunnel-proxies";
+
 const debug = debugModule("wps-sio-ext:EIO:index");
 debug("load");
 
@@ -26,32 +27,33 @@ debug("load");
 export class WebPubSubEioServer extends engine.Server {
   public webPubSubOptions: WebPubSubExtensionOptions | WebPubSubExtensionCredentialOptions;
   public webPubSubConnectionManager: WebPubSubConnectionManager;
-  private _tunnel: InprocessServerProxy;
   private _setuped: Promise<void>;
 
   constructor(
     options: engine.ServerOptions,
-    webPubSubOptions: WebPubSubExtensionOptions | WebPubSubExtensionCredentialOptions,
-    tunnel?: InprocessServerProxy
+    webPubSubOptions: WebPubSubExtensionOptions | WebPubSubExtensionCredentialOptions
   ) {
+    debug(`constructor, options: ${JSON.stringify(options)}, webPubSubOptions: ${JSON.stringify(webPubSubOptions)}`);
     super(options);
-    debug("create Engine.IO Server with AWPS");
     this.webPubSubOptions = webPubSubOptions;
     this.webPubSubConnectionManager = new WebPubSubConnectionManager(this, webPubSubOptions);
 
-    if (tunnel) {
-      this._tunnel = tunnel;
-      this._tunnel.use(this.webPubSubConnectionManager.getEventHandlerExpressMiddleware());
-      this._setuped = this._tunnel.runAsync();
+    // Using tunnel
+    if (this.webPubSubConnectionManager.service instanceof InprocessServerProxy) {
+      debug("constructor, use InprocessServerProxy");
+      const tunnel: InprocessServerProxy = this.webPubSubConnectionManager.service;
+      tunnel.use(this.webPubSubConnectionManager.getEventHandlerExpressMiddleware());
+      this._setuped = tunnel.runAsync();
       /**
        * After closing the EIO server, internal tunnel should be closed as well.
        * Force override `cleanup`, which is executed when closing EIO server.
        * In native implementation, it close internal WebSocket server, this is not needed when using Azure Web PubSub.
        */
       this["cleanup"] = () => {
-        this._tunnel.stop();
+        tunnel.stop();
       };
     } else {
+      debug("constructor, use RestApiServiceCaller");
       const webPubSubEioMiddleware = this.webPubSubConnectionManager.getEventHandlerEioMiddleware();
       this.use(webPubSubEioMiddleware);
     }

--- a/experimental/sdk/webpubsub-socketio-extension/src/SIO/components/web-pubsub-adapter.ts
+++ b/experimental/sdk/webpubsub-socketio-extension/src/SIO/components/web-pubsub-adapter.ts
@@ -6,7 +6,7 @@ import { getSingleEioEncodedPayload } from "./encoder";
 import { Packet as SioPacket, PacketType as SioPacketType } from "socket.io-parser";
 import { Namespace, Server as SioServer } from "socket.io";
 import { Adapter as NativeInMemoryAdapter, BroadcastOptions, Room, SocketId } from "socket.io-adapter";
-import { InprocessServerProxy, WebPubSubServiceCaller } from "awps-tunnel-proxies";
+import { WebPubSubServiceCaller } from "awps-tunnel-proxies";
 import { Mutex, MutexInterface } from "async-mutex";
 import base64url from "base64url";
 import { WebPubSubServiceClient } from "@azure/web-pubsub";
@@ -28,10 +28,10 @@ const NonLocalNotSupported = new Error("Non-local condition is not Supported.");
  *  2. Set the adapter: `io.adapter(WebPubSubAdapterProxy);`, thus additional options are controllable.
  */
 export class WebPubSubAdapterProxy {
-  public serivce: WebPubSubServiceClient;
+  public serivce: WebPubSubServiceCaller;
   public sioServer: SioServer;
 
-  constructor(serviceClient: WebPubSubServiceClient) {
+  constructor(serviceClient: WebPubSubServiceCaller) {
     this.serivce = serviceClient;
 
     const proxyHandler = {
@@ -42,7 +42,7 @@ export class WebPubSubAdapterProxy {
 }
 
 export class WebPubSubAdapterInternal extends NativeInMemoryAdapter {
-  public service: WebPubSubServiceClient;
+  public service: WebPubSubServiceCaller;
   private _roomOperationLock: Map<SocketId, Mutex> = new Map();
 
   /**
@@ -51,7 +51,7 @@ export class WebPubSubAdapterInternal extends NativeInMemoryAdapter {
    * @param nsp - Namespace
    * @param extraArgForWpsAdapter - extra argument for WebPubSubAdapter
    */
-  constructor(readonly nsp: Namespace, serviceClient: WebPubSubServiceClient) {
+  constructor(readonly nsp: Namespace, serviceClient: WebPubSubServiceCaller) {
     debug(`constructor nsp.name = ${nsp.name}, serviceClient = ${serviceClient}`);
     super(nsp);
     this.service = serviceClient;

--- a/experimental/sdk/webpubsub-socketio-extension/src/SIO/components/web-pubsub-adapter.ts
+++ b/experimental/sdk/webpubsub-socketio-extension/src/SIO/components/web-pubsub-adapter.ts
@@ -9,7 +9,6 @@ import { Adapter as NativeInMemoryAdapter, BroadcastOptions, Room, SocketId } fr
 import { WebPubSubServiceCaller } from "awps-tunnel-proxies";
 import { Mutex, MutexInterface } from "async-mutex";
 import base64url from "base64url";
-import { WebPubSubServiceClient } from "@azure/web-pubsub";
 
 const debug = debugModule("wps-sio-ext:SIO:Adapter");
 

--- a/experimental/sdk/webpubsub-socketio-extension/src/SIO/index.ts
+++ b/experimental/sdk/webpubsub-socketio-extension/src/SIO/index.ts
@@ -5,7 +5,6 @@ import {
   debugModule,
   WebPubSubExtensionOptions,
   WebPubSubExtensionCredentialOptions,
-  getWebPubSubServiceCaller,
 } from "../common/utils";
 import { WebPubSubEioServer } from "../EIO";
 import { WebPubSubAdapterProxy } from "./components/web-pubsub-adapter";

--- a/experimental/sdk/webpubsub-socketio-extension/src/SIO/index.ts
+++ b/experimental/sdk/webpubsub-socketio-extension/src/SIO/index.ts
@@ -1,11 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import {
-  debugModule,
-  WebPubSubExtensionOptions,
-  WebPubSubExtensionCredentialOptions,
-} from "../common/utils";
+import { debugModule, WebPubSubExtensionOptions, WebPubSubExtensionCredentialOptions } from "../common/utils";
 import { WebPubSubEioServer } from "../EIO";
 import { WebPubSubAdapterProxy } from "./components/web-pubsub-adapter";
 import * as SIO from "socket.io";

--- a/experimental/sdk/webpubsub-socketio-extension/src/SIO/index.ts
+++ b/experimental/sdk/webpubsub-socketio-extension/src/SIO/index.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { debugModule, WebPubSubExtensionOptions, WebPubSubExtensionCredentialOptions } from "../common/utils";
+import {
+  debugModule,
+  WebPubSubExtensionOptions,
+  WebPubSubExtensionCredentialOptions,
+  getWebPubSubServiceCaller,
+} from "../common/utils";
 import { WebPubSubEioServer } from "../EIO";
 import { WebPubSubAdapterProxy } from "./components/web-pubsub-adapter";
 import * as SIO from "socket.io";
@@ -18,18 +23,16 @@ export async function useAzureSocketIO(
   webPubSubOptions: WebPubSubExtensionOptions | WebPubSubExtensionCredentialOptions,
   useDefaultAdapter = false
 ): Promise<SIO.Server> {
-  debug("use Azure Web PubSub For Socket.IO Server");
-  const useTunnel = true;
-
-  const serverProxy = !useTunnel
-    ? undefined
-    : Object.keys(webPubSubOptions).indexOf("connectionString") !== -1
-    ? InprocessServerProxy.fromConnectionString(webPubSubOptions["connectionString"], webPubSubOptions.hub)
-    : new InprocessServerProxy(webPubSubOptions["endpoint"], webPubSubOptions["credential"], webPubSubOptions["hub"]);
-  const engine = new WebPubSubEioServer(this.engine.opts, webPubSubOptions, serverProxy);
+  debug(
+    `useAzureSocketIO, webPubSubOptions: ${JSON.stringify(webPubSubOptions)}, useDefaultAdapter: ${useDefaultAdapter}`
+  );
+  const engine = new WebPubSubEioServer(this.engine.opts, webPubSubOptions);
   engine.attach(this["httpServer"], this["opts"]);
 
-  await engine.setup();
+  // Using Tunnel
+  if (engine.webPubSubConnectionManager.service instanceof InprocessServerProxy) {
+    await engine.setup();
+  }
 
   // `attachServe` is a Socket.IO design which attachs static file serving to internal http server.
   // Creating new engine makes previous `attachServe` execution invalid.


### PR DESCRIPTION
Before this PR, tunnel only handle the work of upstream handler.  APIs are still handled by rest API `WebPubSubServiceClient`.
And our code uses a mixture of tunnel and rest API `WebPubSubServiceClient`.

Create a new method to create caller, which is either REST API or tunnel. 
In where the upstream invoke is processed, judge the type of caller and then choose how to handle upstream invoke.

Note: This PR only works after the PR which implements all API call via tunnel (in `InprocessServerProxy`) is merged ahead.

# Before merge this PR
- Merge https://github.com/Azure/azure-webpubsub/pull/529. Because this PR contains some changes from PR 529.
- Merge PR which implements API call via tunnel