### PR TITLE
deps: group major updates outside sdk/ and tools/

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,22 @@
+# Dependabot version-update policy for this repository.
+#
+# Grouping is split by risk of the consuming code, not by package:
+#
+#   * sdk/ and tools/ ship or back product artifacts, so a breaking
+#     major update there must be reviewed on its own. Those directories
+#     group minor/patch updates only; majors stay as individual PRs.
+#
+#   * Everywhere else (samples/, tests/, website/, docs/, eng/,
+#     experimental/, protocols/ and the repo root) is demo, test or
+#     site code. A broken major there is cheap to fix, so majors are
+#     grouped into a single PR per ecosystem to cut review noise.
+#
+# Dependabot does not allow two update blocks for the same ecosystem to
+# cover overlapping directories, so the directory list is enumerated
+# explicitly instead of using "**/*". When a new top-level directory is
+# added to the repo, add it to the low-risk list of each ecosystem below
+# (or to the sdk/tools block if it ships product code).
+
 version: 2
 
 updates:
@@ -14,12 +33,33 @@ updates:
         update-types:
           - minor
           - patch
+      actions-major:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - major
     commit-message:
       prefix: deps
 
+  # npm - low-risk locations: majors are grouped.
   - package-ecosystem: npm
     directories:
-      - "**/*"
+      - "/"
+      - "/docs"
+      - "/docs/**/*"
+      - "/eng"
+      - "/eng/**/*"
+      - "/experimental"
+      - "/experimental/**/*"
+      - "/protocols"
+      - "/protocols/**/*"
+      - "/samples"
+      - "/samples/**/*"
+      - "/tests"
+      - "/tests/**/*"
+      - "/website"
+      - "/website/**/*"
     schedule:
       interval: weekly
       day: monday
@@ -36,12 +76,59 @@ updates:
         update-types:
           - minor
           - patch
+      npm-major:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - major
     commit-message:
       prefix: deps
 
+  # npm - sdk/ and tools/: majors stay as individual PRs.
+  - package-ecosystem: npm
+    directories:
+      - "/sdk"
+      - "/sdk/**/*"
+      - "/tools"
+      - "/tools/**/*"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    cooldown:
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      npm-sdk-tools-minor-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: deps
+
+  # pip - low-risk locations: majors are grouped.
   - package-ecosystem: pip
     directories:
-      - "**/*"
+      - "/"
+      - "/docs"
+      - "/docs/**/*"
+      - "/eng"
+      - "/eng/**/*"
+      - "/experimental"
+      - "/experimental/**/*"
+      - "/protocols"
+      - "/protocols/**/*"
+      - "/samples"
+      - "/samples/**/*"
+      - "/tests"
+      - "/tests/**/*"
+      - "/website"
+      - "/website/**/*"
     schedule:
       interval: weekly
       day: monday
@@ -58,12 +145,59 @@ updates:
         update-types:
           - minor
           - patch
+      pip-major:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - major
     commit-message:
       prefix: deps
 
+  # pip - sdk/ and tools/: majors stay as individual PRs.
+  - package-ecosystem: pip
+    directories:
+      - "/sdk"
+      - "/sdk/**/*"
+      - "/tools"
+      - "/tools/**/*"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    cooldown:
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      pip-sdk-tools-minor-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: deps
+
+  # maven - low-risk locations: majors are grouped.
   - package-ecosystem: maven
     directories:
-      - "**/*"
+      - "/"
+      - "/docs"
+      - "/docs/**/*"
+      - "/eng"
+      - "/eng/**/*"
+      - "/experimental"
+      - "/experimental/**/*"
+      - "/protocols"
+      - "/protocols/**/*"
+      - "/samples"
+      - "/samples/**/*"
+      - "/tests"
+      - "/tests/**/*"
+      - "/website"
+      - "/website/**/*"
     schedule:
       interval: weekly
       day: monday
@@ -80,12 +214,59 @@ updates:
         update-types:
           - minor
           - patch
+      maven-major:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - major
     commit-message:
       prefix: deps
 
+  # maven - sdk/ and tools/: majors stay as individual PRs.
+  - package-ecosystem: maven
+    directories:
+      - "/sdk"
+      - "/sdk/**/*"
+      - "/tools"
+      - "/tools/**/*"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    cooldown:
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      maven-sdk-tools-minor-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: deps
+
+  # gomod - low-risk locations: majors are grouped.
   - package-ecosystem: gomod
     directories:
