### PR TITLE
Harden external scripts in samples

### DIFF
--- a/samples/csharp/chatapp-withstorage/wwwroot/index.html
+++ b/samples/csharp/chatapp-withstorage/wwwroot/index.html
@@ -147,7 +147,9 @@
             </div>
         </div>
     </div>
-    <script src="https://unpkg.com/vue@3/dist/vue.global.js"></script>
+    <script src="https://unpkg.com/vue@3.5.40/dist/vue.global.js"
+        integrity="sha384-xZGBZ8/+QRtMg/kJMPyo4v1otVc8kxjAeiKnaCg+yBlIxeE+11fWfYLJAM6BdWbc"
+        crossorigin="anonymous"></script>
     <script src="./js/app.js"></script>
 </body>
 </html>

--- a/samples/functions/client/index.html
+++ b/samples/functions/client/index.html
@@ -150,8 +150,12 @@
         integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
         crossorigin="anonymous"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/vue@2.5.17/dist/vue.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/axios@0.18.0/dist/axios.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue@2.5.17/dist/vue.min.js"
+        integrity="sha384-9MzmvphdUvLZJKasjD7VqYE4SqffhZDOwDTMyokP2tx+fjBo59ljvrlgUAaaME44"
+        crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/axios@0.18.0/dist/axios.min.js"
+        integrity="sha384-U/+EF1mNzvy5eahP9DeB32duTkAmXrePwnRWtuSh1C/bHHhyR1KZCr/aGZBkctpY"
+        crossorigin="anonymous"></script>
     <script>
         function generateUser() {
             return 'User ' + Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 5);

--- a/samples/functions/csharp/notifications/index.html
+++ b/samples/functions/csharp/notifications/index.html
@@ -126,8 +126,12 @@
             integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
             crossorigin="anonymous"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/vue@2.5.17/dist/vue.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/axios@0.18.0/dist/axios.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue@2.5.17/dist/vue.min.js"
