### PR TITLE
Improve performance of loading web pub sub tree items

### DIFF
--- a/tools/vscode-azurewebpubsub/src/tree/ServicesDataProvider.ts
+++ b/tools/vscode-azurewebpubsub/src/tree/ServicesDataProvider.ts
@@ -4,7 +4,7 @@
 *--------------------------------------------------------------------------------------------*/
 
 import { type IActionContext, type TreeElementBase} from "@microsoft/vscode-azext-utils";
-import { callWithTelemetryAndErrorHandling, nonNullProp } from "@microsoft/vscode-azext-utils";
+import { callWithTelemetryAndErrorHandling } from "@microsoft/vscode-azext-utils";
 import { type AzureResource, type AzureResourceBranchDataProvider } from '@microsoft/vscode-azureresources-api';
 import * as vscode from 'vscode';
 import { ServiceItem } from "./service/ServiceItem";
@@ -35,7 +35,7 @@ export class ServicesDataProvider extends vscode.Disposable implements AzureReso
             'getResourceItem',
             async (context: IActionContext) => {
                 context.errorHandling.rethrow = true;
-                const serviceModel = await ServiceItem.get(context, element.subscription, nonNullProp(element, 'resourceGroup'), element.name);
+                const serviceModel = await ServiceItem.get(context, element);
                 return new ServiceItem(element.subscription, element, serviceModel);
             }
         );

--- a/tools/vscode-azurewebpubsub/src/tree/service/ServiceItem.ts
+++ b/tools/vscode-azurewebpubsub/src/tree/service/ServiceItem.ts
@@ -70,7 +70,7 @@ export class ServiceItem implements AzureResourceModel {
             siteCacheLastUpdated = Date.now();
         }
 
-        const site = siteCache.get(resource.name.toLowerCase());
+        const site = siteCache.get(resource.id.toLowerCase());
         return ServiceItem.createWebPubSubModel(nonNullValue(site), resource.name);
     }
 


### PR DESCRIPTION
This change uses a list operation then caches the results to improve performance of the individual calls to `getResourceItem`. The cache is valid for 3 seconds.