### PR TITLE
Ruimhu/fix cookie

### DIFF
--- a/website/src/components/Common/Footer.js
+++ b/website/src/components/Common/Footer.js
@@ -3,7 +3,7 @@ import React, { useState, useEffect } from 'react'
 function Footer() {
   const [visible, setVisible] = useState(true)
   useEffect(() => {
-    setVisible(window.siteConsent.isConsentRequired)
+    setVisible(window.siteConsent && window.siteConsent.isConsentRequired)
   })
 
   return (
@@ -22,7 +22,6 @@ function Footer() {
           <li
             className="cursor-pointer"
             onClick={() => {
-              console.log('hello.')
               window.siteConsent.manageConsent()
             }}
           >

--- a/website/src/plugins/visitor-tracking-plugin/track.js
+++ b/website/src/plugins/visitor-tracking-plugin/track.js
@@ -31,6 +31,7 @@ function AnalyticsCookie(setString) {
     expireCookie('_ga', '/', '.azure.github.io')
     expireCookie(`_ga_${trackingIndex}`, '/', '.azure.github.io')
     expireCookie('_mid', '/')
+    expireCookie('_mid', '/azure-webpubsub')
     expireCookie('_mid', normalizePath(location.pathname))
     expireCookie('_mid', getParentPath())
   }

--- a/website/src/plugins/visitor-tracking-plugin/track.js
+++ b/website/src/plugins/visitor-tracking-plugin/track.js
@@ -4,6 +4,8 @@ const cookies = require('browser-cookies')
 const trackingIndex = '9DVQRCY9L7'
 const SET = 'set'
 const RESET = 'reset'
+const originalCookieSetter = Object.getOwnPropertyDescriptor(Document.prototype, 'cookie').set;
+const originalCookieGetter = Object.getOwnPropertyDescriptor(Document.prototype, 'cookie').get;
 
 function SocialMediaCookie(setString) {
   // todo
@@ -11,7 +13,13 @@ function SocialMediaCookie(setString) {
 
 function AnalyticsCookie(setString) {
   const enable = setString === SET
+  document.__defineGetter__('cookie', function () {
+    return originalCookieGetter.call(document);
+  });
   if (enable) {
+    document.__defineSetter__('cookie', function (value) {
+        originalCookieSetter.call(document, value);
+    });
     window[`ga-disable-G-${trackingIndex}`] = false
     if (window['_ga']) cookies.set('_ga', window['_ga'], { domain: '.azure.github.io', expires: 365, path: '/' })
     if (window[`_ga_${trackingIndex}`]) cookies.set(`_ga_${trackingIndex}`, window[`_ga_${trackingIndex}`], { domain: '.azure.github.io', expires: 365, path: '/' })
@@ -31,9 +39,16 @@ function AnalyticsCookie(setString) {
     expireCookie('_ga', '/', '.azure.github.io')
     expireCookie(`_ga_${trackingIndex}`, '/', '.azure.github.io')
     expireCookie('_mid', '/')
-    expireCookie('_mid', '/azure-webpubsub')
     expireCookie('_mid', normalizePath(location.pathname))
     expireCookie('_mid', getParentPath())
+    document.__defineSetter__('cookie', function (value) {
+      const cookieName = value.split('=')[0].trim();
+      // Block _mid cookie if consent is not given
+      if (cookieName === '_mid') return;
+
+      // Proceed with setting the cookie using the original setter
+      originalCookieSetter.call(document, value);
+    });
   }
 }
 
@@ -107,6 +122,9 @@ function onConsentChanged(categoryPreferences) {
 }
 
 function initConsent() {
+  expireCookie('_mid', '/')
+  expireCookie('_mid', normalizePath(location.pathname))
+  expireCookie('_mid', getParentPath())
   window.siteConsent = null
   window.WcpConsent &&
     WcpConsent.init(


### PR DESCRIPTION
Issue found by cookie scanner:
When analytics consent is denied, the _mid cookie still present.

-The original code already try to delete the _mid cookie when the consent deny is set. However, _mid will be regenerate periodly by gtm.js(google tag manager)

-Add fix(not allow cookie setter to set for _mid cookie to prevent _mid keep generate when user consent is denied.)