### PR TITLE
Fix bug in socket.io passport restore

### DIFF
--- a/sdk/webpubsub-socketio-extension/src/SIO/components/negotiate.ts
+++ b/sdk/webpubsub-socketio-extension/src/SIO/components/negotiate.ts
@@ -92,7 +92,14 @@ export function usePassport(assignProperty = "user"): ConfigureNegotiateOptions 
 export function restorePassport(assignProperty = "user") {
   return (request: IncomingMessage, response: ServerResponse, next: (err?: Error) => void) => {
     try {
-      const passportUserId = JSON.parse(request["claims"].userId);
+      /**
+       * request["claims"] should be an one-element string array. 
+       * Examples: ['0'], ['bob']
+       **/
+      if (request["claims"]?.userId?.length !== 1) {
+        throw new Error(`Invalid claims.userId = ${request["claims"]?.userId}`);
+      }
+      const passportUserId = request["claims"].userId[0];
       request["session"] = { passport: {} } as unknown as Session;
       request["session"]["passport"][assignProperty] = passportUserId;
     } catch (e) {

--- a/sdk/webpubsub-socketio-extension/src/SIO/components/negotiate.ts
+++ b/sdk/webpubsub-socketio-extension/src/SIO/components/negotiate.ts
@@ -93,7 +93,7 @@ export function restorePassport(assignProperty = "user") {
   return (request: IncomingMessage, response: ServerResponse, next: (err?: Error) => void) => {
     try {
       /**
-       * request["claims"] should be an one-element string array. 
+       * request["claims"] should be an one-element string array.
        * Examples: ['0'], ['bob']
        **/
       if (request["claims"]?.userId?.length !== 1) {


### PR DESCRIPTION
`request["claims"].userId` is expected to be an one-element string array. We should pick the first element as userId.

The original code use `JSON.parse(arr)` to pick the first element. It works for array like ['0'] but will fail on ['any-string-user-id']