### PR TITLE
Add item pickers for vscode extension

### DIFF
--- a/tools/vscode-azurewebpubsub/src/tree/hubSettings/EventHandlers/pickEventHandler.ts
+++ b/tools/vscode-azurewebpubsub/src/tree/hubSettings/EventHandlers/pickEventHandler.ts
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { ContextValueQuickPickStep, runQuickPickWizard, type AzureResourceQuickPickWizardContext, type AzureWizardPromptStep, type IActionContext } from "@microsoft/vscode-azext-utils";
+import { ext } from "../../../extensionVariables";
+import { localize } from "../../../utils";
+import { getPickHubSteps } from "../pickHubSetting";
+import  { type PickItemOptions } from "../../utils";
+import { EventHandlerItem } from "./EventHandlerItem";
+
+export async function pickEventHandler(context: IActionContext, options?: PickItemOptions): Promise<EventHandlerItem> {
+    return await runQuickPickWizard(context,
+        {
+            promptSteps: getPickEventHandlerSteps(),
+            title: options?.title,
+            showLoadingPrompt: options?.showLoadingPrompt
+        });
+}
+
+export function getPickEventHandlerSteps(): AzureWizardPromptStep<AzureResourceQuickPickWizardContext>[] {
+    return [
+        ...getPickHubSteps(),
+        new ContextValueQuickPickStep(
+            ext.branchDataProvider,
+            {
+                contextValueFilter: { include: EventHandlerItem.contextValueRegExp },
+                skipIfOne: false,
+            },
+            {
+                placeHolder: localize('selectEventHandler', 'Select an event handler'),
+                noPicksMessage: localize('noEventHandler', 'Current hub contains no event handler'),
+            }
+        )
+    ];
+}

--- a/tools/vscode-azurewebpubsub/src/tree/hubSettings/EventListeners/pickEventListener.ts
+++ b/tools/vscode-azurewebpubsub/src/tree/hubSettings/EventListeners/pickEventListener.ts
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { ContextValueQuickPickStep, runQuickPickWizard, type AzureResourceQuickPickWizardContext, type AzureWizardPromptStep, type IActionContext } from "@microsoft/vscode-azext-utils";
+import { ext } from "../../../extensionVariables";
+import { localize } from "../../../utils";
+import { getPickHubSteps } from "../pickHubSetting";
+import  { type PickItemOptions } from "../../utils";
+import { EventListenerItem } from "./EventListenerItem";
+
+export async function pickEventListener(context: IActionContext, options?: PickItemOptions): Promise<EventListenerItem> {
+    return await runQuickPickWizard(context,
+        {
+            promptSteps: getPickEventListenerSteps(),
+            title: options?.title,
+            showLoadingPrompt: options?.showLoadingPrompt
+        });
+}
+
+export function getPickEventListenerSteps(): AzureWizardPromptStep<AzureResourceQuickPickWizardContext>[] {
+    return [
+        ...getPickHubSteps(),
+        new ContextValueQuickPickStep(
+            ext.branchDataProvider,
+            {
+                contextValueFilter: { include: EventListenerItem.contextValueRegExp },
+                skipIfOne: false,
+            },
+            {
+                placeHolder: localize('selectEventListener', 'Select an event listener'),
+                noPicksMessage: localize('noEventListener', 'Current hub contains no event listener'),
+            }
+        )
+    ];
+}

--- a/tools/vscode-azurewebpubsub/src/tree/hubSettings/pickHubSetting.ts
+++ b/tools/vscode-azurewebpubsub/src/tree/hubSettings/pickHubSetting.ts
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { ContextValueQuickPickStep, runQuickPickWizard, type AzureResourceQuickPickWizardContext, type AzureWizardPromptStep, type IActionContext } from "@microsoft/vscode-azext-utils";
+import { ext } from "../../extensionVariables";
+import { localize } from "../../utils";
+import  { type PickItemOptions } from "../utils";
+import { getPickServiceSteps } from "../service/pickService";
+import { HubSettingItem } from "./HubSettingItem";
+
+export async function pickHub(context: IActionContext, options?: PickItemOptions): Promise<HubSettingItem> {
+    return await runQuickPickWizard(context,
+        {
+            promptSteps: getPickHubSteps(),
+            title: options?.title,
+            showLoadingPrompt: options?.showLoadingPrompt
+        });
+}
+
+export function getPickHubSteps(): AzureWizardPromptStep<AzureResourceQuickPickWizardContext>[] {
+    return [
+        ...getPickServiceSteps(),
+        new ContextValueQuickPickStep(
+            ext.branchDataProvider,
+            {
+                contextValueFilter: { include: [HubSettingItem.contextValueRegExp] },
+                skipIfOne: true,
+            },
+            {
+                placeHolder: localize('selectHub', 'Select a Hub'),
+                noPicksMessage: localize('noHub', 'Current Web PubSub serivce has no hub'),
+            }
+        )
+    ];
+}

