### PR TITLE
Show service properties and icon in vscode extension

### DIFF
--- a/tools/vscode-azurewebpubsub/gulpfile.ts
+++ b/tools/vscode-azurewebpubsub/gulpfile.ts
@@ -14,7 +14,7 @@ async function prepareForWebpack(): Promise<void> {
     const mainJsPath: string = path.join(__dirname, 'main.js');
     let contents: string = (await fse.readFile(mainJsPath)).toString();
     contents = contents
-        .replace('out/src/extension', 'dist/extension.bundle')
+        .replace('out/extension.bundle', 'dist/extension.bundle')
         .replace(', true /* ignoreBundle */', '');
     await fse.writeFile(mainJsPath, contents);
 }

--- a/tools/vscode-azurewebpubsub/package-lock.json
+++ b/tools/vscode-azurewebpubsub/package-lock.json
@@ -14,7 +14,6 @@
                 "@azure/core-rest-pipeline": "1.10.3",
                 "@azure/storage-blob": "^12.4.1",
                 "@microsoft/vscode-azext-azureutils": "^2.0.0",
-                "@microsoft/vscode-azext-github": "^1.0.0",
                 "@microsoft/vscode-azext-utils": "^2.1.3",
                 "@microsoft/vscode-azureresources-api": "^2.0.2",
                 "@vscode/test-electron": "^2.3.8",
@@ -807,15 +806,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/@microsoft/vscode-azext-github": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-github/-/vscode-azext-github-1.0.0.tgz",
-            "integrity": "sha512-LYZ5fN0Yv2zfBy8uNuIL/JaXKf8aw+QfW64fuIDknt9qs7UZtFzfTvOimTB5nGd1oN4o7cpthcZg3YHOH2YpKg==",
-            "dependencies": {
-                "@microsoft/vscode-azext-utils": "^2.0.0",
-                "@octokit/rest": "^18.5.2"
-            }
-        },
         "node_modules/@microsoft/vscode-azext-utils": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@microsoft/vscode-azext-utils/-/vscode-azext-utils-2.1.5.tgz",
@@ -925,126 +915,6 @@
             },
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/@octokit/auth-token": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
-            "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
-            "dependencies": {
-                "@octokit/types": "^6.0.3"
-            }
-        },
-        "node_modules/@octokit/core": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
-            "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
-            "dependencies": {
-                "@octokit/auth-token": "^2.4.4",
-                "@octokit/graphql": "^4.5.8",
-                "@octokit/request": "^5.6.3",
-                "@octokit/request-error": "^2.0.5",
-                "@octokit/types": "^6.0.3",
-                "before-after-hook": "^2.2.0",
-                "universal-user-agent": "^6.0.0"
-            }
-        },
-        "node_modules/@octokit/endpoint": {
-            "version": "6.0.12",
-            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
-            "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
-            "dependencies": {
-                "@octokit/types": "^6.0.3",
-                "is-plain-object": "^5.0.0",
-                "universal-user-agent": "^6.0.0"
-            }
-        },
-        "node_modules/@octokit/graphql": {
-            "version": "4.8.0",
-            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
-            "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
-            "dependencies": {
-                "@octokit/request": "^5.6.0",
-                "@octokit/types": "^6.0.3",
-                "universal-user-agent": "^6.0.0"
-            }
-        },
-        "node_modules/@octokit/openapi-types": {
-            "version": "12.11.0",
-            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.11.0.tgz",
-            "integrity": "sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ=="
-        },
-        "node_modules/@octokit/plugin-paginate-rest": {
-            "version": "2.21.3",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.21.3.tgz",
-            "integrity": "sha512-aCZTEf0y2h3OLbrgKkrfFdjRL6eSOo8komneVQJnYecAxIej7Bafor2xhuDJOIFau4pk0i/P28/XgtbyPF0ZHw==",
-            "dependencies": {
-                "@octokit/types": "^6.40.0"
-            },
-            "peerDependencies": {
-                "@octokit/core": ">=2"
-            }
-        },
-        "node_modules/@octokit/plugin-request-log": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
-            "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-            "peerDependencies": {
-                "@octokit/core": ">=3"
-            }
-        },
-        "node_modules/@octokit/plugin-rest-endpoint-methods": {
-            "version": "5.16.2",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.16.2.tgz",
-            "integrity": "sha512-8QFz29Fg5jDuTPXVtey05BLm7OB+M8fnvE64RNegzX7U+5NUXcOcnpTIK0YfSHBg8gYd0oxIq3IZTe9SfPZiRw==",
-            "dependencies": {
-                "@octokit/types": "^6.39.0",
-                "deprecation": "^2.3.1"
-            },
-            "peerDependencies": {
-                "@octokit/core": ">=3"
-            }
-        },
-        "node_modules/@octokit/request": {
-            "version": "5.6.3",
-            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
-            "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
-            "dependencies": {
-                "@octokit/endpoint": "^6.0.1",
-                "@octokit/request-error": "^2.1.0",
-                "@octokit/types": "^6.16.1",
-                "is-plain-object": "^5.0.0",
-                "node-fetch": "^2.6.7",
-                "universal-user-agent": "^6.0.0"
-            }
-        },
-        "node_modules/@octokit/request-error": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
-            "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
-            "dependencies": {
-                "@octokit/types": "^6.0.3",
-                "deprecation": "^2.0.0",
-                "once": "^1.4.0"
-            }
-        },
-        "node_modules/@octokit/rest": {
-            "version": "18.12.0",
-            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.12.0.tgz",
-            "integrity": "sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==",
-            "dependencies": {
-                "@octokit/core": "^3.5.1",
-                "@octokit/plugin-paginate-rest": "^2.16.8",
-                "@octokit/plugin-request-log": "^1.0.4",
-                "@octokit/plugin-rest-endpoint-methods": "^5.12.0"
-            }
-        },
-        "node_modules/@octokit/types": {
-            "version": "6.41.0",
-            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.41.0.tgz",
-            "integrity": "sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==",
-            "dependencies": {
-                "@octokit/openapi-types": "^12.11.0"
             }
         },
         "node_modules/@opentelemetry/api": {
@@ -2421,11 +2291,6 @@
                 }
             ]
         },
