### PR TITLE
Fix chat client release pipeline: use Node 20

### DIFF
--- a/.github/workflows/release_chat_client.yml
+++ b/.github/workflows/release_chat_client.yml
@@ -22,6 +22,7 @@ jobs:
     with:
       package_name: web-pubsub-chat-client
       package_folder: sdk/webpubsub-chat-client
+      node_version: '20.x'
       pack_command: |
         pushd sdk/webpubsub-chat-client
         yarn

--- a/.github/workflows/workflow-call-release-package.yml
+++ b/.github/workflows/workflow-call-release-package.yml
@@ -14,6 +14,11 @@ on:
         description: 'Shell script that builds and packs the package, producing a single *.tgz inside package_folder. Runs from the repo root.'
         required: true
         type: string
+      node_version:
+        description: 'The Node.js version to use for building and packing.'
+        required: false
+        type: string
+        default: '18.x'
     secrets:
       AZURESDKPARTNERDROPS_URL:
         required: true
@@ -28,8 +33,6 @@ on:
 permissions:
   id-token: write # This is required for requesting the JWT
   contents: read
-env:
-  NODE_VERSION: '18.x'                # set this to the node version to use
 
 jobs:
   check_version:
@@ -96,7 +99,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: ${{ env.NODE_VERSION }}
+        node-version: ${{ inputs.node_version }}
         cache: 'npm'
     - name: Install dependencies
       run: npm install -g yarn 


### PR DESCRIPTION
## Problem

After merging the unified release pipeline, the **Release Azure Web PubSub chat client package** workflow failed at the `Pack the package` step:

```
error @azure/logger@1.3.0: The engine "node" is incompatible with this module. Expected version ">=20.0.0". Got "18.20.8"
```

The reusable `workflow-call-release-package.yml` hardcoded `NODE_VERSION: '18.x'`, but the chat client SDK depends on `@azure/logger@1.3.0`, which requires Node ≥20.

## Fix

- Add an optional `node_version` input to the reusable workflow, defaulting to `18.x` so the SocketIO release behavior is unchanged.
- Use `inputs.node_version` in the `Set up Node.js` step (removed the now-unused top-level `env.NODE_VERSION`).
- `release_chat_client.yml` passes `node_version: '20.x'`.

## Note

The SocketIO workflow also showed a red run, but that is **pre-existing and unrelated**: `check_version` fails with `No log entry found for version 1.2.1-beta.1` because the package is currently at a beta version that has no CHANGELOG entry (betas don't get one until release). Prior SocketIO runs failed the same way. This PR does not change that behavior.