-      - "**/*"
+      - "/"
+      - "/docs"
+      - "/docs/**/*"
+      - "/eng"
+      - "/eng/**/*"
+      - "/experimental"
+      - "/experimental/**/*"
+      - "/protocols"
+      - "/protocols/**/*"
+      - "/samples"
+      - "/samples/**/*"
+      - "/tests"
+      - "/tests/**/*"
+      - "/website"
+      - "/website/**/*"
     schedule:
       interval: weekly
       day: monday
@@ -98,12 +279,55 @@ updates:
         update-types:
           - minor
           - patch
+      gomod-major:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - major
     commit-message:
       prefix: deps
 
+  # gomod - sdk/ and tools/: majors stay as individual PRs.
+  - package-ecosystem: gomod
+    directories:
+      - "/sdk"
+      - "/sdk/**/*"
+      - "/tools"
+      - "/tools/**/*"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      gomod-sdk-tools-minor-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: deps
+
+  # nuget - low-risk locations: majors are grouped.
   - package-ecosystem: nuget
     directories:
-      - "**/*"
+      - "/"
+      - "/docs"
+      - "/docs/**/*"
+      - "/eng"
+      - "/eng/**/*"
+      - "/experimental"
+      - "/experimental/**/*"
+      - "/protocols"
+      - "/protocols/**/*"
+      - "/samples"
+      - "/samples/**/*"
+      - "/tests"
+      - "/tests/**/*"
+      - "/website"
+      - "/website/**/*"
     schedule:
       interval: weekly
       day: monday
@@ -120,18 +344,93 @@ updates:
         update-types:
           - minor
           - patch
+      nuget-major:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - major
     commit-message:
       prefix: deps
 
+  # nuget - sdk/ and tools/: majors stay as individual PRs.
+  - package-ecosystem: nuget
+    directories:
+      - "/sdk"
+      - "/sdk/**/*"
+      - "/tools"
+      - "/tools/**/*"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    cooldown:
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      nuget-sdk-tools-minor-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: deps
+
+  # docker - low-risk locations: majors are grouped.
   - package-ecosystem: docker
     directories:
-      - "**/*"
+      - "/"
+      - "/docs"
+      - "/docs/**/*"
+      - "/eng"
+      - "/eng/**/*"
+      - "/experimental"
+      - "/experimental/**/*"
+      - "/protocols"
+      - "/protocols/**/*"
+      - "/samples"
+      - "/samples/**/*"
+      - "/tests"
+      - "/tests/**/*"
+      - "/website"
+      - "/website/**/*"
     schedule:
       interval: weekly
       day: monday
     open-pull-requests-limit: 3
     groups:
       docker-minor-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+      docker-major:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - major
+    commit-message:
+      prefix: deps
+
+  # docker - sdk/ and tools/: majors stay as individual PRs.
+  - package-ecosystem: docker
+    directories:
+      - "/sdk"
+      - "/sdk/**/*"
+      - "/tools"
+      - "/tools/**/*"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    groups:
+      docker-sdk-tools-minor-patch:
         applies-to: version-updates
         patterns:
           - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -223,31 +223,10 @@ updates:
     commit-message:
       prefix: deps
 
-  # maven - sdk/ and tools/: majors stay as individual PRs.
-  - package-ecosystem: maven
-    directories:
-      - "/sdk"
-      - "/sdk/**/*"
-      - "/tools"
-      - "/tools/**/*"
-    schedule:
-      interval: weekly
-      day: monday
-    open-pull-requests-limit: 5
-    cooldown:
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 3
-    groups:
-      maven-sdk-tools-minor-patch:
-        applies-to: version-updates
-        patterns:
-          - "*"
-        update-types:
-          - minor
-          - patch
-    commit-message:
-      prefix: deps
+  # maven has no manifests under sdk/ or tools/, so there is no block for
+  # them: a block whose directories contain no manifest at all fails with
+  # DependencyFileNotFound. Add one alongside the npm/pip/nuget/docker
+  # sdk-tools blocks below if a Maven project is ever added there.
 
   # gomod - low-risk locations: majors are grouped.
   - package-ecosystem: gomod
@@ -288,27 +267,8 @@ updates:
     commit-message:
       prefix: deps
 
-  # gomod - sdk/ and tools/: majors stay as individual PRs.
-  - package-ecosystem: gomod
-    directories:
-      - "/sdk"
-      - "/sdk/**/*"
-      - "/tools"
-      - "/tools/**/*"
-    schedule:
-      interval: weekly
-      day: monday
-    open-pull-requests-limit: 5
-    groups:
-      gomod-sdk-tools-minor-patch:
-        applies-to: version-updates
-        patterns:
-          - "*"
-        update-types:
-          - minor
-          - patch
-    commit-message:
-      prefix: deps
+  # gomod has no manifests under sdk/ or tools/, so there is no block for
+  # them, for the same reason as maven above.
 
   # nuget - low-risk locations: majors are grouped.
   - package-ecosystem: nuget


