### PR TITLE
fix minor sdk release pipeline errors

### DIFF
--- a/.github/workflows/workflow-call-release-package.yml
+++ b/.github/workflows/workflow-call-release-package.yml
@@ -29,7 +29,7 @@ permissions:
   id-token: write # This is required for requesting the JWT
   contents: read
 env:
-  NODE_VERSION: '18.x'                # set this to the node version to use
+  NODE_VERSION: '20.x'                # set this to the node version to use
 
 jobs:
   check_version:

--- a/sdk/webpubsub-socketio-extension/CHANGELOG.md
+++ b/sdk/webpubsub-socketio-extension/CHANGELOG.md
@@ -1,6 +1,8 @@
 
 # Changelog
 
+## [1.2.1-beta.1]
+
 ## [1.2.1] - 2026-04-22
 
 - Upgrade internal package `awps-tunnel` [#https://github.com/Azure/azure-webpubsub/pull/880](https://github.com/Azure/azure-webpubsub/pull/880) empty string subprotocol rejected issue


### PR DESCRIPTION
## Summary

Fixes two failures observed after the unified SDK release pipeline landed on `main`.

### 1. Node.js version
The reusable `workflow-call-release-package.yml` hardcoded Node `18.x`, but the chat client SDK depends on `@azure/logger@1.3.0` which requires Node `>=20`, so the pack step failed. Bumped `NODE_VERSION` to `20.x`.

### 2. SocketIO CHANGELOG
`check_version` hard-failed with `No log entry found for version 1.2.1-beta.1` because the package is at a beta version with no matching CHANGELOG entry. Added an empty `## [1.2.1-beta.1]` entry. Because it has no date, `check_version` finds the version but does not trigger a release.