### PR TITLE
Enable telemetry for VSCode Extension

### DIFF
--- a/tools/vscode-azurewebpubsub/package.json
+++ b/tools/vscode-azurewebpubsub/package.json
@@ -5,7 +5,7 @@
     "version": "0.0.1-beta.1",
     "publisher": "ms-azuretools",
     "icon": "resources/azure-web-pubsub.png",
-    "aiKey": "<to-be-determined>",
+    "aiKey": "3fc79002-1908-48c5-b7ac-794e604e6590",
     "engines": {
         "vscode": "^1.76.0"
     },

--- a/tools/vscode-azurewebpubsub/src/extension.ts
+++ b/tools/vscode-azurewebpubsub/src/extension.ts
@@ -6,17 +6,16 @@
 'use strict';
 
 import { registerAzureUtilsExtensionVariables } from '@microsoft/vscode-azext-azureutils';
-import { type IActionContext} from '@microsoft/vscode-azext-utils';
-import { TreeElementStateManager, callWithTelemetryAndErrorHandling, createAzExtOutputChannel, registerUIExtensionVariables } from '@microsoft/vscode-azext-utils';
+import { TreeElementStateManager, createAzExtOutputChannel, registerUIExtensionVariables } from '@microsoft/vscode-azext-utils';
 import type * as vscode from 'vscode';
 import { registerCommands } from './commands';
 import { ext } from './extensionVariables';
 import { ServicesDataProvider } from './tree/ServicesDataProvider';
 import { type AzExtResourceType, getAzureResourcesExtensionApi } from '@microsoft/vscode-azureresources-api';
+import { loadPackageInfo } from './utils';
+import { dispose as disposeTelemetryWrapper, initialize, instrumentOperation } from 'vscode-extension-telemetry-wrapper';
 
 export async function activate(context: vscode.ExtensionContext, perfStats: { loadStartTime: number; loadEndTime: number }, ignoreBundle?: boolean): Promise<void> {
-    // the entry point for vscode.dev is this activate, not main.js, so we need to instantiate perfStats here
-    // the perf stats don't matter for vscode because there is no main file to load-- we may need to see if we can track the download time
     perfStats ||= { loadStartTime: Date.now(), loadEndTime: Date.now() };
     ext.context = context;
     ext.ignoreBundle = ignoreBundle;
@@ -26,19 +25,19 @@ export async function activate(context: vscode.ExtensionContext, perfStats: { lo
     registerUIExtensionVariables(ext);
     registerAzureUtilsExtensionVariables(ext);
 
-    await callWithTelemetryAndErrorHandling('webPubSub.activate', async (activateContext: IActionContext) => {
-        activateContext.telemetry.properties.isActivationEvent = 'true';
-        activateContext.telemetry.measurements.mainFileLoad = (perfStats.loadEndTime - perfStats.loadStartTime) / 1000;
+    const { version, applicationInsightKey, extensionId } = await loadPackageInfo(context);
+    initialize(extensionId, version, applicationInsightKey, { firstParty: true });
 
+    instrumentOperation('activation', async () => {
         ext.state = new TreeElementStateManager();
         ext.branchDataProvider = new ServicesDataProvider();
         ext.rgApiV2 = await getAzureResourcesExtensionApi(context, '2.0.0');
         ext.rgApiV2.resources.registerAzureResourceBranchDataProvider("WebPubSub" as AzExtResourceType, ext.branchDataProvider);
 
         registerCommands();
-    });
+    })();
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-export function deactivate(): void {
+export async function deactivate(): Promise<void> {
+    await disposeTelemetryWrapper();
 }

--- a/tools/vscode-azurewebpubsub/src/extension.ts
+++ b/tools/vscode-azurewebpubsub/src/extension.ts
@@ -16,7 +16,6 @@ import { loadPackageInfo } from './utils';
 import { dispose as disposeTelemetryWrapper, initialize, instrumentOperation } from 'vscode-extension-telemetry-wrapper';
 
 export async function activate(context: vscode.ExtensionContext, perfStats: { loadStartTime: number; loadEndTime: number }, ignoreBundle?: boolean): Promise<void> {
-    perfStats ||= { loadStartTime: Date.now(), loadEndTime: Date.now() };
     ext.context = context;
     ext.ignoreBundle = ignoreBundle;
     ext.outputChannel = createAzExtOutputChannel('Azure Web PubSub', ext.prefix);

--- a/tools/vscode-azurewebpubsub/src/utils.ts
+++ b/tools/vscode-azurewebpubsub/src/utils.ts
@@ -1,5 +1,7 @@
+import { type ExtensionContext } from "vscode";
 import { window } from "vscode";
 import * as nls from 'vscode-nls';
+import * as fs from "fs";
 import { WebPubSubManagementClient } from "@azure/arm-webpubsub";
 import { type AzExtClientContext} from "@microsoft/vscode-azext-azureutils";
 import { createAzureClient } from "@microsoft/vscode-azext-azureutils";
@@ -41,4 +43,17 @@ export function isUrlValid(url: string): boolean {
     } catch (_err) {
         return false;
     }
+}
+
+export async function loadPackageInfo(context: ExtensionContext) {
+    const raw = await fs.promises.readFile(context.asAbsolutePath("./package.json"), { encoding: 'utf-8' });
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const { publisher, name, version, aiKey } = JSON.parse(raw);
+    return {
+        publisher: publisher as string,
+        name: name as string,
+        version: version as string,
+        applicationInsightKey: aiKey as string,
+        extensionId: `${publisher}.${name}`
+    };
 }


### PR DESCRIPTION
Add Azure Application Insight key (aiKey) to enable telemetry
Ref: https://github.com/microsoft/vscode-azurespringcloud/blob/main/src/extension.ts#L50