+        integrity="sha384-9MzmvphdUvLZJKasjD7VqYE4SqffhZDOwDTMyokP2tx+fjBo59ljvrlgUAaaME44"
+        crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/axios@0.18.0/dist/axios.min.js"
+        integrity="sha384-U/+EF1mNzvy5eahP9DeB32duTkAmXrePwnRWtuSh1C/bHHhyR1KZCr/aGZBkctpY"
+        crossorigin="anonymous"></script>
     <script>
         const data = {
             websocket: null,

--- a/samples/functions/csharp/simplechat-wpscontext/index.html
+++ b/samples/functions/csharp/simplechat-wpscontext/index.html
@@ -150,8 +150,12 @@
         integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
         crossorigin="anonymous"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/vue@2.5.17/dist/vue.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/axios@0.18.0/dist/axios.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue@2.5.17/dist/vue.min.js"
+        integrity="sha384-9MzmvphdUvLZJKasjD7VqYE4SqffhZDOwDTMyokP2tx+fjBo59ljvrlgUAaaME44"
+        crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/axios@0.18.0/dist/axios.min.js"
+        integrity="sha384-U/+EF1mNzvy5eahP9DeB32duTkAmXrePwnRWtuSh1C/bHHhyR1KZCr/aGZBkctpY"
+        crossorigin="anonymous"></script>
     <script>
         function generateUser() {
             return 'User ' + Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 5);

--- a/samples/functions/csharp/simplechat/index.html
+++ b/samples/functions/csharp/simplechat/index.html
@@ -150,8 +150,12 @@
         integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
         crossorigin="anonymous"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/vue@2.5.17/dist/vue.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/axios@0.18.0/dist/axios.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue@2.5.17/dist/vue.min.js"
+        integrity="sha384-9MzmvphdUvLZJKasjD7VqYE4SqffhZDOwDTMyokP2tx+fjBo59ljvrlgUAaaME44"
+        crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/axios@0.18.0/dist/axios.min.js"
+        integrity="sha384-U/+EF1mNzvy5eahP9DeB32duTkAmXrePwnRWtuSh1C/bHHhyR1KZCr/aGZBkctpY"
+        crossorigin="anonymous"></script>
     <script>
         function generateUser() {
             return 'User ' + Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 5);

--- a/samples/functions/js/iot-hub-data-visualization_v4/index.html
+++ b/samples/functions/js/iot-hub-data-visualization_v4/index.html
@@ -7,7 +7,9 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <script src="https://cdn.jsdelivr.net/npm/chart.js@2.8.0/dist/Chart.min.js" type="text/javascript"
-        charset="utf-8"></script>
+        charset="utf-8"
+        integrity="sha384-QzN1ywg2QLsf72ZkgRHgjkB/cfI4Dqjg6RJYQUqH6Wm8qp/MvmEYn+2NBsLnhLkr"
+        crossorigin="anonymous"></script>
     <script>
         document.addEventListener("DOMContentLoaded", async function (event) {
             const res = await fetch(`/api/negotiate?id=${1}`);

--- a/samples/functions/js/notifications/index.html
+++ b/samples/functions/js/notifications/index.html
@@ -126,8 +126,12 @@
             integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
             crossorigin="anonymous"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/vue@2.5.17/dist/vue.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/axios@0.18.0/dist/axios.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue@2.5.17/dist/vue.min.js"
+        integrity="sha384-9MzmvphdUvLZJKasjD7VqYE4SqffhZDOwDTMyokP2tx+fjBo59ljvrlgUAaaME44"
+        crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/axios@0.18.0/dist/axios.min.js"
+        integrity="sha384-U/+EF1mNzvy5eahP9DeB32duTkAmXrePwnRWtuSh1C/bHHhyR1KZCr/aGZBkctpY"
+        crossorigin="anonymous"></script>
     <script>
         const data = {
             websocket: null,

--- a/samples/functions/js/simplechat-wpscontext/index.html
+++ b/samples/functions/js/simplechat-wpscontext/index.html
@@ -150,8 +150,12 @@
         integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
         crossorigin="anonymous"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/vue@2.5.17/dist/vue.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/axios@0.18.0/dist/axios.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue@2.5.17/dist/vue.min.js"
+        integrity="sha384-9MzmvphdUvLZJKasjD7VqYE4SqffhZDOwDTMyokP2tx+fjBo59ljvrlgUAaaME44"
+        crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/axios@0.18.0/dist/axios.min.js"
+        integrity="sha384-U/+EF1mNzvy5eahP9DeB32duTkAmXrePwnRWtuSh1C/bHHhyR1KZCr/aGZBkctpY"
+        crossorigin="anonymous"></script>
     <script>
         function generateUser() {
             return 'User ' + Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 5);

--- a/samples/functions/js/simplechat/index.html
+++ b/samples/functions/js/simplechat/index.html
@@ -150,8 +150,12 @@
         integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
         crossorigin="anonymous"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/vue@2.5.17/dist/vue.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/axios@0.18.0/dist/axios.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue@2.5.17/dist/vue.min.js"
+        integrity="sha384-9MzmvphdUvLZJKasjD7VqYE4SqffhZDOwDTMyokP2tx+fjBo59ljvrlgUAaaME44"
+        crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/axios@0.18.0/dist/axios.min.js"
+        integrity="sha384-U/+EF1mNzvy5eahP9DeB32duTkAmXrePwnRWtuSh1C/bHHhyR1KZCr/aGZBkctpY"
+        crossorigin="anonymous"></script>
     <script>
         function generateUser() {
             return 'User ' + Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 5);

--- a/samples/javascript/chatapp-microsoft-entra-id/public/fancy.html
+++ b/samples/javascript/chatapp-microsoft-entra-id/public/fancy.html
@@ -146,7 +146,9 @@
         integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
         crossorigin="anonymous"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/vue@2.5.17/dist/vue.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue@2.5.17/dist/vue.min.js"
+        integrity="sha384-9MzmvphdUvLZJKasjD7VqYE4SqffhZDOwDTMyokP2tx+fjBo59ljvrlgUAaaME44"
+        crossorigin="anonymous"></script>
     <script>
         const data = {
             client: {

--- a/samples/javascript/chatapp-reliable-subprotocol/public/index.html
+++ b/samples/javascript/chatapp-reliable-subprotocol/public/index.html
@@ -152,7 +152,9 @@
         integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
         crossorigin="anonymous"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/vue@2.5.17/dist/vue.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue@2.5.17/dist/vue.min.js"
+        integrity="sha384-9MzmvphdUvLZJKasjD7VqYE4SqffhZDOwDTMyokP2tx+fjBo59ljvrlgUAaaME44"
+        crossorigin="anonymous"></script>
     <script src="client.js"></script>
     <script>
         const group = "reliableChat";

--- a/samples/javascript/chatapp/nativeapi/public/fancy.html
+++ b/samples/javascript/chatapp/nativeapi/public/fancy.html
@@ -155,7 +155,9 @@
         integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
         crossorigin="anonymous"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/vue@2.5.17/dist/vue.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue@2.5.17/dist/vue.min.js"
+        integrity="sha384-9MzmvphdUvLZJKasjD7VqYE4SqffhZDOwDTMyokP2tx+fjBo59ljvrlgUAaaME44"
+        crossorigin="anonymous"></script>
     <script>
         const data = {
             client: {

--- a/samples/javascript/codestream/public/index.html
+++ b/samples/javascript/codestream/public/index.html
@@ -10,7 +10,9 @@
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css"
           integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
     <link data-name="vs/editor/editor.main" rel="stylesheet"
-          href="https://microsoft.github.io/monaco-editor/node_modules/monaco-editor/min/vs/editor/editor.main.css">
+          href="https://cdn.jsdelivr.net/npm/monaco-editor@0.45.0/min/vs/editor/editor.main.css"
+          integrity="sha384-wEPX4DLcb8X/8D6XpJSbLB+Kkbta6MLPDGjmGaPjX8v1tLBRY4u2NkNqbGrQH6K9"
+          crossorigin="anonymous">
     <title>Code Stream</title>
     <style>
         #monacoeditor {
@@ -49,9 +51,15 @@
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js"
     integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6"
     crossorigin="anonymous"></script>
-  <script src="https://microsoft.github.io/monaco-editor/node_modules/monaco-editor/min/vs/loader.js"></script>
-  <script src="https://microsoft.github.io/monaco-editor/node_modules/monaco-editor/min/vs/editor/editor.main.nls.js"></script>
-  <script src="https://microsoft.github.io/monaco-editor/node_modules/monaco-editor/min/vs/editor/editor.main.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.45.0/min/vs/loader.js"
+    integrity="sha384-SF/kPhqG3NMxqsYAbQqHkdF53WQx8yTkY0Ys+M+ayeC20QNujPyyxIuUEdEf0eG/"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.45.0/min/vs/editor/editor.main.nls.js"
+    integrity="sha384-cix2RIie30iUZhZyK1eVQ62JWBkFq0P/HZxXZd6S1sW4qFpVXX+zPtceiItULQr4"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.45.0/min/vs/editor/editor.main.js"
+    integrity="sha384-os9TjZrRjoQTEvsOjrxLJbCM+NLu690WDBQ3xbbca3TCO5tH7sXLweujZYcsk27F"
+    crossorigin="anonymous"></script>
   <script>
     //https://unpkg.com/browse/monaco-editor@0.8.3/min/vs/editor/
     function createEditor(element, readOnly) {

--- a/samples/javascript/videoshare/public/index.html
+++ b/samples/javascript/videoshare/public/index.html
@@ -98,7 +98,9 @@
     integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
     crossorigin="anonymous"></script>
 
-  <script src="https://cdn.jsdelivr.net/npm/vue@2.5.17/dist/vue.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vue@2.5.17/dist/vue.min.js"
+    integrity="sha384-9MzmvphdUvLZJKasjD7VqYE4SqffhZDOwDTMyokP2tx+fjBo59ljvrlgUAaaME44"
+    crossorigin="anonymous"></script>
   <script src="video.js"></script>
   <script>
     const data = {
@@ -172,7 +174,7 @@
               log(`You're in sharing, auto deny new call from ${sender}`)
               this.deny(client, sender, receiver)
             } else {
-              document.getElementById('exampleModalLabel').innerHTML = `Do you Accept call request from user ${sender}?`
+              document.getElementById('exampleModalLabel').textContent = `Do you Accept call request from user ${sender}?`
               $('#acceptDialog').modal('toggle');
               document.getElementById('acceptButton').onclick = () => this.accept(client, sender, receiver);
               document.getElementById('denyButton').onclick = () => this.deny(client, sender, receiver);

--- a/samples/python/chatapp-microsoft-entra-id/public/fancy.html
+++ b/samples/python/chatapp-microsoft-entra-id/public/fancy.html
@@ -145,7 +145,9 @@
         integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
         crossorigin="anonymous"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/vue@2.5.17/dist/vue.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue@2.5.17/dist/vue.min.js"
+        integrity="sha384-9MzmvphdUvLZJKasjD7VqYE4SqffhZDOwDTMyokP2tx+fjBo59ljvrlgUAaaME44"
+        crossorigin="anonymous"></script>
     <script>
         const data = {
             client: {

--- a/samples/python/chatapp/public/fancy.html
+++ b/samples/python/chatapp/public/fancy.html
@@ -145,7 +145,9 @@
         integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
         crossorigin="anonymous"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/vue@2.5.17/dist/vue.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue@2.5.17/dist/vue.min.js"
+        integrity="sha384-9MzmvphdUvLZJKasjD7VqYE4SqffhZDOwDTMyokP2tx+fjBo59ljvrlgUAaaME44"
+        crossorigin="anonymous"></script>
     <script>
         const data = {
             client: {

--- a/sdk/webpubsub-socketio-extension/examples/chat-serverless-dotnet/public/index.html
+++ b/sdk/webpubsub-socketio-extension/examples/chat-serverless-dotnet/public/index.html
@@ -159,7 +159,9 @@
         </div>
     </div>
 
-    <script src="https://cdn.socket.io/4.7.5/socket.io.min.js"></script>
+    <script src="https://cdn.socket.io/4.7.5/socket.io.min.js"
+        integrity="sha384-2huaZvOR9iDzHqslqwpR87isEmrfxqyWOF7hr7BY6KG0+hVKLoEXMPUJw3ynWuhO"
+        crossorigin="anonymous"></script>
     <script>
         let socket;
         let realUserName;

--- a/sdk/webpubsub-socketio-extension/examples/chat-serverless-javascript/src/public/index.html
+++ b/sdk/webpubsub-socketio-extension/examples/chat-serverless-javascript/src/public/index.html
@@ -9,7 +9,9 @@
     </div>
     <div id="chatMessages" class="chat-messages"></div>
 </div>
-  <script src="https://cdn.socket.io/4.7.5/socket.io.min.js"></script>
+  <script src="https://cdn.socket.io/4.7.5/socket.io.min.js"
+    integrity="sha384-2huaZvOR9iDzHqslqwpR87isEmrfxqyWOF7hr7BY6KG0+hVKLoEXMPUJw3ynWuhO"
+    crossorigin="anonymous"></script>
   <script>
     function appendMessage(message) {
       const chatMessages = document.getElementById('chatMessages');

--- a/sdk/webpubsub-socketio-extension/examples/chat-serverless-typescript/src/public/index.html
+++ b/sdk/webpubsub-socketio-extension/examples/chat-serverless-typescript/src/public/index.html
@@ -159,7 +159,9 @@
         </div>
     </div>
 
-    <script src="https://cdn.socket.io/4.7.5/socket.io.min.js"></script>
+    <script src="https://cdn.socket.io/4.7.5/socket.io.min.js"
+        integrity="sha384-2huaZvOR9iDzHqslqwpR87isEmrfxqyWOF7hr7BY6KG0+hVKLoEXMPUJw3ynWuhO"
+        crossorigin="anonymous"></script>
     <script>
         let socket;
         let realUserName;

--- a/sdk/webpubsub-socketio-extension/examples/codestream/public/index.html
+++ b/sdk/webpubsub-socketio-extension/examples/codestream/public/index.html
@@ -10,7 +10,9 @@
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css"
           integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
     <link data-name="vs/editor/editor.main" rel="stylesheet"
-          href="https://microsoft.github.io/monaco-editor/node_modules/monaco-editor/min/vs/editor/editor.main.css">
+          href="https://cdn.jsdelivr.net/npm/monaco-editor@0.45.0/min/vs/editor/editor.main.css"
+          integrity="sha384-wEPX4DLcb8X/8D6XpJSbLB+Kkbta6MLPDGjmGaPjX8v1tLBRY4u2NkNqbGrQH6K9"
+          crossorigin="anonymous">
     <title>Code Stream</title>
     <style>
         #monacoeditor {
@@ -52,9 +54,15 @@
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js"
     integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6"
     crossorigin="anonymous"></script>
-  <script src="https://microsoft.github.io/monaco-editor/node_modules/monaco-editor/min/vs/loader.js"></script>
-  <script src="https://microsoft.github.io/monaco-editor/node_modules/monaco-editor/min/vs/editor/editor.main.nls.js"></script>
-  <script src="https://microsoft.github.io/monaco-editor/node_modules/monaco-editor/min/vs/editor/editor.main.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.45.0/min/vs/loader.js"
+    integrity="sha384-SF/kPhqG3NMxqsYAbQqHkdF53WQx8yTkY0Ys+M+ayeC20QNujPyyxIuUEdEf0eG/"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.45.0/min/vs/editor/editor.main.nls.js"
+    integrity="sha384-cix2RIie30iUZhZyK1eVQ62JWBkFq0P/HZxXZd6S1sW4qFpVXX+zPtceiItULQr4"
+    crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.45.0/min/vs/editor/editor.main.js"
+    integrity="sha384-os9TjZrRjoQTEvsOjrxLJbCM+NLu690WDBQ3xbbca3TCO5tH7sXLweujZYcsk27F"
+    crossorigin="anonymous"></script>
   
   <script src="./client.js"> </script>
 </body>

--- a/sdk/webpubsub-socketio-extension/examples/publish-only-python/index.html
+++ b/sdk/webpubsub-socketio-extension/examples/publish-only-python/index.html
@@ -66,7 +66,9 @@
         <div id="nasdaqIndex" class="index-value">14,000.00</div>
     </div>
 
-    <script src="https://cdn.socket.io/4.7.5/socket.io.min.js"></script>
+    <script src="https://cdn.socket.io/4.7.5/socket.io.min.js"
+        integrity="sha384-2huaZvOR9iDzHqslqwpR87isEmrfxqyWOF7hr7BY6KG0+hVKLoEXMPUJw3ynWuhO"
+        crossorigin="anonymous"></script>
     <script>
         function updateIndexCore(newIndex) {
             newIndex = parseFloat(newIndex);


### PR DESCRIPTION
## Summary
- fixes a DOM XSS in the JavaScript video-sharing sample by rendering the remote sender name as text
- replaces mutable, broken Monaco Editor URLs with exact versioned assets
- adds verified SRI and CORS metadata to every external script used by tracked HTML under `samples/` and `sdk/`
- covers Vue, Axios, Socket.IO, Monaco Editor, and Chart.js references without changing application APIs or upgrading legacy sample frameworks

## Validation
- parsed all 64 tracked HTML files under `samples/` and `sdk/`
- downloaded and cryptographically verified all 86 external script references (22 unique assets) against their declared integrity hashes
- confirmed there are no remaining external scripts without SRI
- reviewed both CodeStream copies for matching, compatible Monaco changes