### PR TITLE
Fix Yarn PATH in OneBranch release pipeline

### DIFF
--- a/.pipelines/templates/stages/release-package.yml
+++ b/.pipelines/templates/stages/release-package.yml
@@ -98,6 +98,7 @@ stages:
                   --output '$(Agent.TempDirectory)/yarn-1.22.22.tgz'
                 tar -xzf '$(Agent.TempDirectory)/yarn-1.22.22.tgz' --strip-components=1 -C "$yarn_root"
                 echo "##vso[task.prependpath]$yarn_root/bin"
+                export PATH="$yarn_root/bin:$PATH"
                 yarn config set registry "$feed_registry"
                 find . -name yarn.lock -type f -exec sed -Ei \
                   "s#https://registry\\.(npmjs\\.org|yarnpkg\\.com)/#${feed_registry}#g" {} +


### PR DESCRIPTION
## Summary

Make the downloaded Yarn binary available within the installation task before invoking `yarn config`.

Azure Pipelines processes `##vso[task.prependpath]` for subsequent tasks only. The installation task therefore failed with `yarn: command not found` immediately after downloading and extracting Yarn. Exporting the same path fixes the current task while retaining `prependpath` for later build steps.

## Validation

- YAML parses successfully.
- `git diff --check` passes.