### PR TITLE
fix(chat-demo): pin python_server requirements so CI tests what we ship

### DIFF
--- a/samples/ai/chat-demo/python_server/requirements.txt
+++ b/samples/ai/chat-demo/python_server/requirements.txt
@@ -1,13 +1,19 @@
+############################################################
+# Runtime & test dependencies (fully pinned)
+# Keep in sync with ../requirements.txt, which is what App
+# Service deploys. Pinning keeps CI testing the versions we
+# actually ship; upgrades arrive as reviewable Dependabot PRs.
+############################################################
 Flask[async]==3.1.3
 flask-sock==0.7.0
-openai>=3.0.0
-websockets>=17.0.1
-flask-cors>=6.0.5
-azure-storage-blob>=12.30.0
-azure-messaging-webpubsubservice>=1.3.0
-azure-identity>=1.25.3
-asgiref>=3.12.1
-python-dotenv>=1.2.3
-azure-data-tables>=12.7.0
-pytest>=9.1.1
-pytest-asyncio>=1.4.0
+openai==2.50.0
+websockets==17.0.1
+flask-cors==6.0.5
+azure-storage-blob==12.30.0
+azure-messaging-webpubsubservice==1.3.0
+azure-identity==1.25.3
+asgiref==3.12.1
+python-dotenv==1.2.3
+azure-data-tables==12.7.0
+pytest==9.1.1
+pytest-asyncio==1.4.0

--- a/samples/ai/chat-demo/requirements.txt
+++ b/samples/ai/chat-demo/requirements.txt
@@ -1,7 +1,7 @@
 ############################################################
 # Runtime & test dependencies (fully pinned)
-# Snapshot date: 2025-10-13
-# To update: bump desired lines & reinstall
+# This is the file App Service deploys (azure.yaml project: .).
+# Keep in sync with python_server/requirements.txt.
 ############################################################
 Flask[async]==3.1.3
 flask-sock==0.7.0


### PR DESCRIPTION
## Problem

`samples/ai/chat-demo/requirements.txt` is labelled **"fully pinned"** and is the file App Service actually deploys (`azure.yaml` sets `project: .`). But CI installs it and *then* installs `requirements-dev.txt`, whose first line is `-r python_server/requirements.txt`. That file used `>=` floors, and `openai>=3.0.0` does **not** accept the pinned `openai==2.50.0` — so the second install silently upgraded openai across a major version.

Reproduced in `python:3.11-slim` (the version `chat-demo-tests.yml` uses), running exactly what CI runs:

```
=== STEP 1: pip install -r requirements.txt  (the "fully pinned" file) ===
  openai      -> 2.50.0
=== STEP 2: pip install -r requirements-dev.txt  (pulls in python_server floors) ===
  openai      -> 3.2.0      <-- pin silently overridden
```

So **CI has been validating openai 3.2.0 while App Service deploys 2.50.0** — a major-version dev/prod skew with no commit, no diff and no review behind it. Neither version is covered by the other's tests.

### How it drifted

`openai` was bumped to `>=3.0.0` in #972 (`python_server/requirements.txt`) while `requirements.txt` stayed at `==2.50.0`. Dependabot treats the two files as independent targets, so nothing kept them aligned.

## Fix

Pin all 13 deps in `python_server/requirements.txt` to match the deployed file. openai was the **only** real divergence — the other 12 pins already satisfied their floors, which is why only openai moved in the repro above.

openai stays at **2.50.0**, the version that actually ships. Adopting openai 3.x is a genuine major upgrade and should arrive as its own reviewable Dependabot PR rather than riding along in a "pin the deps" change.

## Why this also stops the drift recurring

A `>=` requirement update carries no resolved version, so it fails the `update-types` check in Dependabot's group matcher and escapes grouping into individual PRs:

```ruby
# updater/lib/dependabot/updater/group_update_creation.rb
def semver_rules_allow_grouping?(group, dependency, checker)
  update_types = group.update_types
  return true unless update_types
  ...
  unless version_class.correct?(dependency.version.to_s) && version_class.correct?(checker.latest_version)
    return false      # dependency.version is nil for a `>=` floor -> not grouped
  end
```

`version` is nil because pip only records a version for pinned specifiers:

```python
# python/helpers/lib/parser.py
def version_from_install_req(install_req):
    if install_req.is_pinned:          # only == / ===
        return next(iter(install_req.specifier)).version
```

With both files pinned, the same group PR now updates them together, so they can't diverge again.

## Verification

In `python:3.11-slim`, matching `chat-demo-tests.yml`:

- the two dependency lists are now byte-identical (13 deps, verified by `diff`)
- openai stays at **2.50.0** through both install steps
- `pip check` — no broken requirements
- `pytest -q tests python_server/tests` — **58 passed**

Also confirmed `pip install -r requirements.txt` succeeds on `python:3.12-slim`, the App Service runtime (`linuxFxVersion: PYTHON|3.12`).

For completeness, the suite also passes on openai 3.2.0 (58 passed), so this is a deliberate choice to ship what production runs — not a workaround for a broken upgrade.