-        "node_modules/before-after-hook": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
-            "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
-        },
         "node_modules/big.js": {
             "version": "5.2.2",
             "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -3510,11 +3375,6 @@
             "engines": {
                 "node": ">=0.4.0"
             }
-        },
-        "node_modules/deprecation": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
-            "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
         },
         "node_modules/detect-file": {
             "version": "1.0.0",
@@ -6456,6 +6316,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
             "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -8321,6 +8182,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "dev": true,
             "dependencies": {
                 "wrappy": "1"
             }
@@ -10963,11 +10825,6 @@
                 "through2-filter": "^3.0.0"
             }
         },
-        "node_modules/universal-user-agent": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
-            "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="
-        },
         "node_modules/universalify": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -11643,7 +11500,8 @@
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "dev": true
         },
         "node_modules/xml": {
             "version": "1.0.1",

--- a/tools/vscode-azurewebpubsub/package.json
+++ b/tools/vscode-azurewebpubsub/package.json
@@ -129,7 +129,6 @@
         "@azure/core-rest-pipeline": "1.10.3",
         "@azure/storage-blob": "^12.4.1",
         "@microsoft/vscode-azext-azureutils": "^2.0.0",
-        "@microsoft/vscode-azext-github": "^1.0.0",
         "@microsoft/vscode-azext-utils": "^2.1.3",
         "@microsoft/vscode-azureresources-api": "^2.0.2",
         "@vscode/test-electron": "^2.3.8",

--- a/tools/vscode-azurewebpubsub/resources/azure-web-pubsub-socketio.svg
+++ b/tools/vscode-azurewebpubsub/resources/azure-web-pubsub-socketio.svg
@@ -1,0 +1,50 @@
+<svg width="78" height="78" viewBox="0 0 78 78" fill="white" xmlns="http://www.w3.org/2000/svg">
+<path d="M18.1754 46.6648C18.1754 62.1302 30.7127 74.6674 46.1781 74.6674C61.6436 74.6674 74.1808 62.1302 74.1808 46.6648C74.1808 31.1993 61.6436 18.6621 46.1781 18.6621" stroke="#010101" stroke-width="4.91275"/>
+<path d="M38.72 45.1153C45.4325 39.6312 51.9987 33.957 58.8574 28.6338C55.2598 34.1619 51.56 39.6165 47.9624 45.1443C44.8767 45.159 41.7912 45.1593 38.72 45.1153ZM44.3942 48.1715C47.4944 48.1715 50.5801 48.1715 53.6658 48.2155C46.9096 53.6701 40.3727 59.3881 33.4992 64.6968C37.0968 59.1687 40.7966 53.6996 44.3942 48.1715Z" fill="#010101"/>
+<circle cx="18.3882" cy="46.1407" r="3.89479" fill="white" stroke="#30CEF0" stroke-width="2.43445"/>
+<circle cx="47.1146" cy="18.8748" r="3.89479" fill="white" stroke="#30CEF0" stroke-width="2.43445"/>
+<g clip-path="url(#clip0_2627_522)">
+<path d="M0.101166 2.50689C0.101166 1.1782 1.1783 0.101074 2.50698 0.101074H33.7825C35.1113 0.101074 36.1884 1.1782 36.1884 2.50689V33.7825C36.1884 35.1112 35.1113 36.1883 33.7825 36.1883H2.50698C1.1783 36.1883 0.101166 35.1112 0.101166 33.7825V2.50689Z" fill="#0078D7"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M19.3477 16.9418V0.101074H16.9419V16.9418H0.101166V19.3476H16.9419V36.1883H19.3477V19.3476H36.1884V16.9418H19.3477Z" fill="white" fill-opacity="0.8"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M7.31885 28.9714V7.31909H9.72466V28.9714H7.31885Z" fill="white"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M8.27292 9.97364L9.97409 8.27246L28.0177 26.3161L26.3166 28.0173L8.27292 9.97364Z" fill="white"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M28.9712 9.72491H9.7247V7.31909H28.9712V9.72491Z" fill="white"/>
+<path d="M8.52098 14.5344C11.8423 14.5344 14.5348 11.8419 14.5348 8.52061C14.5348 5.19929 11.8423 2.50684 8.52098 2.50684C5.19966 2.50684 2.5072 5.19929 2.5072 8.52061C2.5072 11.8419 5.19966 14.5344 8.52098 14.5344Z" fill="url(#paint0_linear_2627_522)"/>
+<path d="M27.7679 12.1294C29.7607 12.1294 31.3762 10.5139 31.3762 8.52111C31.3762 6.52832 29.7607 4.91284 27.7679 4.91284C25.7751 4.91284 24.1596 6.52832 24.1596 8.52111C24.1596 10.5139 25.7751 12.1294 27.7679 12.1294Z" fill="url(#paint1_linear_2627_522)"/>
+<path d="M8.52141 31.376C10.5142 31.376 12.1297 29.7605 12.1297 27.7677C12.1297 25.7749 10.5142 24.1594 8.52141 24.1594C6.52862 24.1594 4.91315 25.7749 4.91315 27.7677C4.91315 29.7605 6.52862 31.376 8.52141 31.376Z" fill="url(#paint2_linear_2627_522)"/>
+<path d="M27.7679 31.376C29.7607 31.376 31.3762 29.7605 31.3762 27.7677C31.3762 25.7749 29.7607 24.1594 27.7679 24.1594C25.7751 24.1594 24.1596 25.7749 24.1596 27.7677C24.1596 29.7605 25.7751 31.376 27.7679 31.376Z" fill="url(#paint3_linear_2627_522)"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_2627_522" x1="8.56502" y1="14.6886" x2="8.49894" y2="5.98734" gradientUnits="userSpaceOnUse">
+<stop stop-color="#CCCCCC"/>
+<stop offset="0.12" stop-color="#D7D7D7"/>
+<stop offset="0.42" stop-color="#EBEBEB"/>
+<stop offset="0.72" stop-color="#F8F8F8"/>
+<stop offset="1" stop-color="#FCFCFC"/>
+</linearGradient>
+<linearGradient id="paint1_linear_2627_522" x1="27.7944" y1="12.2219" x2="27.7547" y2="7.00114" gradientUnits="userSpaceOnUse">
+<stop stop-color="#CCCCCC"/>
+<stop offset="0.12" stop-color="#D7D7D7"/>
+<stop offset="0.42" stop-color="#EBEBEB"/>
+<stop offset="0.72" stop-color="#F8F8F8"/>
+<stop offset="1" stop-color="#FCFCFC"/>
+</linearGradient>
+<linearGradient id="paint2_linear_2627_522" x1="8.54785" y1="31.4686" x2="8.50821" y2="26.2476" gradientUnits="userSpaceOnUse">
+<stop stop-color="#CCCCCC"/>
+<stop offset="0.12" stop-color="#D7D7D7"/>
+<stop offset="0.42" stop-color="#EBEBEB"/>
+<stop offset="0.72" stop-color="#F8F8F8"/>
+<stop offset="1" stop-color="#FCFCFC"/>
+</linearGradient>
+<linearGradient id="paint3_linear_2627_522" x1="27.7944" y1="31.4686" x2="27.7547" y2="26.2476" gradientUnits="userSpaceOnUse">
+<stop stop-color="#CCCCCC"/>
+<stop offset="0.12" stop-color="#D7D7D7"/>
+<stop offset="0.42" stop-color="#EBEBEB"/>
+<stop offset="0.72" stop-color="#F8F8F8"/>
+<stop offset="1" stop-color="#FCFCFC"/>
+</linearGradient>
+<clipPath id="clip0_2627_522">
+<rect width="37" height="37" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/tools/vscode-azurewebpubsub/src/extension.ts
+++ b/tools/vscode-azurewebpubsub/src/extension.ts
@@ -6,10 +6,12 @@
 'use strict';
 
 import { registerAzureUtilsExtensionVariables } from '@microsoft/vscode-azext-azureutils';
-import { IActionContext, callWithTelemetryAndErrorHandling, createAzExtOutputChannel, registerUIExtensionVariables } from '@microsoft/vscode-azext-utils';
+import { IActionContext, TreeElementStateManager, callWithTelemetryAndErrorHandling, createAzExtOutputChannel, registerUIExtensionVariables } from '@microsoft/vscode-azext-utils';
 import * as vscode from 'vscode';
 import { registerCommands } from './commands';
 import { ext } from './extensionVariables';
+import { ServicesDataProvider } from './tree/ServicesDataProvider';
+import { getAzureResourcesExtensionApi } from '@microsoft/vscode-azureresources-api';
 
 export async function activate(context: vscode.ExtensionContext, perfStats: { loadStartTime: number; loadEndTime: number }, ignoreBundle?: boolean): Promise<void> {
     // the entry point for vscode.dev is this activate, not main.js, so we need to instantiate perfStats here
@@ -26,6 +28,11 @@ export async function activate(context: vscode.ExtensionContext, perfStats: { lo
     await callWithTelemetryAndErrorHandling('webPubSub.activate', async (activateContext: IActionContext) => {
         activateContext.telemetry.properties.isActivationEvent = 'true';
         activateContext.telemetry.measurements.mainFileLoad = (perfStats.loadEndTime - perfStats.loadStartTime) / 1000;
+
+        ext.state = new TreeElementStateManager();
+        ext.branchDataProvider = new ServicesDataProvider();
+        ext.rgApiV2 = await getAzureResourcesExtensionApi(context, '2.0.0');
+        ext.rgApiV2.resources.registerAzureResourceBranchDataProvider("WebPubSub" as any, ext.branchDataProvider);
 
         registerCommands();
     });

--- a/tools/vscode-azurewebpubsub/src/extensionVariables.ts
+++ b/tools/vscode-azurewebpubsub/src/extensionVariables.ts
@@ -3,8 +3,10 @@
 *  Licensed under the MIT License. See License.txt in the project root for license information.
 *--------------------------------------------------------------------------------------------*/
 
-import { IAzExtOutputChannel } from "@microsoft/vscode-azext-utils";
+import { IAzExtOutputChannel, TreeElementStateManager } from "@microsoft/vscode-azext-utils";
 import { ExtensionContext } from "vscode";
+import { ServicesDataProvider } from "./tree/ServicesDataProvider";
+import { AzureResourcesExtensionApi } from "@microsoft/vscode-azureresources-api";
 
 /**
  * Namespace for common variables used throughout the extension. They must be initialized in the activate() method of extension.ts
@@ -12,6 +14,9 @@ import { ExtensionContext } from "vscode";
 // tslint:disable-next-line: export-name
 export namespace ext {
     export const prefix: string = 'webPubSub';
+    export let state: TreeElementStateManager;
+    export let branchDataProvider: ServicesDataProvider;
+    export let rgApiV2: AzureResourcesExtensionApi;
     export let context: ExtensionContext;
     export let outputChannel: IAzExtOutputChannel;
     export let ignoreBundle: boolean | undefined;

--- a/tools/vscode-azurewebpubsub/src/tree/ServicesDataProvider.ts
+++ b/tools/vscode-azurewebpubsub/src/tree/ServicesDataProvider.ts
@@ -1,0 +1,54 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { IActionContext, TreeElementBase, callWithTelemetryAndErrorHandling, nonNullProp } from "@microsoft/vscode-azext-utils";
+import { AzureResource, AzureResourceBranchDataProvider } from '@microsoft/vscode-azureresources-api';
+import * as vscode from 'vscode';
+import { ServiceItem } from "./service/ServiceItem";
+import { ext } from "../extensionVariables";
+
+
+export class ServicesDataProvider extends vscode.Disposable implements AzureResourceBranchDataProvider<TreeElementBase> {
+    private readonly onDidChangeTreeDataEmitter = new vscode.EventEmitter<TreeElementBase | undefined>();
+
+    constructor() {
+        super(() => { this.onDidChangeTreeDataEmitter.dispose(); });
+    }
+
+    get onDidChangeTreeData(): vscode.Event<TreeElementBase | undefined> {
+        return this.onDidChangeTreeDataEmitter.event;
+    }
+
+    async getChildren(element: TreeElementBase): Promise<TreeElementBase[] | null | undefined> {
+        return (await element.getChildren?.())?.map((child) => {
+            if (child.id) {
+                return ext.state.wrapItemInStateHandling(child as TreeElementBase & { id: string; }, () => this.refresh(child));
+            }
+            return child;
+        });
+    }
+
+    async getResourceItem(element: AzureResource): Promise<TreeElementBase> {
+        const resourceItem = await callWithTelemetryAndErrorHandling(
+            'getResourceItem',
+            async (context: IActionContext) => {
+                context.errorHandling.rethrow = true;
+                const serviceModel = await ServiceItem.Get(context, element.subscription, nonNullProp(element, 'resourceGroup'), element.name);
+                return new ServiceItem(element.subscription, element, serviceModel);
+            }
+        );
+
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        return ext.state.wrapItemInStateHandling(resourceItem!, () => this.refresh(resourceItem));
+    }
+
+    async getTreeItem(element: TreeElementBase): Promise<vscode.TreeItem> {
+        return await element.getTreeItem();
+    }
+
+    refresh(element?: TreeElementBase): void {
+        this.onDidChangeTreeDataEmitter.fire(element);
+    }
+}

--- a/tools/vscode-azurewebpubsub/src/tree/service/ServiceItem.ts
+++ b/tools/vscode-azurewebpubsub/src/tree/service/ServiceItem.ts
@@ -6,7 +6,7 @@
 import { KnownServiceKind, WebPubSubResource } from "@azure/arm-webpubsub";
 import { getResourceGroupFromId, uiUtils } from "@microsoft/vscode-azext-azureutils";
 import { IActionContext, TreeElementBase, createContextValue } from "@microsoft/vscode-azext-utils";
-import { AzureResource, AzureSubscription } from '@microsoft/vscode-azureresources-api';
+import { AzureResource, AzureResourceModel, AzureSubscription, ViewPropertiesModel } from '@microsoft/vscode-azureresources-api';
 import * as vscode from 'vscode';
 import { createWebPubSubAPIClient } from "../../utils";
 import { getServiceIconPath } from "../utils";
@@ -14,8 +14,8 @@ import { ServicePropertiesItem } from "./ServicePropertiesItem";
 import { ServiceModel } from "./ServiceModel";
 
 
-export class ServiceItem implements TreeElementBase {
-    static readonly contextValue: string = 'serviceItem';
+export class ServiceItem implements AzureResourceModel {
+    static readonly contextValue: string = 'webPubSubServiceItem';
     static readonly contextValueRegExp: RegExp = new RegExp(ServiceItem.contextValue);
 
     id: string;
@@ -44,6 +44,11 @@ export class ServiceItem implements TreeElementBase {
             tooltip: `${this.service.name}, ${this.service.sku?.tier} ${this.service.sku?.capacity} units, ${this.service.location}`,
         };
     }
+
+    viewProperties: ViewPropertiesModel = {
+        data: this.service,
+        label: `Properties`
+    };
 
     static async List(context: IActionContext, subscription: AzureSubscription): Promise<WebPubSubResource[]> {
         const client = await createWebPubSubAPIClient(context, subscription);

--- a/tools/vscode-azurewebpubsub/src/tree/service/ServiceItem.ts
+++ b/tools/vscode-azurewebpubsub/src/tree/service/ServiceItem.ts
@@ -1,0 +1,69 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { KnownServiceKind, WebPubSubResource } from "@azure/arm-webpubsub";
+import { getResourceGroupFromId, uiUtils } from "@microsoft/vscode-azext-azureutils";
+import { IActionContext, TreeElementBase, createContextValue } from "@microsoft/vscode-azext-utils";
+import { AzureResource, AzureSubscription } from '@microsoft/vscode-azureresources-api';
+import * as vscode from 'vscode';
+import { createWebPubSubAPIClient } from "../../utils";
+import { getServiceIconPath } from "../utils";
+import { ServicePropertiesItem } from "./ServicePropertiesItem";
+import { ServiceModel } from "./ServiceModel";
+
+
+export class ServiceItem implements TreeElementBase {
+    static readonly contextValue: string = 'serviceItem';
+    static readonly contextValueRegExp: RegExp = new RegExp(ServiceItem.contextValue);
+
+    id: string;
+    resourceGroup: string;
+    name: string;
+    properties: ServicePropertiesItem;
+
+    constructor(public readonly subscription: AzureSubscription, public readonly resource: AzureResource, public readonly service: ServiceModel) {
+        this.id = service.id;
+        this.name = service.name;
+        this.resourceGroup = service.resourceGroup;
+        this.properties = new ServicePropertiesItem(this.service);
+    }
+
+    async getChildren(): Promise<TreeElementBase[]> {
+        return [this.properties];
+    }
+
+    getTreeItem(): vscode.TreeItem {
+        return {
+            label: this.service.name,
+            id: this.id,
+            iconPath: getServiceIconPath(this.service.kind === KnownServiceKind.WebPubSub),
+            contextValue: createContextValue([ServiceItem.contextValue]),
+            collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+            tooltip: `${this.service.name}, ${this.service.sku?.tier} ${this.service.sku?.capacity} units, ${this.service.location}`,
+        };
+    }
+
+    static async List(context: IActionContext, subscription: AzureSubscription): Promise<WebPubSubResource[]> {
+        const client = await createWebPubSubAPIClient(context, subscription);
+        return await uiUtils.listAllIterator(client.webPubSub.listBySubscription());
+    }
+
+    static async Get(context: IActionContext, subscription: AzureSubscription, resourceGroup: string, name: string): Promise<ServiceModel> {
+        const client = await createWebPubSubAPIClient(context, subscription);
+        return ServiceItem.CreateWebPubSubModel(await client.webPubSub.get(resourceGroup, name), name);
+    }
+
+    static CreateWebPubSubModel(serviceResource: WebPubSubResource, serviceName: string): ServiceModel {
+        if (!serviceResource.id) {
+            throw new Error(`Invalid webPubSub.id: ${serviceResource.id}`);
+        }
+        return {
+            name: serviceName,
+            resourceGroup: getResourceGroupFromId(serviceResource.id),
+            id: serviceResource.id,
+            ...serviceResource
+        }
+    }
+}

--- a/tools/vscode-azurewebpubsub/src/tree/service/ServiceModel.ts
+++ b/tools/vscode-azurewebpubsub/src/tree/service/ServiceModel.ts
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { WebPubSubResource } from "@azure/arm-webpubsub";
+import { ResourceModel } from "../utils";
+
+
+export type ServiceModel = WebPubSubResource & ResourceModel;

--- a/tools/vscode-azurewebpubsub/src/tree/service/ServicePropertiesItem.ts
+++ b/tools/vscode-azurewebpubsub/src/tree/service/ServicePropertiesItem.ts
@@ -25,7 +25,7 @@ export class ServicePropertiesItem implements TreeElementBase {
             collapsibleState: vscode.TreeItemCollapsibleState.Collapsed
         };
     }
-    
+
     async getChildren(): Promise<TreeElementBase[]> {
         const childs: TreeElementBase[] = [];
         childs.push(createGenericElement({
@@ -38,7 +38,7 @@ export class ServicePropertiesItem implements TreeElementBase {
             label: localize('serviceSku', 'Sku'),
             description: this.webPubSub.sku?.name,
             contextValue: "serviceSku",
-            iconPath: new ThemeIcon("plug")
+            iconPath: new ThemeIcon("settings")
         }));
         childs.push(createGenericElement({
             label: localize('serviceUnitCount', 'Unit'),

--- a/tools/vscode-azurewebpubsub/src/tree/service/ServicePropertiesItem.ts
+++ b/tools/vscode-azurewebpubsub/src/tree/service/ServicePropertiesItem.ts
@@ -1,0 +1,97 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { KnownWebPubSubSkuTier, ProvisioningState } from "@azure/arm-webpubsub";
+import { TreeElementBase, TreeItemIconPath, createContextValue, createGenericElement } from "@microsoft/vscode-azext-utils";
+import * as vscode from 'vscode';
+import { ThemeIcon } from "vscode";
+import { localize } from "../../utils";
+import { ServiceModel } from "./ServiceModel";
+
+
+export class ServicePropertiesItem implements TreeElementBase {
+    static readonly contextValue: string = 'servicePropertiesItem';
+    static readonly contextValueRegExp: RegExp = new RegExp(ServicePropertiesItem.contextValue);
+
+    constructor(public readonly webPubSub: ServiceModel) { }
+    
+    getTreeItem(): vscode.TreeItem {
+        return {
+            label: `Properties`,
+            iconPath: new ThemeIcon("symbol-property"),
+            contextValue:  createContextValue([ServicePropertiesItem.contextValue]),
+            collapsibleState: vscode.TreeItemCollapsibleState.Collapsed
+        };
+    }
+
+    private getIconPathForProvisoningState(provisioningState?: ProvisioningState): TreeItemIconPath {
+        switch (provisioningState) {
+            case "Running": case "Creating": case "Updating": case "Deleting": case "Moving": return new ThemeIcon("refresh");
+            case "Succeeded": return new ThemeIcon("check"); 
+            case "Failed": return new ThemeIcon("error"); 
+            case "Canceled": return new ThemeIcon("close"); 
+            case "Unknown": return new ThemeIcon("question"); 
+            default: return new ThemeIcon("error"); 
+        }
+    }
+
+    async getChildren(): Promise<TreeElementBase[]> {
+        const childs: TreeElementBase[] = [];
+        childs.push(createGenericElement({
+            label: localize('serviceLocation', 'Location'),
+            description: this.webPubSub.location,
+            contextValue: "serviceLocation",
+            iconPath: new ThemeIcon("location")
+        }));
+        childs.push(createGenericElement({
+            label: localize('serviceProvisioningState', 'Provisioning State'),
+            description: this.webPubSub.provisioningState,
+            contextValue: "serviceStatus",
+            iconPath: this.getIconPathForProvisoningState(this.webPubSub.provisioningState)
+        }));
+        childs.push(createGenericElement({
+            label: localize('serviceLocalAuth', 'Local Auth'),
+            description: this.webPubSub.disableLocalAuth ? "Disabled" : "Enabled",
+            contextValue: "servicePropertyDisableLocalAuth",
+            iconPath: new ThemeIcon(this.webPubSub.disableLocalAuth ? "error" : "check"),
+        }));
+        childs.push(createGenericElement({
+            label: localize('servicePublicNetworkAccess', 'Public Network Access'),
+            description: this.webPubSub.publicNetworkAccess ? "Allow" : "Deny",
+            contextValue: "servicePropertyPublicNetworkAccess",
+            iconPath: new ThemeIcon(this.webPubSub.publicNetworkAccess ? "check" : "error"),
+        }));
+
+        let tlsNodeDesc = "";
+        if (this.webPubSub.sku?.tier !== KnownWebPubSubSkuTier.Free) {
+            if (this.webPubSub.tls) {
+                tlsNodeDesc = this.webPubSub.tls.clientCertEnabled ? "Client Cert Enabled" : "Client Cert Disabled";
+            }
+            else {
+                tlsNodeDesc = "Unconfigured";
+            }
+        }
+        else {
+            tlsNodeDesc = `Not Supported for ${this.webPubSub.sku?.tier} Tier`;
+        }
+
+        childs.push(createGenericElement({
+            label: localize('serviceTls', 'TLS'),
+            description: tlsNodeDesc,
+            contextValue: "serviceTls",
+            iconPath: new ThemeIcon(tlsNodeDesc.includes("Enabled") ? "check" : "error"),
+        }));
+
+        childs.push(createGenericElement({
+            label: localize('serviceVersion', 'Version'),
+            description: this.webPubSub.version,
+            contextValue: "serviceVersion",
+            iconPath: new ThemeIcon("versions"),
+        }));
+
+        return childs;
+    }
+
+}

--- a/tools/vscode-azurewebpubsub/src/tree/service/ServicePropertiesItem.ts
+++ b/tools/vscode-azurewebpubsub/src/tree/service/ServicePropertiesItem.ts
@@ -40,12 +40,14 @@ export class ServicePropertiesItem implements TreeElementBase {
             contextValue: "serviceSku",
             iconPath: new ThemeIcon("settings")
         }));
-        childs.push(createGenericElement({
-            label: localize('serviceUnitCount', 'Unit'),
-            description: (this.webPubSub.sku?.capacity ?? 1).toString(),
-            contextValue: "serviceUnitCount",
-            iconPath: new ThemeIcon("symbol-unit")
-        }));
+        if (this.webPubSub.sku?.tier !== KnownWebPubSubSkuTier.Free) {
+            childs.push(createGenericElement({
+                label: localize('serviceUnitCount', 'Unit'),
+                description: (this.webPubSub.sku?.capacity ?? 1).toString(),
+                contextValue: "serviceUnitCount",
+                iconPath: new ThemeIcon("symbol-unit")
+            }));
+        }
         childs.push(createGenericElement({
             label: localize('serviceStatus', 'Status'),
             description: this.webPubSub.provisioningState,
@@ -64,7 +66,7 @@ export class ServicePropertiesItem implements TreeElementBase {
             case "Failed": return new ThemeIcon("error"); 
             case "Canceled": return new ThemeIcon("close"); 
             case "Unknown": return new ThemeIcon("question"); 
-            default: return new ThemeIcon("error"); 
+            default: return new ThemeIcon("question"); 
         }
     }
 

--- a/tools/vscode-azurewebpubsub/src/tree/service/ServicePropertiesItem.ts
+++ b/tools/vscode-azurewebpubsub/src/tree/service/ServicePropertiesItem.ts
@@ -83,14 +83,7 @@ export class ServicePropertiesItem implements TreeElementBase {
             contextValue: "serviceTls",
             iconPath: new ThemeIcon(tlsNodeDesc.includes("Enabled") ? "check" : "error"),
         }));
-
-        childs.push(createGenericElement({
-            label: localize('serviceVersion', 'Version'),
-            description: this.webPubSub.version,
-            contextValue: "serviceVersion",
-            iconPath: new ThemeIcon("versions"),
-        }));
-
+        
         return childs;
     }
 

--- a/tools/vscode-azurewebpubsub/src/tree/service/ServicePropertiesItem.ts
+++ b/tools/vscode-azurewebpubsub/src/tree/service/ServicePropertiesItem.ts
@@ -25,18 +25,7 @@ export class ServicePropertiesItem implements TreeElementBase {
             collapsibleState: vscode.TreeItemCollapsibleState.Collapsed
         };
     }
-
-    private getIconPathForProvisoningState(provisioningState?: ProvisioningState): TreeItemIconPath {
-        switch (provisioningState) {
-            case "Running": case "Creating": case "Updating": case "Deleting": case "Moving": return new ThemeIcon("refresh");
-            case "Succeeded": return new ThemeIcon("check"); 
-            case "Failed": return new ThemeIcon("error"); 
-            case "Canceled": return new ThemeIcon("close"); 
-            case "Unknown": return new ThemeIcon("question"); 
-            default: return new ThemeIcon("error"); 
-        }
-    }
-
+    
     async getChildren(): Promise<TreeElementBase[]> {
         const childs: TreeElementBase[] = [];
         childs.push(createGenericElement({
@@ -46,45 +35,37 @@ export class ServicePropertiesItem implements TreeElementBase {
             iconPath: new ThemeIcon("location")
         }));
         childs.push(createGenericElement({
-            label: localize('serviceProvisioningState', 'Provisioning State'),
+            label: localize('serviceSku', 'Sku'),
+            description: this.webPubSub.sku?.name,
+            contextValue: "serviceSku",
+            iconPath: new ThemeIcon("plug")
+        }));
+        childs.push(createGenericElement({
+            label: localize('serviceUnitCount', 'Unit'),
+            description: (this.webPubSub.sku?.capacity ?? 1).toString(),
+            contextValue: "serviceUnitCount",
+            iconPath: new ThemeIcon("symbol-unit")
+        }));
+        childs.push(createGenericElement({
+            label: localize('serviceStatus', 'Status'),
             description: this.webPubSub.provisioningState,
             contextValue: "serviceStatus",
             iconPath: this.getIconPathForProvisoningState(this.webPubSub.provisioningState)
         }));
-        childs.push(createGenericElement({
-            label: localize('serviceLocalAuth', 'Local Auth'),
-            description: this.webPubSub.disableLocalAuth ? "Disabled" : "Enabled",
-            contextValue: "servicePropertyDisableLocalAuth",
-            iconPath: new ThemeIcon(this.webPubSub.disableLocalAuth ? "error" : "check"),
-        }));
-        childs.push(createGenericElement({
-            label: localize('servicePublicNetworkAccess', 'Public Network Access'),
-            description: this.webPubSub.publicNetworkAccess ? "Allow" : "Deny",
-            contextValue: "servicePropertyPublicNetworkAccess",
-            iconPath: new ThemeIcon(this.webPubSub.publicNetworkAccess ? "check" : "error"),
-        }));
 
-        let tlsNodeDesc = "";
-        if (this.webPubSub.sku?.tier !== KnownWebPubSubSkuTier.Free) {
-            if (this.webPubSub.tls) {
-                tlsNodeDesc = this.webPubSub.tls.clientCertEnabled ? "Client Cert Enabled" : "Client Cert Disabled";
-            }
-            else {
-                tlsNodeDesc = "Unconfigured";
-            }
-        }
-        else {
-            tlsNodeDesc = `Not Supported for ${this.webPubSub.sku?.tier} Tier`;
-        }
-
-        childs.push(createGenericElement({
-            label: localize('serviceTls', 'TLS'),
-            description: tlsNodeDesc,
-            contextValue: "serviceTls",
-            iconPath: new ThemeIcon(tlsNodeDesc.includes("Enabled") ? "check" : "error"),
-        }));
-        
         return childs;
+    }
+
+    
+    getIconPathForProvisoningState(provisioningState?: ProvisioningState): TreeItemIconPath {
+        switch (provisioningState) {
+            case "Running": case "Creating": case "Updating": case "Deleting": case "Moving": return new ThemeIcon("refresh");
+            case "Succeeded": return new ThemeIcon("check"); 
+            case "Failed": return new ThemeIcon("error"); 
+            case "Canceled": return new ThemeIcon("close"); 
+            case "Unknown": return new ThemeIcon("question"); 
+            default: return new ThemeIcon("error"); 
+        }
     }
 
 }

--- a/tools/vscode-azurewebpubsub/src/tree/utils.ts
+++ b/tools/vscode-azurewebpubsub/src/tree/utils.ts
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { TreeItemIconPath } from "@microsoft/vscode-azext-utils";
+import { Resource } from '@azure/arm-webpubsub';
+import { ext } from '../extensionVariables';
+
+
+export interface ResourceModel extends Resource {
+    id: string;
+    name: string;
+    resourceGroup: string;
+}
+
+const getResourcesUri = () => vscode.Uri.joinPath(ext.context.extensionUri, 'resources');
+export const getIconPath = (iconName: string, suffix: "svg" | "png" = "svg"): TreeItemIconPath => vscode.Uri.joinPath(getResourcesUri(), `${iconName}.${suffix}`);
+export const getServiceIconPath = (isClassical: boolean = true) => isClassical ? getIconPath('azure-web-pubsub') : getIconPath('azure-web-pubsub-socketio');

--- a/tools/vscode-azurewebpubsub/src/utils.ts
+++ b/tools/vscode-azurewebpubsub/src/utils.ts
@@ -1,4 +1,20 @@
 import { window } from "vscode";
+import * as nls from 'vscode-nls';
+import { WebPubSubManagementClient } from "@azure/arm-webpubsub";
+import { AzExtClientContext, createAzureClient } from "@microsoft/vscode-azext-azureutils";
+import { IActionContext, createSubscriptionContext } from "@microsoft/vscode-azext-utils";
+import { AzureSubscription } from "@microsoft/vscode-azureresources-api";
+
+
+export const localize: nls.LocalizeFunc = nls.loadMessageBundle();
+
+export async function createAzureApiClient(context: AzExtClientContext): Promise<WebPubSubManagementClient> {
+    return createAzureClient(context, WebPubSubManagementClient);
+}
+
+export async function createWebPubSubAPIClient(context: IActionContext, subscription: AzureSubscription): Promise<WebPubSubManagementClient> {
+    return createAzureApiClient([context, createSubscriptionContext(subscription)]);
+}
 
 export function showError(commandName: string, error: Error): void {
     void window.showErrorMessage(`Command "${commandName}" fails. ${error.message}`);


### PR DESCRIPTION
1. show service properties in resource tree
2. right click service name then click "View Properties" to view detail
3. show correct icon for socket.io service
4. fix a packing issue in `gulpfile.ts`. 

How to use the extension: https://github.com/Azure/azure-webpubsub/pull/685
![image](https://github.com/Azure/azure-webpubsub/assets/87063252/b81f85f7-8ef4-4bcd-9e87-b5bb4c3e8e08)

![image](https://github.com/Azure/azure-webpubsub/assets/87063252/745f0553-3f2c-48f4-b764-8a114add4dd1)