--- a/tools/vscode-azurewebpubsub/src/tree/hubSettings/pickHubSetting.ts
+++ b/tools/vscode-azurewebpubsub/src/tree/hubSettings/pickHubSetting.ts
@@ -29,8 +29,8 @@ export function getPickHubSteps(): AzureWizardPromptStep<AzureResourceQuickPickW
                 skipIfOne: true,
             },
             {
-                placeHolder: localize('selectHub', 'Select a Hub'),
-                noPicksMessage: localize('noHub', 'Current Web PubSub serivce has no hub'),
+                placeHolder: localize('selectHub', 'Select a hub setting'),
+                noPicksMessage: localize('noHub', 'Current Web PubSub serivce has no hub setting configured'),
             }
         )
     ];

--- a/tools/vscode-azurewebpubsub/src/tree/hubSettings/pickHubSettings.ts
+++ b/tools/vscode-azurewebpubsub/src/tree/hubSettings/pickHubSettings.ts
@@ -29,8 +29,8 @@ export function getPickHubsSteps(): AzureWizardPromptStep<AzureResourceQuickPick
                 skipIfOne: true,
             },
             {
-                placeHolder: localize('selectHub', 'Select hubs'),
-                noPicksMessage: localize('noHub', 'Current Web PubSub serivce has no hubs'),
+                placeHolder: localize('selectHub', 'Select a hub settings'),
+                noPicksMessage: localize('noHub', 'Current Web PubSub serivce has no hub setting configured'),
             }
         )
     ];

--- a/tools/vscode-azurewebpubsub/src/tree/hubSettings/pickHubSettings.ts
+++ b/tools/vscode-azurewebpubsub/src/tree/hubSettings/pickHubSettings.ts
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { ContextValueQuickPickStep, runQuickPickWizard, type AzureResourceQuickPickWizardContext, type AzureWizardPromptStep, type IActionContext } from "@microsoft/vscode-azext-utils";
+import { ext } from "../../extensionVariables";
+import { localize } from "../../utils";
+import  { type PickItemOptions } from "../utils";
+import { getPickServiceSteps } from "../service/pickService";
+import { HubSettingsItem } from "./HubSettingsItem";
+
+export async function pickHubs(context: IActionContext, options?: PickItemOptions): Promise<HubSettingsItem> {
+    return await runQuickPickWizard(context,
+        {
+            promptSteps: getPickHubsSteps(),
+            title: options?.title,
+            showLoadingPrompt: options?.showLoadingPrompt
+        });
+}
+
+export function getPickHubsSteps(): AzureWizardPromptStep<AzureResourceQuickPickWizardContext>[] {
+    return [
+        ...getPickServiceSteps(),
+        new ContextValueQuickPickStep(
+            ext.branchDataProvider,
+            {
+                contextValueFilter: { include: HubSettingsItem.contextValueRegExp },
+                skipIfOne: true,
+            },
+            {
+                placeHolder: localize('selectHub', 'Select hubs'),
+                noPicksMessage: localize('noHub', 'Current Web PubSub serivce has no hubs'),
+            }
+        )
+    ];
+}

--- a/tools/vscode-azurewebpubsub/src/tree/service/pickService.ts
+++ b/tools/vscode-azurewebpubsub/src/tree/service/pickService.ts
@@ -33,7 +33,7 @@ export function getPickServiceSteps(): AzureWizardPromptStep<AzureResourceQuickP
                 skipIfOne: false, // user won't skip selection step even if there is only one choice
             },
             {
-                placeHolder: localize('selectService', 'Select an Web PubSub resource'),
+                placeHolder: localize('selectService', 'Select a Web PubSub resource'),
                 noPicksMessage: localize('noServiceInSubscription', 'Current subscription has no Web PubSub resource'),
             }
         )

