### PR TITLE
Group routine Dependabot updates by ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
       day: monday
     groups:
       actions-minor-patch:
+        applies-to: version-updates
         patterns:
           - "*"
         update-types:
@@ -29,6 +30,7 @@ updates:
       semver-patch-days: 3
     groups:
       npm-minor-patch:
+        applies-to: version-updates
         patterns:
           - "*"
         update-types:
@@ -50,6 +52,7 @@ updates:
       semver-patch-days: 3
     groups:
       pip-minor-patch:
+        applies-to: version-updates
         patterns:
           - "*"
         update-types:
@@ -71,6 +74,7 @@ updates:
       semver-patch-days: 3
     groups:
       maven-minor-patch:
+        applies-to: version-updates
         patterns:
           - "*"
         update-types:
@@ -88,6 +92,7 @@ updates:
     open-pull-requests-limit: 5
     groups:
       gomod-minor-patch:
+        applies-to: version-updates
         patterns:
           - "*"
         update-types:
@@ -109,6 +114,7 @@ updates:
       semver-patch-days: 3
     groups:
       nuget-minor-patch:
+        applies-to: version-updates
         patterns:
           - "*"
         update-types:
@@ -126,6 +132,7 @@ updates:
     open-pull-requests-limit: 3
     groups:
       docker-minor-patch:
+        applies-to: version-updates
         patterns:
           - "*"
         update-types:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,12 @@ updates:
       interval: weekly
       day: monday
     groups:
-      actions:
+      actions-minor-patch:
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch
     commit-message:
       prefix: deps
 
@@ -25,10 +28,12 @@ updates:
       semver-minor-days: 7
       semver-patch-days: 3
     groups:
-      shared-dependencies:
+      npm-minor-patch:
         patterns:
           - "*"
-        group-by: dependency-name
+        update-types:
+          - minor
+          - patch
     commit-message:
       prefix: deps
 
@@ -44,10 +49,12 @@ updates:
       semver-minor-days: 7
       semver-patch-days: 3
     groups:
-      shared-dependencies:
+      pip-minor-patch:
         patterns:
           - "*"
-        group-by: dependency-name
+        update-types:
+          - minor
+          - patch
     commit-message:
       prefix: deps
 
@@ -63,10 +70,12 @@ updates:
       semver-minor-days: 7
       semver-patch-days: 3
     groups:
-      shared-dependencies:
+      maven-minor-patch:
         patterns:
           - "*"
-        group-by: dependency-name
+        update-types:
+          - minor
+          - patch
     commit-message:
       prefix: deps
 
@@ -78,10 +87,12 @@ updates:
       day: monday
     open-pull-requests-limit: 5
     groups:
-      shared-dependencies:
+      gomod-minor-patch:
         patterns:
           - "*"
-        group-by: dependency-name
+        update-types:
+          - minor
+          - patch
     commit-message:
       prefix: deps
 
@@ -97,10 +108,12 @@ updates:
       semver-minor-days: 7
       semver-patch-days: 3
     groups:
-      shared-dependencies:
+      nuget-minor-patch:
         patterns:
           - "*"
-        group-by: dependency-name
+        update-types:
+          - minor
+          - patch
     commit-message:
       prefix: deps
 
@@ -112,9 +125,11 @@ updates:
       day: monday
     open-pull-requests-limit: 3
     groups:
-      container-images:
+      docker-minor-patch:
         patterns:
           - "*"
-        group-by: dependency-name
+        update-types:
+          - minor
+          - patch
     commit-message:
       prefix: deps


### PR DESCRIPTION
## Summary
- batch routine minor and patch updates into one pull request per ecosystem
- keep major updates separate for focused compatibility review
- keep Dependabot security updates separate so urgent fixes remain independently visible

## Expected effect
The current configuration groups by dependency name, which still creates one PR for each dependency. This change groups eligible updates across all configured directories for npm, pip, Maven, Go modules, NuGet, Docker, and GitHub Actions. Weekly update volume should fall to at most one routine minor/patch PR per ecosystem, plus any major or security PRs.

Existing open Dependabot PRs may be superseded when Dependabot next evaluates the merged configuration. Strict branch protection remains unchanged.