### PR TITLE
Remove getUserProfile from chat client SDK and release 1.0.0-beta.2

### DIFF
--- a/sdk/webpubsub-chat-client/CHANGELOG.md
+++ b/sdk/webpubsub-chat-client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.0.0-beta.2] - 2026-06-30
+
+### Breaking Changes
+
+- Remove the `getUserProfile()` method from `ChatClient` and its associated `GetUserProfileOptions` type.
+
 ## [1.0.0-beta.1] - 2026-06-09
 
 - Initial beta release of `@azure/web-pubsub-chat-client`, the client SDK for Azure Web PubSub Chat.

--- a/sdk/webpubsub-chat-client/README.md
+++ b/sdk/webpubsub-chat-client/README.md
@@ -93,7 +93,6 @@ new ChatClient(credential: WebPubSubClientCredential)
 | `removeUserFromRoom(roomId, userId, options?)` | Remove user from room (admin operation) |
 | `sendToRoom(roomId, message, options?)` | Send text message to room, returns a `SendMessageResult` (`{ messageId }`) |
 | `listRoomMessages(roomId, options?)` | Paged async iterator over room message history (auto-paginates). Use `for await` to stream every message, or `.byPage({ maxPageSize })` to load up to `maxPageSize` messages at a time. `options = { startId?, endId?, maxPageSize?, abortSignal? }` |
-| `getUserProfile(userId, options?)` | Get user profile |
 
 Every asynchronous method accepts an optional final `options` argument
 extending `OperationOptions` (`{ abortSignal?: AbortSignalLike }`) to

--- a/sdk/webpubsub-chat-client/package.json
+++ b/sdk/webpubsub-chat-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/web-pubsub-chat-client",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "Client SDK for building chat applications with Azure Web PubSub",
   "author": "Microsoft",
   "license": "MIT",

--- a/sdk/webpubsub-chat-client/review/web-pubsub-chat-client.api.md
+++ b/sdk/webpubsub-chat-client/review/web-pubsub-chat-client.api.md
@@ -18,7 +18,6 @@ export class ChatClient {
     addUserToRoom(roomId: string, userId: string, options?: AddUserToRoomOptions): Promise<void>;
     createRoom(title: string, members: string[], options?: CreateRoomOptions): Promise<RoomDetail>;
     getRoomDetail(roomId: string, options?: GetRoomDetailOptions): Promise<RoomDetail>;
-    getUserProfile(userId: string, options?: GetUserProfileOptions): Promise<UserProfile>;
     hasJoinedRoom(roomId: string): boolean;
     listRoomMessages(roomId: string, options?: ListRoomMessagesOptions): PagedAsyncIterableIterator<MessageInfo>;
     off(event: "started", listener: (e: OnStartedArgs) => void): void;
@@ -63,10 +62,6 @@ export interface CreateRoomOptions extends OperationOptions {
 // @public
 export interface GetRoomDetailOptions extends OperationOptions {
     withMembers?: boolean;
-}
-
-// @public
-export interface GetUserProfileOptions extends OperationOptions {
 }
 
 // @public

--- a/sdk/webpubsub-chat-client/src/chatClient.ts
+++ b/sdk/webpubsub-chat-client/src/chatClient.ts
@@ -15,7 +15,7 @@ import {
   MemberLeftNotificationBody,
   RoomLeftNotificationBody,
 } from "./generatedTypes.js";
-import type { MessageInfo, RoomInfo, RoomDetail, UserProfile, SendMessageResult } from "./models.js";
+import type { MessageInfo, RoomInfo, RoomDetail, SendMessageResult } from "./models.js";
 import type {
   ChatMessage,
   OnMemberJoinedArgs,
@@ -33,7 +33,6 @@ import type {
   GetRoomDetailOptions,
   CreateRoomOptions,
   SendToRoomOptions,
-  GetUserProfileOptions,
   AddUserToRoomOptions,
   RemoveUserFromRoomOptions,
 } from "./options.js";
@@ -350,22 +349,6 @@ class ChatClient {
     if (!this._isStarted) {
       throw new ChatError("Not started. Please call start() first.", ERRORS.NotStarted);
     }
-  }
-
-  /**
-   * Fetch a user's profile.
-   *
-   * @param userId - Id of the user to look up.
-   * @param options - Optional `{ abortSignal }`.
-   */
-  public async getUserProfile(userId: string, options?: GetUserProfileOptions): Promise<UserProfile> {
-    this.ensureStarted();
-    return this.invokeWithReturnType<WireUserProfile>(
-      INVOCATION_NAME.GET_USER_PROPERTIES,
-      { userId: userId },
-      "json",
-      options,
-    );
   }
 
   private async sendToConversation(

--- a/sdk/webpubsub-chat-client/src/constant.ts
+++ b/sdk/webpubsub-chat-client/src/constant.ts
@@ -1,12 +1,9 @@
 const INVOCATION_NAME = {
     LOGIN: "chat.login",
-    LIST_USER_CONVERSATION: "chat.listUserConversation",
-    GET_USER_PROPERTIES: "chat.getUserProperties",
     GET_ROOM: "chat.getRoom",
     LIST_MESSAGES: "chat.queryMessageHistory",
     SEND_TEXT_MESSAGE: "chat.sendTextMessage",
     CREATE_ROOM: "chat.createRoom",
-    JOIN_ROOM: "chat.joinRoom",
     MANAGE_ROOM_MEMBER: "chat.manageRoomMember",
 } as const;
 

--- a/sdk/webpubsub-chat-client/src/index.ts
+++ b/sdk/webpubsub-chat-client/src/index.ts
@@ -26,7 +26,6 @@ export type {
   GetRoomDetailOptions,
   CreateRoomOptions,
   SendToRoomOptions,
-  GetUserProfileOptions,
   AddUserToRoomOptions,
   RemoveUserFromRoomOptions,
   ListRoomMessagesOptions,

--- a/sdk/webpubsub-chat-client/src/options.ts
+++ b/sdk/webpubsub-chat-client/src/options.ts
@@ -43,9 +43,6 @@ export interface CreateRoomOptions extends OperationOptions {
 /** Options for `ChatClient.sendToRoom()`. */
 export interface SendToRoomOptions extends OperationOptions {}
 
-/** Options for `ChatClient.getUserProfile()`. */
-export interface GetUserProfileOptions extends OperationOptions {}
-
 /** Options for `ChatClient.addUserToRoom()`. */
 export interface AddUserToRoomOptions extends OperationOptions {}
 


### PR DESCRIPTION
## What
Remove unsupported chat invocations and the exposed `getUserProfile` API, and bump the package to `1.0.0-beta.2`.

## Changes
- Remove unused invocation constants: `chat.listUserConversation`, `chat.getUserProperties`, `chat.joinRoom`.
- Remove the public `getUserProfile()` method from `ChatClient` and its `GetUserProfileOptions` type (and its export/README entry).
- Update the API report (`review/web-pubsub-chat-client.api.md`) to match.

## Release
Merging to `main` triggers publishing of `1.0.0-beta.2`.
- `package.json`: `1.0.0-beta.1` → `1.0.0-beta.2`
- `CHANGELOG.md`: add `## [1.0.0-beta.2] - 2026-06-30`

## Breaking change
`ChatClient.getUserProfile()` is removed.