--- a/tools/vscode-azurewebpubsub/src/tree/service/pickService.ts
+++ b/tools/vscode-azurewebpubsub/src/tree/service/pickService.ts
@@ -1,0 +1,41 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import { ContextValueQuickPickStep, QuickPickAzureSubscriptionStep, QuickPickGroupStep, runQuickPickWizard, type AzureResourceQuickPickWizardContext, type AzureWizardPromptStep, type IActionContext } from "@microsoft/vscode-azext-utils";
+import  { type AzExtResourceType } from "@microsoft/vscode-azureresources-api";
+import { ext } from "../../extensionVariables";
+import { localize } from "../../utils";
+import { ServiceItem } from "../service/ServiceItem";
+import  { type PickItemOptions } from "../utils";
+import { WEB_PUBSUB_RESOURCE_TYPE } from "../../constants";
+
+export async function pickService(context: IActionContext, options?: PickItemOptions): Promise<ServiceItem> {
+    return await runQuickPickWizard(
+        context, { 
+            title: options?.title, 
+            promptSteps: getPickServiceSteps(),
+            showLoadingPrompt: options?.showLoadingPrompt 
+        }
+    )
+}
+
+export function getPickServiceSteps(): AzureWizardPromptStep<AzureResourceQuickPickWizardContext>[] {
+    const tdp = ext.rgApiV2.resources.azureResourceTreeDataProvider;
+    return [
+        new QuickPickAzureSubscriptionStep(tdp),
+        new QuickPickGroupStep(tdp, { groupType: [ WEB_PUBSUB_RESOURCE_TYPE as AzExtResourceType ] }),
+        new ContextValueQuickPickStep(
+            ext.rgApiV2.resources.azureResourceTreeDataProvider,
+            {
+                contextValueFilter: { include: ServiceItem.contextValueRegExp },
+                skipIfOne: false, // user won't skip selection step even if there is only one choice
+            },
+            {
+                placeHolder: localize('selectService', 'Select an Web PubSub resource'),
+                noPicksMessage: localize('noServiceInSubscription', 'Current subscription has no Web PubSub resource'),
+            }
+        )
+    ];
+}

--- a/tools/vscode-azurewebpubsub/src/tree/utils.ts
+++ b/tools/vscode-azurewebpubsub/src/tree/utils.ts
@@ -14,6 +14,11 @@ export interface ResourceModel extends Resource {
     resourceGroup: string;
 }
 
+export interface PickItemOptions {
+    title?: string;
+    showLoadingPrompt?: boolean;
+}
+
 const getResourcesUri = () => vscode.Uri.joinPath(ext.context.extensionUri, 'resources');
 export const getIconPath = (iconName: string, suffix: "svg" | "png" = "svg"): TreeItemIconPath => vscode.Uri.joinPath(getResourcesUri(), `${iconName}.${suffix}`);
 export const getServiceIconPath = (isClassical: boolean = true) => isClassical ? getIconPath('azure-web-pubsub') : getIconPath('azure-web-pubsub-socketio');

--- a/tools/vscode-azurewebpubsub/src/workflows/common/contexts.ts
+++ b/tools/vscode-azurewebpubsub/src/workflows/common/contexts.ts
@@ -5,7 +5,7 @@
 
 import  { type EventListener} from "@azure/arm-webpubsub";
 import  { type EventHandler} from "@azure/arm-webpubsub";
-import   { type ExecuteActivityContext, type IActionContext, type ISubscriptionContext } from "@microsoft/vscode-azext-utils";
+import  { type ExecuteActivityContext, type IActionContext, type ISubscriptionContext } from "@microsoft/vscode-azext-utils";
 
 export interface IPickServiceContext extends IActionContext, ExecuteActivityContext {
     subscription?: ISubscriptionContext;

--- a/tools/vscode-azurewebpubsub/src/workflows/common/contexts.ts
+++ b/tools/vscode-azurewebpubsub/src/workflows/common/contexts.ts
@@ -1,0 +1,26 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Microsoft Corporation. All rights reserved.
+*  Licensed under the MIT License. See License.txt in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import  { type EventListener} from "@azure/arm-webpubsub";
+import  { type EventHandler} from "@azure/arm-webpubsub";
+import   { type ExecuteActivityContext, type IActionContext, type ISubscriptionContext } from "@microsoft/vscode-azext-utils";
+
+export interface IPickServiceContext extends IActionContext, ExecuteActivityContext {
+    subscription?: ISubscriptionContext;
+    resourceGroupName?: string;
+    serviceName?: string;
+}
+
+export interface IPickHubSettingContext extends IPickServiceContext {
+    hubName?: string;
+}
+
+export interface IPickEventHandlerContext extends IPickHubSettingContext {
+    eventHandler?: EventHandler;
+}
+
+export interface IPickEventListenerContext extends IPickHubSettingContext {
+    eventListener?: EventListener;
+}


### PR DESCRIPTION
Define the steps to select a item (shown as a node in resource tree), including service, hub settings (a virtual node containing all hub setting), single hub setting/event handler/event listener

