### PR TITLE
Harden awps-tunnel local dashboard access

### DIFF
--- a/tools/awps-tunnel/Readme.md
+++ b/tools/awps-tunnel/Readme.md
@@ -26,7 +26,7 @@ npm install -g @azure/web-pubsub-tunnel-tool
    awps-tunnel run --hub <hub> --endpoint https://<resource-name>.webpubsub.azure.com
    ```
    Add `--upstream http://localhost:3000` to forward to your own server, or enable the **Built-in Echo Server** later from the web view. Use `awps-tunnel bind --hub <hub> --endpoint ...` once if you want to save the settings.
-3. Open the printed web link (defaults to `http://127.0.0.1:4000`) to check status. Use the **Client** tab to start a test WebSocket connection and the **Tunnel** tab to inspect requests/responses flowing through the tunnel.
+3. Open the printed web link to check status. The link contains a one-time access token (`#access_token=...`) that the dashboard needs to connect, so open the exact URL printed in the terminal and keep it private — anyone who obtains it can drive the tunnel's messaging hub. Use the **Client** tab to start a test WebSocket connection and the **Tunnel** tab to inspect requests/responses flowing through the tunnel.
 4. Need a quick upstream? Run the sample:
    ```bash
    cd server/samples/upstream
@@ -44,8 +44,17 @@ npm install -g @azure/web-pubsub-tunnel-tool
 Build and run the published CLI in a container:
 ```bash
 docker build -f tools/awps-tunnel/docker/Dockerfile -t awps-tunnel .
-docker run --rm -p 4000:4000 -e WebPubSubConnectionString="<connection-string>" awps-tunnel run --hub <hub> --webviewHost 0.0.0.0 -u http://host.docker.internal:3000
+docker run --rm -p 127.0.0.1:4000:4000 -e WebPubSubConnectionString="<connection-string>" awps-tunnel run --hub <hub> --webviewHost 0.0.0.0 -u http://host.docker.internal:3000
 ```
+The container prints an `Open webview at: http://localhost:4000/#access_token=...` link. Open that exact link (the access token is required to connect).
+
+When running detached (`docker run -d`), or if you want a stable bookmark, pin the token with `AWPS_TUNNEL_DASHBOARD_TOKEN` instead of using the random per-run token:
+```bash
+docker run --rm -p 127.0.0.1:4000:4000 -e WebPubSubConnectionString="<connection-string>" -e AWPS_TUNNEL_DASHBOARD_TOKEN="<your-token>" awps-tunnel run --hub <hub> --webviewHost 0.0.0.0 -u http://host.docker.internal:3000
+```
+Then browse to `http://localhost:4000/#access_token=<your-token>`.
+
+> The dashboard is protected by a per-process access token, but binding it to a non-loopback interface (`--webviewHost 0.0.0.0`) still exposes the privileged endpoint to your network. Publish the port to loopback only (`-p 127.0.0.1:4000:4000`) unless you specifically need remote access, and keep the `#access_token=...` URL (and any pinned token) private.
 
 ## More info
 - Detailed CLI usage and screenshots: `server/README.md`

--- a/tools/awps-tunnel/client/src/providers/ConnectionBasedDataFether.tsx
+++ b/tools/awps-tunnel/client/src/providers/ConnectionBasedDataFether.tsx
@@ -120,9 +120,31 @@ abstract class ConnectionBasedDataFether implements IDataFetcher {
   }
 }
 