### PR DESCRIPTION
## What

Dependabot only groups **minor and patch** updates today, so every **major** bump opens its own PR anywhere in the repo. Most manifests here belong to samples, tests and the website, where a broken major is cheap to fix — so those individual PRs are mostly review noise.

This splits each ecosystem into two update blocks:

| Scope | minor / patch | major |
| --- | --- | --- |
| `sdk/`, `tools/` | grouped | **individual PRs** (unchanged) |
| everywhere else | grouped | **grouped** (new) |

`sdk/` and `tools/` back shipped/consumed artifacts, so each breaking change there still gets its own PR to review.

Majors go in their own group (`<eco>-major`) rather than being merged into the existing minor/patch group, so a breaking major never blocks routine minor/patch updates from merging.

## Why `**/*` had to go

Dependabot does not allow two blocks of the same ecosystem to cover overlapping directories:

> If you need to use more than one block in the configuration file to define updates for a single target branch of an ecosystem, you must ensure that all values are unique and there is no overlap in directories defined.

So `directories: ["**/*"]` is replaced by an explicit list. Each top-level directory is listed **both bare and as `/**/*`**, and the repo root `/` is listed explicitly, so nothing that is updated today is dropped.

## Verification

Rather than guessing at the glob semantics, I reproduced Dependabot's actual directory resolution — Ruby `Dir.glob` with `File::FNM_DOTMATCH`, from [`updater/lib/dependabot/file_fetcher_command.rb#L210-L221`](https://github.com/dependabot/dependabot-core/blob/main/updater/lib/dependabot/file_fetcher_command.rb#L210-L221) — and ran it against this repo:

```
=== resolved directories (exact Dependabot expansion) ===
  github-actions  low-risk   dirs=1     with_manifests=n/a  majors_grouped=true
  npm             low-risk   dirs=487   with_manifests=41   majors_grouped=true
  npm             sdk+tools  dirs=150   with_manifests=23   majors_grouped=false
  pip             low-risk   dirs=487   with_manifests=10   majors_grouped=true
  pip             sdk+tools  dirs=150   with_manifests=1    majors_grouped=false
  maven           low-risk   dirs=487   with_manifests=8    majors_grouped=true
  gomod           low-risk   dirs=487   with_manifests=3    majors_grouped=true
  nuget           low-risk   dirs=487   with_manifests=27   majors_grouped=true
  nuget           sdk+tools  dirs=150   with_manifests=7    majors_grouped=false
  docker          low-risk   dirs=487   with_manifests=1    majors_grouped=true
  docker          sdk+tools  dirs=150   with_manifests=2    majors_grouped=false

=== old '**/*' vs new, per ecosystem ===
  npm      old=64   new=64   lost=0   gained=0
  pip      old=11   new=11   lost=0   gained=0
  maven    old=8    new=8    lost=0   gained=0
  gomod    old=3    new=3    lost=0   gained=0
  nuget    old=34   new=34   lost=0   gained=0
  docker   old=3    new=3    lost=0   gained=0
```

- **No coverage regression** — `lost=0` for every ecosystem; all 123 manifest directories `**/*` reached are still reached.
- **No overlap** — no directory is matched by two blocks of the same ecosystem.
- All group identifiers are unique, and the YAML parses.

`cooldown`, `open-pull-requests-limit`, the weekly Monday schedule and `commit-message.prefix: deps` are preserved per ecosystem.

## One bug this caught

My first attempt also added `sdk/`+`tools/` blocks for **maven** and **gomod**. The run above showed both resolved 150 directories but `with_manifests=0`, because there is no Maven or Go project under `sdk/` or `tools/`.

That would have failed on every scheduled run: `list_files_in_directory` compacts away every directory that raises `DependencyFileNotFound` ([L246](https://github.com/dependabot/dependabot-core/blob/main/updater/lib/dependabot/file_fetcher_command.rb#L246)), leaving an empty file list, which then raises `DependencyFileNotFound` for the whole block ([L199-L203](https://github.com/dependabot/dependabot-core/blob/main/updater/lib/dependabot/file_fetcher_command.rb#L199-L203)).

Both blocks were dropped in the second commit, with a comment noting when to add them back.