### PR TITLE
Fix Yarn PATH in npm release pipeline

### DIFF
--- a/.pipelines/templates/stages/release-package.yml
+++ b/.pipelines/templates/stages/release-package.yml
@@ -97,6 +97,7 @@ stages:
                   "${feed_registry}yarn/-/yarn-1.22.22.tgz" \
                   --output '$(Agent.TempDirectory)/yarn-1.22.22.tgz'
                 tar -xzf '$(Agent.TempDirectory)/yarn-1.22.22.tgz' --strip-components=1 -C "$yarn_root"
+                export PATH="$yarn_root/bin:$PATH"
                 echo "##vso[task.prependpath]$yarn_root/bin"
                 yarn config set registry "$feed_registry"
                 find . -name yarn.lock -type f -exec sed -Ei \


### PR DESCRIPTION
## Summary
- add the extracted Yarn binary directory to the current Bash process PATH
- retain the Azure Pipelines prepend-path command for subsequent build and pack tasks

## Root cause
	ask.prependpath updates PATH for later tasks only. The Yarn setup task invoked yarn config immediately after extraction, before the current shell PATH included the Yarn binary directory.

## Validation
- reproduced from Azure DevOps build 176223396 (yarn: command not found inside the Yarn setup task)
- YAML parsing completed successfully
- language-server diagnostics are clean
- Oracle review passed with no blockers