+const DASHBOARD_TOKEN_STORAGE_KEY = "awps-tunnel-dashboard-token";
+
+// The dashboard access token is delivered out of band in the URL fragment
+// (#access_token=...) that the CLI prints. Read it once, keep it in sessionStorage so
+// in-tab refreshes/navigation keep working, and strip it from the visible URL so it is
+// not accidentally shared or bookmarked.
+function getDashboardToken(): string {
+  try {
+    const rawHash = window.location.hash ?? "";
+    const hash = rawHash.startsWith("#") ? rawHash.slice(1) : rawHash;
+    const fromHash = new URLSearchParams(hash).get("access_token");
+    if (fromHash) {
+      window.sessionStorage.setItem(DASHBOARD_TOKEN_STORAGE_KEY, fromHash);
+      window.history.replaceState(null, "", window.location.pathname + window.location.search);
+      return fromHash;
+    }
+    return window.sessionStorage.getItem(DASHBOARD_TOKEN_STORAGE_KEY) ?? "";
+  } catch {
+    return "";
+  }
+}
+
 export class SocketIODataFetcher extends ConnectionBasedDataFether {
   async _createConnection(): Promise<Socket> {
-    return io();
+    return io({ auth: { token: getDashboardToken() } });
   }
   async _startConnection(_: Socket): Promise<void> {
     console.log("SocketIO connection established.");

--- a/tools/awps-tunnel/server/CHANGELOG.md
+++ b/tools/awps-tunnel/server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.0-beta.13] - 2026-08-11
+### Changed
+- Harden local dashboard connection authorization and document secure container usage.
+
 ## [1.0.0-beta.12] - 2026-04-13
 ### Fixed
 - Fix tunnel connection failing to establish on Node.js 20+

--- a/tools/awps-tunnel/server/commander.ts
+++ b/tools/awps-tunnel/server/commander.ts
@@ -11,8 +11,9 @@ import { WebPubSubManagementClient } from "@azure/arm-webpubsub";
 import fs from "fs";
 
 import { Command, program } from "commander";
+import { randomBytes } from "crypto";
 import { AzureCliCredential, ChainedTokenCredential, EnvironmentCredential, ManagedIdentityCredential, AzurePowerShellCredential } from "@azure/identity";
-import { parseUrl, dumpRawRequest, getRawResponse, tryParseInt } from "./util";
+import { parseUrl, dumpRawRequest, getRawResponse, tryParseInt, getDashboardAllowedOrigins } from "./util";
 
 import packageJson from "./package.json";
 const name = packageJson["cli-name"];
@@ -235,6 +236,7 @@ async function loadHubSettings(subscriptionId: string | undefined, resourceGroup
   return { message, eventHandlers, subscriptionId, resourceGroup, resourceName, loaded: true };
 }
 
+// Build the set of browser origins allowed to connect to the local dashboard.
 function createRunCommand(run: Command, dbFile: string, settings: Settings, command: RunCommandLineArgs) {
   if (command.verbose) {
     printer.enableVerboseLogging();
@@ -320,7 +322,30 @@ function createRunCommand(run: Command, dbFile: string, settings: Settings, comm
   const app = express();
   const server = createServer(app);
   printer.status(`Connecting to ${tunnel.endpoint}, hub: ${tunnel.hub}, upstream: ${currentUpstream}`);
-  const dataHub = new DataHub(server, tunnel, upstream, dbFile);
+
+  // Resolve the dashboard (webview) bind host/port up front so the DataHub can be
+  // configured with the matching allowed browser origins.
+  const upstreamPort = tryParseInt(upstream.port) ?? 80;
+  const webviewHost = command.webviewHost ?? settings.WebPubSub.WebviewHost ?? "127.0.0.1";
+  const webviewPortValue = command.webviewPort ?? settings.WebPubSub.WebviewPort ?? process.env.AWPS_TUNNEL_SERVER_PORT;
+  let webviewPort: number | undefined = upstreamPort + 1000;
+  if (webviewPortValue) {
+    webviewPort = tryParseInt(webviewPortValue);
+    if (!webviewPort) {
+      printer.error(`Error: invalid webview port: ${webviewPortValue}`);
+      return;
+    }
+  }
+
+  // Protect dashboard operations with a per-process token delivered in the printed URL,
+  // plus browser origin validation where the bind address permits it.
+  const dashboardToken = process.env.AWPS_TUNNEL_DASHBOARD_TOKEN || randomBytes(24).toString("hex");
+  const dashboardAllowedOrigins = getDashboardAllowedOrigins(webviewHost, webviewPort);
+
+  const dataHub = new DataHub(server, tunnel, upstream, dbFile, {
+    token: dashboardToken,
+    allowedOrigins: dashboardAllowedOrigins,
+  });
   dataHub.ReportStatusChange(ConnectionStatus.Connecting);
 
   reportServiceConfiguration(dataHub, subscription, resourceGroup, new URL(tunnel.endpoint), tunnel.hub);
@@ -359,22 +384,19 @@ function createRunCommand(run: Command, dbFile: string, settings: Settings, comm
       dataHub.ReportStatusChange(ConnectionStatus.Disconnected);
     });
 
-  const upstreamPort = tryParseInt(upstream.port) ?? 80;
   if (!command.noWebview) {
-    const webviewHost = command.webviewHost ?? settings.WebPubSub.WebviewHost ?? "127.0.0.1";
-    const webviewPort = command.webviewPort ?? settings.WebPubSub.WebviewPort ?? process.env.AWPS_TUNNEL_SERVER_PORT;
-    let port: number | undefined = upstreamPort + 1000;
-    if (webviewPort) {
-      port = tryParseInt(webviewPort);
-      if (!port) {
-        printer.error(`Error: invalid webview port: ${port}`);
-        return;
-      }
-    }
     app.use(express.static(path.join(__dirname, "../client/build")));
     server
-      .listen(port, webviewHost, () => {
-        printer.text(`Open webview at: http://${webviewHost}:${port}`);
+      .listen(webviewPort, webviewHost, () => {
+        // A wildcard bind host (e.g. 0.0.0.0) is not browsable; print a loopback host so
+        // the user can open the link directly. Origin is not enforced for wildcard binds,
+        // so any loopback host is accepted by the dashboard.
+        const browseHost = dashboardAllowedOrigins.length === 0 ? "localhost" : webviewHost;
+        const url = `http://${browseHost}:${webviewPort}/#access_token=${dashboardToken}`;
+        printer.text(`Open webview at: ${url}`);
+        printer.status(
+          `The dashboard requires the access token embedded in the URL above. Keep this URL private: anyone who obtains it can control the tunnel's messaging hub.`,
+        );
       })
       .on("error", (err) => {
         printer.error(`Error on starting webview server: ${err}`);

--- a/tools/awps-tunnel/server/dataHub.ts
+++ b/tools/awps-tunnel/server/dataHub.ts
@@ -9,6 +9,16 @@ import { DataRepo } from "./dataRepo";
 import { startUpstreamServer } from "./upstream";
 import { printer } from "./output";
 
+export interface DashboardAuthOptions {
+  // Random per-process token that the dashboard page must present to connect.
+  // It is delivered through the printed webview URL.
+  token: string;
+  // Browser origins allowed to connect. An empty list means the bind host is a
+  // wildcard (e.g. 0.0.0.0) where the browser origin cannot be predetermined, so
+  // origin is not enforced and the token becomes the sole gate.
+  allowedOrigins: string[];
+}
+
 // singleton per hub?
 export class DataHub {
   // make sure only one server is there
@@ -23,8 +33,30 @@ export class DataHub {
   public hub = "";
   private io: Server;
   private repo: DataRepo;
-  constructor(server: http.Server, private tunnel: HttpServerProxy, upstreamUrl: URL, dbFile: string) {
-    const io = (this.io = new Server(server));
+  constructor(server: http.Server, private tunnel: HttpServerProxy, upstreamUrl: URL, dbFile: string, auth: DashboardAuthOptions) {
+    const io = (this.io = new Server(server, {
+      // Validate WebSocket and polling origins before establishing the connection.
+      allowRequest: (req, callback) => {
+        const origin = req.headers.origin;
+        if (origin && auth.allowedOrigins.length > 0 && !auth.allowedOrigins.includes(origin)) {
+          printer.warn(`Rejected dashboard connection from disallowed origin: ${origin}`);
+          callback("origin_not_allowed", false);
+          return;
+        }
+        callback(null, true);
+      },
+    }));
+    // Require the per-process access token as the primary connection gate, including for
+    // non-loopback interfaces where the Origin header can be spoofed or omitted.
+    io.use((socket, next) => {
+      const token = (socket.handshake.auth as { token?: string } | undefined)?.token;
+      if (!auth.token || token !== auth.token) {
+        printer.warn("Rejected dashboard connection with missing or invalid access token.");
+        next(new Error("unauthorized"));
+        return;
+      }
+      next();
+    });
     printer.log("Webview client connecting to get the latest status");
     this.repo = new DataRepo(dbFile);
     this.endpoint = tunnel.endpoint;

--- a/tools/awps-tunnel/server/package.json
+++ b/tools/awps-tunnel/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/web-pubsub-tunnel-tool",
-  "version": "1.0.0-beta.12",
+  "version": "1.0.0-beta.13",
   "description": "A local tool to help tunnel Azure Web PubSub traffic to local web app and provide a vivid view to the end to end workflow.",
   "keywords": [
     "azure",

--- a/tools/awps-tunnel/server/test/dataHubAuth.test.ts
+++ b/tools/awps-tunnel/server/test/dataHubAuth.test.ts
@@ -1,0 +1,155 @@
+import http from "http";
+import { AddressInfo } from "net";
+import { io as ioClient, Socket } from "socket.io-client";
+
+// Replace the sqlite-backed repo so the test does not need the native module.
+// Persistence is not part of the security boundary under test.
+jest.mock("../dataRepo", () => ({
+  DataRepo: jest.fn().mockImplementation(() => ({
+    getAsync: jest.fn().mockResolvedValue([]),
+    insertDataAsync: jest.fn().mockResolvedValue(1),
+    updateDataAsync: jest.fn().mockResolvedValue(undefined),
+    clearDataAsync: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+// Import after the mock is registered.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+import { DataHub, DashboardAuthOptions } from "../dataHub";
+import { getDashboardAllowedOrigins } from "../util";
+
+// Minimal fake tunnel: DataHub only reads endpoint/hub/getLiveTraceUrl at construction
+// and forwards token RPCs to it. None of these need a real Azure Web PubSub connection.
+function createFakeTunnel() {
+  return {
+    endpoint: "https://unit-test.webpubsub.azure.com/",
+    hub: "testhub",
+    getLiveTraceUrl: () => "https://unit-test.webpubsub.azure.com/livetrace",
+    getLiveTraceToken: jest.fn().mockResolvedValue("live-trace-token"),
+    getRestApiToken: jest.fn().mockResolvedValue("rest-api-token"),
+    getClientAccessUrl: jest.fn().mockResolvedValue("wss://unit-test.webpubsub.azure.com/client/hubs/testhub?access_token=xyz"),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+interface Harness {
+  port: number;
+  close: () => Promise<void>;
+}
+
+async function startHub(auth: DashboardAuthOptions): Promise<Harness> {
+  const server = http.createServer();
+  // Constructing DataHub attaches the authenticated Socket.IO server to `server`.
+  new DataHub(server, createFakeTunnel(), new URL("http://localhost:3000"), ":memory:", auth);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const port = (server.address() as AddressInfo).port;
+  return {
+    port,
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      }),
+  };
+}
+
+// Attempt a connection and resolve with the outcome instead of throwing.
+function tryConnect(
+  port: number,
+  opts: { token?: string; origin?: string },
+): Promise<{ connected: boolean; error?: string; socket?: Socket }> {
+  return new Promise((resolve) => {
+    const socket = ioClient(`http://127.0.0.1:${port}`, {
+      reconnection: false,
+      transports: ["polling"],
+      forceNew: true,
+      auth: opts.token !== undefined ? { token: opts.token } : {},
+      extraHeaders: opts.origin ? { Origin: opts.origin } : undefined,
+    });
+    const timer = setTimeout(() => {
+      socket.close();
+      resolve({ connected: false, error: "timeout" });
+    }, 4000);
+    socket.on("connect", () => {
+      clearTimeout(timer);
+      resolve({ connected: true, socket });
+    });
+    socket.on("connect_error", (err) => {
+      clearTimeout(timer);
+      socket.close();
+      resolve({ connected: false, error: err.message });
+    });
+  });
+}
+
+describe("getDashboardAllowedOrigins", () => {
+  it("returns loopback origins for a concrete host", () => {
+    const origins = getDashboardAllowedOrigins("127.0.0.1", 4000);
+    expect(origins).toContain("http://127.0.0.1:4000");
+    expect(origins).toContain("http://localhost:4000");
+  });
+
+  it("returns an empty list (origin not enforced) for wildcard bind hosts", () => {
+    expect(getDashboardAllowedOrigins("0.0.0.0", 4000)).toEqual([]);
+    expect(getDashboardAllowedOrigins("::", 4000)).toEqual([]);
+    expect(getDashboardAllowedOrigins("", 4000)).toEqual([]);
+  });
+});
+
+describe("DataHub dashboard authentication", () => {
+  const TOKEN = "s3cret-access-token";
+  const ORIGIN = "http://127.0.0.1:4000";
+
+  let loopbackHub: Harness;
+
+  beforeAll(async () => {
+    loopbackHub = await startHub({ token: TOKEN, allowedOrigins: [ORIGIN] });
+  });
+
+  afterAll(async () => {
+    await loopbackHub.close();
+  });
+
+  it("rejects a connection with no access token", async () => {
+    const res = await tryConnect(loopbackHub.port, { origin: ORIGIN });
+    expect(res.connected).toBe(false);
+    expect(res.error).toBe("unauthorized");
+  });
+
+  it("rejects a connection with a wrong access token", async () => {
+    const res = await tryConnect(loopbackHub.port, { token: "wrong", origin: ORIGIN });
+    expect(res.connected).toBe(false);
+    expect(res.error).toBe("unauthorized");
+  });
+
+  it("rejects a correct token from a disallowed origin", async () => {
+    const res = await tryConnect(loopbackHub.port, { token: TOKEN, origin: "http://evil.example.com" });
+    expect(res.connected).toBe(false);
+    // allowRequest rejection surfaces as a transport/handshake error, not "unauthorized".
+    expect(res.error).not.toBe(undefined);
+    expect(res.error).not.toBe("unauthorized");
+  });
+
+  it("accepts a correct token from the allowed origin and can invoke a token RPC", async () => {
+    const res = await tryConnect(loopbackHub.port, { token: TOKEN, origin: ORIGIN });
+    expect(res.connected).toBe(true);
+    const socket = res.socket!;
+    const restToken: string = await socket.emitWithAck("getRestApiToken", "https://unit-test.webpubsub.azure.com/api");
+    expect(restToken).toBe("rest-api-token");
+    socket.close();
+  });
+
+  it("does not enforce origin when bound to a wildcard host (token is the sole gate)", async () => {
+    const wildcardHub = await startHub({ token: TOKEN, allowedOrigins: [] });
+    try {
+      const good = await tryConnect(wildcardHub.port, { token: TOKEN, origin: "http://any-origin.example.com" });
+      expect(good.connected).toBe(true);
+      good.socket?.close();
+
+      const bad = await tryConnect(wildcardHub.port, { token: "wrong", origin: "http://any-origin.example.com" });
+      expect(bad.connected).toBe(false);
+      expect(bad.error).toBe("unauthorized");
+    } finally {
+      await wildcardHub.close();
+    }
+  });
+});

--- a/tools/awps-tunnel/server/util.ts
+++ b/tools/awps-tunnel/server/util.ts
@@ -50,3 +50,17 @@ export function parseUrl(url: string, optionalScheme: false | "http" | "https" =
     return undefined;
   }
 }
+
+/**
+ * Build the set of browser origins allowed to connect to the local dashboard.
+ * A wildcard bind host (e.g. 0.0.0.0/::) has no predetermined browser origin, so the
+ * returned list is empty and origin is not enforced (the access token remains the sole gate).
+ */
+export function getDashboardAllowedOrigins(host: string, port: number): string[] {
+  const isWildcard = !host || host === "0.0.0.0" || host === "::" || host === "0000:0000:0000:0000:0000:0000:0000:0000";
+  if (isWildcard) {
+    return [];
+  }
+  const hosts = new Set<string>([host, "127.0.0.1", "localhost", "[::1]"]);
+  return Array.from(hosts, (h) => `http://${h}:${port}`);
+}


### PR DESCRIPTION
## Summary

Improve `awps-tunnel` local dashboard connection safeguards and session initialization.

- Preserve loopback, container, and explicitly configured non-loopback scenarios.
- Update dashboard client initialization and operator guidance.
- Add targeted connection coverage.

## Testing

- Ran the targeted dashboard connection test suite.
- Verified local and container-compatible connection paths.
- Verified operation against an Azure Web PubSub resource using Entra authentication.