### PR TITLE
Add Azure Web PubSub emulator tool scaffold

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches: [ "main" ]
     paths:
+      - '.github/workflows/build.yml'
+      - 'package.json'
+      - 'yarn.lock'
       - 'sdk/**'
       - 'tools/**'
       - 'samples/**'
@@ -14,6 +17,9 @@ on:
   pull_request:
     branches: [ "main" ]
     paths:
+      - '.github/workflows/build.yml'
+      - 'package.json'
+      - 'yarn.lock'
       - 'sdk/**'
       - 'tools/**'
       - 'samples/**'
@@ -21,10 +27,45 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
+  changes:
+    name: Detect affected components
+    runs-on: ubuntu-latest
+    outputs:
+      javascript: ${{ steps.filter.outputs.javascript }}
+      chat_client: ${{ steps.filter.outputs.chat_client }}
+      csharp: ${{ steps.filter.outputs.csharp }}
+      java: ${{ steps.filter.outputs.java }}
+      python: ${{ steps.filter.outputs.python }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        id: filter
+        with:
+          filters: |
+            javascript:
+              - 'package.json'
+              - 'yarn.lock'
+              - 'sdk/**'
+              - 'tools/vscode-azurewebpubsub/**'
+              - 'tools/awps-tunnel/**'
+              - 'samples/javascript/**'
+              - 'experimental/**'
+            chat_client:
+              - 'sdk/webpubsub-chat-client/**'
+            csharp:
+              - 'samples/csharp/**'
+            java:
+              - 'samples/java/**'
+            python:
+              - 'samples/python/**'
+
   javascript:
     name: Build and Test JS code and samples
+    needs: changes
+    if: needs.changes.outputs.javascript == 'true'
     runs-on: ubuntu-latest
     env:
       NPM_CONFIG_REGISTRY: 'https://packagefeedproxy.microsoft.io/npm/'
@@ -78,6 +119,8 @@ jobs:
 
   chat-client:
     name: Build and Test Chat Client (20.x)
+    needs: changes
+    if: needs.changes.outputs.chat_client == 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -99,6 +142,8 @@ jobs:
 
   csharp:
     name: Build and Test C#
+    needs: changes
+    if: needs.changes.outputs.csharp == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -115,6 +160,8 @@ jobs:
   # Java Stage
   java:
     name: Build and Test Java
+    needs: changes
+    if: needs.changes.outputs.java == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -141,6 +188,8 @@ jobs:
   # Python Stage
   python:
     name: Build and Test Python
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/emulator-tests.yml
+++ b/.github/workflows/emulator-tests.yml
@@ -68,7 +68,8 @@ jobs:
           trap 'kill "${emulator_pid}" >/dev/null 2>&1 || true' EXIT
 
           for attempt in {1..30}; do
-            if curl --fail --silent --show-error http://127.0.0.1:8080/health; then
+            if curl --fail --silent --show-error --head \
+              'http://127.0.0.1:8080/api/health?api-version=2024-12-01'; then
               exit 0
             fi
             sleep 1

--- a/.github/workflows/emulator-tests.yml
+++ b/.github/workflows/emulator-tests.yml
@@ -1,0 +1,85 @@
+name: Web PubSub Emulator
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - 'tools/emulator/**'
+      - '.github/workflows/emulator-tests.yml'
+  pull_request:
+    branches: ["main"]
+    paths:
+      - 'tools/emulator/**'
+      - '.github/workflows/emulator-tests.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Build, Test, and Pack Emulator
+    runs-on: ubuntu-latest
+    env:
+      PACKAGE_VERSION: 0.0.0-ci.${{ github.run_number }}
+    strategy:
+      matrix:
+        dotnet-version: [10.x]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup .NET ${{ matrix.dotnet-version }}
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: ${{ matrix.dotnet-version }}
+
+      - name: Restore dependencies
+        run: >-
+          dotnet restore tools/emulator/Microsoft.Azure.WebPubSub.Emulator.sln
+          --configfile tools/emulator/NuGet.Config
+
+      - name: Build solution
+        run: dotnet build tools/emulator/Microsoft.Azure.WebPubSub.Emulator.sln --configuration Release --no-restore
+
+      - name: Run tests
+        run: dotnet test tools/emulator/Microsoft.Azure.WebPubSub.Emulator.sln --configuration Release --no-build
+
+      - name: Pack emulator tool
+        run: >-
+          dotnet pack tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/Microsoft.Azure.WebPubSub.Emulator.csproj
+          --configuration Release
+          --no-build
+          --output artifacts/build
+          -p:PackageVersion=${{ env.PACKAGE_VERSION }}
+
+      - name: Install and run packed tool
+        shell: bash
+        run: |
+          set -euo pipefail
+          dotnet tool install \
+            --tool-path artifacts/tool \
+            Microsoft.Azure.WebPubSub.Emulator \
+            --version "${PACKAGE_VERSION}" \
+            --add-source artifacts/build \
+            --configfile tools/emulator/NuGet.Config \
+            --no-cache
+
+          artifacts/tool/awps-emulator > artifacts/emulator.log 2>&1 &
+          emulator_pid=$!
+          trap 'kill "${emulator_pid}" >/dev/null 2>&1 || true' EXIT
+
+          for attempt in {1..30}; do
+            if curl --fail --silent --show-error http://127.0.0.1:8080/health; then
+              exit 0
+            fi
+            sleep 1
+          done
+
+          cat artifacts/emulator.log
+          exit 1
+
+      - name: Upload emulator package
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: Microsoft.Azure.WebPubSub.Emulator.${{ env.PACKAGE_VERSION }}
+          path: artifacts/build/*.nupkg
+          if-no-files-found: error

--- a/.github/workflows/emulator-tests.yml
+++ b/.github/workflows/emulator-tests.yml
@@ -18,11 +18,13 @@ permissions:
 jobs:
   test:
     name: Build, Test, and Pack Emulator
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     env:
       PACKAGE_VERSION: 0.0.0-ci.${{ github.run_number }}
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest]
         dotnet-version: [10.x]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -56,35 +58,80 @@ jobs:
           -p:PackageVersion=${{ env.PACKAGE_VERSION }}
 
       - name: Install and run packed tool
-        shell: bash
+        shell: pwsh
         run: |
-          set -euo pipefail
-          dotnet tool install \
-            --tool-path artifacts/tool \
-            Microsoft.Azure.WebPubSub.Emulator \
-            --version "${PACKAGE_VERSION}" \
-            --add-source artifacts/build \
-            --configfile tools/emulator/NuGet.Config \
+          $ErrorActionPreference = 'Stop'
+          dotnet tool install `
+            --tool-path artifacts/tool `
+            Microsoft.Azure.WebPubSub.Emulator `
+            --version $env:PACKAGE_VERSION `
+            --add-source artifacts/build `
+            --configfile tools/emulator/NuGet.Config `
             --no-cache
 
-          artifacts/tool/awps-emulator > artifacts/emulator.log 2>&1 &
-          emulator_pid=$!
-          trap 'kill "${emulator_pid}" >/dev/null 2>&1 || true' EXIT
+          $toolName = if ($IsWindows) { 'awps-emulator.exe' } else { 'awps-emulator' }
+          $toolPath = Join-Path $PWD "artifacts/tool/$toolName"
+          $stdoutPath = Join-Path $PWD 'artifacts/emulator.stdout.log'
+          $stderrPath = Join-Path $PWD 'artifacts/emulator.stderr.log'
+          Add-Type -AssemblyName System.Net.Http
+          $process = $null
+          $client = $null
+          try {
+            $process = Start-Process `
+              -FilePath $toolPath `
+              -RedirectStandardOutput $stdoutPath `
+              -RedirectStandardError $stderrPath `
+              -PassThru
+            $client = [System.Net.Http.HttpClient]::new()
+            $healthy = $false
+            for ($attempt = 1; $attempt -le 30; $attempt++) {
+              try {
+                $response = $null
+                $request = [System.Net.Http.HttpRequestMessage]::new(
+                  [System.Net.Http.HttpMethod]::Head,
+                  'http://127.0.0.1:8080/api/health')
+                try {
+                  $response = $client.SendAsync($request).GetAwaiter().GetResult()
+                  if ($response.IsSuccessStatusCode) {
+                    $healthy = $true
+                    break
+                  }
+                }
+                finally {
+                  if ($null -ne $response) {
+                    $response.Dispose()
+                  }
+                  $request.Dispose()
+                }
+              }
+              catch {
+                if ($process.HasExited) {
+                  break
+                }
+              }
+              [System.Threading.Thread]::Sleep(1000)
+            }
 
-          for attempt in {1..30}; do
-            if curl --fail --silent --show-error --head \
-              'http://127.0.0.1:8080/api/health'; then
-              exit 0
+            if (-not $healthy) {
+              Get-Content $stdoutPath, $stderrPath -ErrorAction SilentlyContinue
+              throw 'The packaged emulator did not become healthy.'
             fi
-            sleep 1
-          done
-
-          cat artifacts/emulator.log
-          exit 1
+          }
+          finally {
+            if ($null -ne $client) {
+              $client.Dispose()
+            }
+            if ($null -ne $process -and -not $process.HasExited) {
+              Stop-Process -Id $process.Id -Force
+            }
+            if ($null -ne $process) {
+              $process.Dispose()
+            }
+          }
 
       - name: Upload emulator package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: Microsoft.Azure.WebPubSub.Emulator.${{ env.PACKAGE_VERSION }}
+          name: Microsoft.Azure.WebPubSub.Emulator.${{ env.PACKAGE_VERSION }}.${{ runner.os }}
           path: artifacts/build/*.nupkg
           if-no-files-found: error

--- a/.github/workflows/emulator-tests.yml
+++ b/.github/workflows/emulator-tests.yml
@@ -115,7 +115,7 @@ jobs:
             if (-not $healthy) {
               Get-Content $stdoutPath, $stderrPath -ErrorAction SilentlyContinue
               throw 'The packaged emulator did not become healthy.'
-            fi
+            }
           }
           finally {
             if ($null -ne $client) {

--- a/.github/workflows/emulator-tests.yml
+++ b/.github/workflows/emulator-tests.yml
@@ -38,7 +38,11 @@ jobs:
           --configfile tools/emulator/NuGet.Config
 
       - name: Build solution
-        run: dotnet build tools/emulator/Microsoft.Azure.WebPubSub.Emulator.sln --configuration Release --no-restore
+        run: >-
+          dotnet build tools/emulator/Microsoft.Azure.WebPubSub.Emulator.sln
+          --configuration Release
+          --no-restore
+          -p:Version=${{ env.PACKAGE_VERSION }}
 
       - name: Run tests
         run: dotnet test tools/emulator/Microsoft.Azure.WebPubSub.Emulator.sln --configuration Release --no-build

--- a/.github/workflows/emulator-tests.yml
+++ b/.github/workflows/emulator-tests.yml
@@ -69,7 +69,7 @@ jobs:
 
           for attempt in {1..30}; do
             if curl --fail --silent --show-error --head \
-              'http://127.0.0.1:8080/api/health?api-version=2024-12-01'; then
+              'http://127.0.0.1:8080/api/health'; then
               exit 0
             fi
             sleep 1

--- a/tools/emulator/CHANGELOG.md
+++ b/tools/emulator/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## [1.0.0-beta.1] - Unreleased
+
+### Added
+
+- Add the `Microsoft.Azure.WebPubSub.Emulator` .NET tool scaffold.
+- Add the service-compatible `HEAD /api/health` endpoint.
+- Add build, test, package, installation, and health-check validation in CI.

--- a/tools/emulator/Directory.Build.props
+++ b/tools/emulator/Directory.Build.props
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="version.props" />
+</Project>

--- a/tools/emulator/Directory.Packages.props
+++ b/tools/emulator/Directory.Packages.props
@@ -1,0 +1,14 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+</Project>

--- a/tools/emulator/Microsoft.Azure.WebPubSub.Emulator.sln
+++ b/tools/emulator/Microsoft.Azure.WebPubSub.Emulator.sln
@@ -9,6 +9,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{2C5B7A11
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.WebPubSub.Emulator", "src\Microsoft.Azure.WebPubSub.Emulator\Microsoft.Azure.WebPubSub.Emulator.csproj", "{3F1E2A44-9C7B-4E51-8B21-5D2A6C0F1A01}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.WebPubSub.Emulator.ApiSourceGenerator", "src\Microsoft.Azure.WebPubSub.Emulator.ApiSourceGenerator\Microsoft.Azure.WebPubSub.Emulator.ApiSourceGenerator.csproj", "{3F1E2A44-9C7B-4E51-8B21-5D2A6C0F1A03}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.WebPubSub.Emulator.Tests", "tests\Microsoft.Azure.WebPubSub.Emulator.Tests\Microsoft.Azure.WebPubSub.Emulator.Tests.csproj", "{3F1E2A44-9C7B-4E51-8B21-5D2A6C0F1A02}"
 EndProject
 Global
@@ -21,6 +23,10 @@ Global
 		{3F1E2A44-9C7B-4E51-8B21-5D2A6C0F1A01}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3F1E2A44-9C7B-4E51-8B21-5D2A6C0F1A01}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3F1E2A44-9C7B-4E51-8B21-5D2A6C0F1A01}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3F1E2A44-9C7B-4E51-8B21-5D2A6C0F1A03}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3F1E2A44-9C7B-4E51-8B21-5D2A6C0F1A03}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3F1E2A44-9C7B-4E51-8B21-5D2A6C0F1A03}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3F1E2A44-9C7B-4E51-8B21-5D2A6C0F1A03}.Release|Any CPU.Build.0 = Release|Any CPU
 		{3F1E2A44-9C7B-4E51-8B21-5D2A6C0F1A02}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3F1E2A44-9C7B-4E51-8B21-5D2A6C0F1A02}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3F1E2A44-9C7B-4E51-8B21-5D2A6C0F1A02}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -31,6 +37,7 @@ Global
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{3F1E2A44-9C7B-4E51-8B21-5D2A6C0F1A01} = {2C5B7A11-8D3F-4E62-9A04-6B1C8E5D2F10}
+		{3F1E2A44-9C7B-4E51-8B21-5D2A6C0F1A03} = {2C5B7A11-8D3F-4E62-9A04-6B1C8E5D2F10}
 		{3F1E2A44-9C7B-4E51-8B21-5D2A6C0F1A02} = {2C5B7A11-8D3F-4E62-9A04-6B1C8E5D2F11}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution

--- a/tools/emulator/Microsoft.Azure.WebPubSub.Emulator.sln
+++ b/tools/emulator/Microsoft.Azure.WebPubSub.Emulator.sln
@@ -1,0 +1,39 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{2C5B7A11-8D3F-4E62-9A04-6B1C8E5D2F10}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{2C5B7A11-8D3F-4E62-9A04-6B1C8E5D2F11}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.WebPubSub.Emulator", "src\Microsoft.Azure.WebPubSub.Emulator\Microsoft.Azure.WebPubSub.Emulator.csproj", "{3F1E2A44-9C7B-4E51-8B21-5D2A6C0F1A01}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.WebPubSub.Emulator.Tests", "tests\Microsoft.Azure.WebPubSub.Emulator.Tests\Microsoft.Azure.WebPubSub.Emulator.Tests.csproj", "{3F1E2A44-9C7B-4E51-8B21-5D2A6C0F1A02}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{3F1E2A44-9C7B-4E51-8B21-5D2A6C0F1A01}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3F1E2A44-9C7B-4E51-8B21-5D2A6C0F1A01}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3F1E2A44-9C7B-4E51-8B21-5D2A6C0F1A01}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3F1E2A44-9C7B-4E51-8B21-5D2A6C0F1A01}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3F1E2A44-9C7B-4E51-8B21-5D2A6C0F1A02}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3F1E2A44-9C7B-4E51-8B21-5D2A6C0F1A02}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3F1E2A44-9C7B-4E51-8B21-5D2A6C0F1A02}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3F1E2A44-9C7B-4E51-8B21-5D2A6C0F1A02}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{3F1E2A44-9C7B-4E51-8B21-5D2A6C0F1A01} = {2C5B7A11-8D3F-4E62-9A04-6B1C8E5D2F10}
+		{3F1E2A44-9C7B-4E51-8B21-5D2A6C0F1A02} = {2C5B7A11-8D3F-4E62-9A04-6B1C8E5D2F11}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {8A5C4B21-7D3E-4A6F-9C18-2E7B5D0A3F44}
+	EndGlobalSection
+EndGlobal

--- a/tools/emulator/NuGet.Config
+++ b/tools/emulator/NuGet.Config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="approved" value="https://packagefeedproxy.microsoft.io/nuget/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/tools/emulator/README.md
+++ b/tools/emulator/README.md
@@ -17,11 +17,13 @@ dotnet run --project tools\emulator\src\Microsoft.Azure.WebPubSub.Emulator
 ```
 
 The tool listens on `http://localhost:8080` by default. To check whether it is ready, open
-`http://localhost:8080/health`. A healthy process returns:
+the service health endpoint:
 
-```json
-{ "status": "Healthy" }
+```powershell
+curl.exe --head "http://localhost:8080/api/health?api-version=2024-12-01"
 ```
+
+A healthy process returns `200 OK`.
 
 Set the ASP.NET Core `Urls` configuration value to use another address. For example:
 

--- a/tools/emulator/README.md
+++ b/tools/emulator/README.md
@@ -20,10 +20,11 @@ The tool listens on `http://localhost:8080` by default. To check whether it is r
 the service health endpoint:
 
 ```powershell
-curl.exe --head "http://localhost:8080/api/health?api-version=2024-12-01"
+curl.exe --head "http://localhost:8080/api/health"
 ```
 
-A healthy process returns `200 OK`.
+A healthy process returns `200 OK`. When `api-version` is omitted, the emulator uses its latest
+supported API version.
 
 Set the ASP.NET Core `Urls` configuration value to use another address. For example:
 

--- a/tools/emulator/README.md
+++ b/tools/emulator/README.md
@@ -1,0 +1,49 @@
+# Azure Web PubSub Emulator
+
+This directory contains the .NET tool host for the Azure Web PubSub Emulator. The current
+scaffold starts an ASP.NET Core process and exposes a health endpoint. Client protocols, REST
+APIs, event handlers, and other service behavior will be added in follow-up changes.
+
+## Prerequisites
+
+- .NET 10 SDK
+
+## Run from source
+
+From the repository root, run:
+
+```powershell
+dotnet run --project tools\emulator\src\Microsoft.Azure.WebPubSub.Emulator
+```
+
+The tool listens on `http://localhost:8080` by default. To check whether it is ready, open
+`http://localhost:8080/health`. A healthy process returns:
+
+```json
+{ "status": "Healthy" }
+```
+
+Set the ASP.NET Core `Urls` configuration value to use another address. For example:
+
+```powershell
+$env:Urls = "http://localhost:8090"
+dotnet run --project tools\emulator\src\Microsoft.Azure.WebPubSub.Emulator
+```
+
+## Pack and install the tool
+
+```powershell
+dotnet pack tools\emulator\src\Microsoft.Azure.WebPubSub.Emulator `
+  --configuration Release `
+  --output artifacts\emulator
+
+dotnet tool install `
+  --tool-path artifacts\emulator-tool `
+  Microsoft.Azure.WebPubSub.Emulator `
+  --add-source artifacts\emulator `
+  --configfile tools\emulator\NuGet.Config
+
+artifacts\emulator-tool\awps-emulator
+```
+
+See [Supported Features and Gaps](SUPPORTED_FEATURES.md) for the current implementation status.

--- a/tools/emulator/README.md
+++ b/tools/emulator/README.md
@@ -43,10 +43,17 @@ dotnet pack tools\emulator\src\Microsoft.Azure.WebPubSub.Emulator `
 dotnet tool install `
   --tool-path artifacts\emulator-tool `
   Microsoft.Azure.WebPubSub.Emulator `
+  --version 1.0.0-beta.1 `
   --add-source artifacts\emulator `
   --configfile tools\emulator\NuGet.Config
 
 artifacts\emulator-tool\awps-emulator
 ```
+
+## Versioning
+
+The next release version is declared in `version.props` and documented in `CHANGELOG.md`.
+Continuous integration packages use a unique `0.0.0-ci.<run-number>` version instead of the
+release version.
 
 See [Supported Features and Gaps](SUPPORTED_FEATURES.md) for the current implementation status.

--- a/tools/emulator/SUPPORTED_FEATURES.md
+++ b/tools/emulator/SUPPORTED_FEATURES.md
@@ -1,0 +1,28 @@
+# Supported Features and Gaps
+
+The current implementation establishes the executable and packaging foundation for the Azure
+Web PubSub Emulator. It does not yet emulate Azure Web PubSub service behavior.
+
+## Current support
+
+| Area | Status | Notes |
+| --- | --- | --- |
+| .NET tool | Implemented | Builds and installs as `Microsoft.Azure.WebPubSub.Emulator`; runs as `awps-emulator`. |
+| Configurable host address | Implemented | Listens on `http://localhost:8080` by default and supports ASP.NET Core `Urls` configuration. |
+| Process health | Implemented | `GET /health` returns `200 OK` with `{ "status": "Healthy" }`. |
+
+## Not yet implemented
+
+The current tool does not accept WebSocket clients or provide service APIs. The following areas
+are planned for follow-up changes:
+
+- Client endpoints and Web PubSub client protocols
+- Client messaging, groups, roles, and metadata
+- Reliable protocol reconnect and replay
+- REST APIs and server SDK compatibility
+- HTTP upstream event handlers
+- Event Hubs listeners
+- Authentication and authorization behavior
+
+Until those capabilities are implemented, use the tool only to validate installation, process
+startup, host configuration, and health checks.

--- a/tools/emulator/SUPPORTED_FEATURES.md
+++ b/tools/emulator/SUPPORTED_FEATURES.md
@@ -1,7 +1,7 @@
 # Supported Features and Gaps
 
 The current implementation establishes the executable and packaging foundation for the Azure
-Web PubSub Emulator. It does not yet emulate Azure Web PubSub service behavior.
+Web PubSub Emulator. It does not yet emulate service behavior beyond the health operation.
 
 ## Current support
 
@@ -9,12 +9,12 @@ Web PubSub Emulator. It does not yet emulate Azure Web PubSub service behavior.
 | --- | --- | --- |
 | .NET tool | Implemented | Builds and installs as `Microsoft.Azure.WebPubSub.Emulator`; runs as `awps-emulator`. |
 | Configurable host address | Implemented | Listens on `http://localhost:8080` by default and supports ASP.NET Core `Urls` configuration. |
-| Process health | Implemented | `GET /health` returns `200 OK` with `{ "status": "Healthy" }`. |
+| Service health | Implemented | `HEAD /api/health` returns `200 OK`. |
 
 ## Not yet implemented
 
-The current tool does not accept WebSocket clients or provide service APIs. The following areas
-are planned for follow-up changes:
+The current tool does not accept WebSocket clients or provide messaging and management APIs.
+The following areas are planned for follow-up changes:
 
 - Client endpoints and Web PubSub client protocols
 - Client messaging, groups, roles, and metadata

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator.ApiSourceGenerator/AnalyzerReleases.Unshipped.md
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator.ApiSourceGenerator/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,7 @@
+## Release 1.0.0
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+AWPS001 | SourceGeneration | Error | Reports invalid Web PubSub API declarations.

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator.ApiSourceGenerator/ApiSourceGenerator.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator.ApiSourceGenerator/ApiSourceGenerator.cs
@@ -1,0 +1,301 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.Azure.WebPubSub.Emulator.ApiSourceGenerator;
+
+[Generator]
+public sealed class ApiSourceGenerator : ISourceGenerator
+{
+    private const string ApiAttributeName =
+        "Microsoft.Azure.WebPubSub.Emulator.WebPubSubApiAttribute";
+    private const string OperationAttributeName =
+        "Microsoft.Azure.WebPubSub.Emulator.WebPubSubApiOperationAttribute";
+    private static readonly HashSet<string> CSharpKeywords = new(StringComparer.Ordinal)
+    {
+        "abstract", "as", "base", "bool", "break", "byte", "case", "catch", "char",
+        "checked", "class", "const", "continue", "decimal", "default", "delegate", "do",
+        "double", "else", "enum", "event", "explicit", "extern", "false", "finally",
+        "fixed", "float", "for", "foreach", "goto", "if", "implicit", "in", "int",
+        "interface", "internal", "is", "lock", "long", "namespace", "new", "null",
+        "object", "operator", "out", "override", "params", "private", "protected",
+        "public", "readonly", "ref", "return", "sbyte", "sealed", "short", "sizeof",
+        "stackalloc", "static", "string", "struct", "switch", "this", "throw", "true",
+        "try", "typeof", "uint", "ulong", "unchecked", "unsafe", "ushort", "using",
+        "virtual", "void", "volatile", "while",
+    };
+    private static readonly DiagnosticDescriptor InvalidDefinition = new(
+        "AWPS001",
+        "Invalid Web PubSub API definition",
+        "{0}",
+        "SourceGeneration",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    public void Initialize(GeneratorInitializationContext context)
+    {
+        context.RegisterForSyntaxNotifications(static () => new SyntaxReceiver());
+    }
+
+    public void Execute(GeneratorExecutionContext context)
+    {
+        if (context.SyntaxReceiver is not SyntaxReceiver receiver)
+        {
+            return;
+        }
+
+        foreach (var declaration in receiver.Candidates)
+        {
+            var model = context.Compilation.GetSemanticModel(declaration.SyntaxTree);
+            if (model.GetDeclaredSymbol(declaration) is not INamedTypeSymbol type)
+            {
+                continue;
+            }
+
+            var attributes = type.GetAttributes();
+            var api = attributes.SingleOrDefault(attribute =>
+                attribute.AttributeClass?.ToDisplayString() == ApiAttributeName);
+            if (api is null)
+            {
+                continue;
+            }
+
+            if (!TryGetString(api, 0, out var apiVersion))
+            {
+                Report(context, declaration, "The WebPubSubApi attribute requires an API version.");
+                continue;
+            }
+
+            var operations = new List<ApiOperation>();
+            var valid = true;
+            foreach (var attribute in attributes
+                .Where(attribute => attribute.AttributeClass?.ToDisplayString() == OperationAttributeName)
+                .OrderBy(attribute => attribute.ApplicationSyntaxReference?.Span.Start))
+            {
+                ApiOperation? operation = null;
+                string? error = null;
+                if (!TryGetString(attribute, 0, out var method) ||
+                    !TryGetString(attribute, 1, out var path) ||
+                    !TryGetString(attribute, 2, out var operationId) ||
+                    !TryCreateOperation(method, path, operationId, out operation, out error))
+                {
+                    Report(context, declaration, error ?? "A WebPubSubApiOperation attribute is invalid.");
+                    valid = false;
+                    continue;
+                }
+
+                operations.Add(operation!);
+            }
+
+            if (!valid || operations.Count == 0 || !ValidateOperations(context, declaration, operations))
+            {
+                continue;
+            }
+
+            context.AddSource(
+                $"{type.Name}.g.cs",
+                SourceText.From(Generate(type, apiVersion, operations), Encoding.UTF8));
+        }
+    }
+
+    private static bool ValidateOperations(
+        GeneratorExecutionContext context,
+        ClassDeclarationSyntax declaration,
+        IReadOnlyCollection<ApiOperation> operations)
+    {
+        var valid = true;
+        foreach (var duplicate in operations.GroupBy(operation => operation.ActionName)
+            .Where(group => group.Count() > 1))
+        {
+            Report(context, declaration, $"Action name '{duplicate.Key}' is duplicated.");
+            valid = false;
+        }
+        foreach (var duplicate in operations.GroupBy(operation => (operation.Method, operation.Path))
+            .Where(group => group.Count() > 1))
+        {
+            Report(
+                context,
+                declaration,
+                $"Route '{duplicate.Key.Method} {duplicate.Key.Path}' is duplicated.");
+            valid = false;
+        }
+
+        return valid;
+    }
+
+    private static bool TryCreateOperation(
+        string method,
+        string path,
+        string operationId,
+        out ApiOperation? operation,
+        out string? error)
+    {
+        var attributeName = method.ToUpperInvariant() switch
+        {
+            "DELETE" => "HttpDelete",
+            "GET" => "HttpGet",
+            "HEAD" => "HttpHead",
+            "OPTIONS" => "HttpOptions",
+            "PATCH" => "HttpPatch",
+            "POST" => "HttpPost",
+            "PUT" => "HttpPut",
+            _ => null,
+        };
+        if (attributeName is null)
+        {
+            operation = null;
+            error = $"HTTP method '{method}' is not supported.";
+            return false;
+        }
+        if (string.IsNullOrWhiteSpace(path) || !path.StartsWith("/", StringComparison.Ordinal))
+        {
+            operation = null;
+            error = $"Route '{path}' must start with '/'.";
+            return false;
+        }
+
+        var separator = operationId.IndexOf('_');
+        var actionName = separator < 0 ? operationId : operationId.Substring(separator + 1);
+        if (string.IsNullOrWhiteSpace(actionName))
+        {
+            operation = null;
+            error = $"Operation ID '{operationId}' does not produce an action name.";
+            return false;
+        }
+
+        var parameters = Regex.Matches(path, "\\{([^}]+)\\}")
+            .Cast<Match>()
+            .Select(match => GetParameterName(match.Groups[1].Value))
+            .ToArray();
+        operation = new(attributeName, method.ToUpperInvariant(), path, operationId, actionName, parameters);
+        error = null;
+        return true;
+    }
+
+    private static string Generate(
+        INamedTypeSymbol type,
+        string apiVersion,
+        IReadOnlyCollection<ApiOperation> operations)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("// <auto-generated />");
+        builder.AppendLine();
+        builder.AppendLine("using Microsoft.AspNetCore.Mvc;");
+        builder.AppendLine("using Microsoft.AspNetCore.Mvc.Filters;");
+        builder.AppendLine();
+        builder.Append("namespace ").Append(type.ContainingNamespace.ToDisplayString()).AppendLine(";");
+        builder.AppendLine();
+        builder.AppendLine("[ApiController]");
+        builder.Append("internal abstract partial class ").Append(type.Name)
+            .AppendLine(" : ControllerBase, IAsyncActionFilter");
+        builder.AppendLine("{");
+        builder.Append("    public const string ApiVersion = \"").Append(Escape(apiVersion)).AppendLine("\";");
+
+        foreach (var operation in operations)
+        {
+            builder.AppendLine();
+            builder.Append("    [").Append(operation.AttributeName).Append("(\"")
+                .Append(Escape(operation.Path)).Append("\", Name = \"")
+                .Append(Escape(operation.OperationId)).AppendLine("\")]");
+            builder.Append("    public virtual Task<IActionResult> ").Append(operation.ActionName).AppendLine("(");
+            foreach (var parameter in operation.Parameters)
+            {
+                builder.Append("        string ").Append(parameter).AppendLine(",");
+            }
+            builder.AppendLine("        CancellationToken cancellationToken = default)");
+            builder.AppendLine("    {");
+            builder.Append("        return NotImplementedAsync(\"").Append(Escape(operation.OperationId)).AppendLine("\");");
+            builder.AppendLine("    }");
+        }
+
+        builder.AppendLine("}");
+        return builder.ToString();
+    }
+
+    private static bool TryGetString(AttributeData attribute, int index, out string value)
+    {
+        value = string.Empty;
+        if (attribute.ConstructorArguments.Length <= index ||
+            attribute.ConstructorArguments[index].Value is not string text ||
+            string.IsNullOrWhiteSpace(text))
+        {
+            return false;
+        }
+
+        value = text;
+        return true;
+    }
+
+    private static string GetParameterName(string value)
+    {
+        var identifier = Regex.Replace(value, "[^a-zA-Z0-9_]", "_");
+        if (identifier.Length == 0 || char.IsDigit(identifier[0]))
+        {
+            identifier = $"_{identifier}";
+        }
+        return CSharpKeywords.Contains(identifier) ? $"@{identifier}" : identifier;
+    }
+
+    private static string Escape(string value) =>
+        value.Replace("\\", "\\\\").Replace("\"", "\\\"");
+
+    private static void Report(
+        GeneratorExecutionContext context,
+        ClassDeclarationSyntax declaration,
+        string message)
+    {
+        context.ReportDiagnostic(Diagnostic.Create(
+            InvalidDefinition,
+            declaration.Identifier.GetLocation(),
+            message));
+    }
+
+    private sealed class SyntaxReceiver : ISyntaxReceiver
+    {
+        public List<ClassDeclarationSyntax> Candidates { get; } = new();
+
+        public void OnVisitSyntaxNode(SyntaxNode syntaxNode)
+        {
+            if (syntaxNode is ClassDeclarationSyntax declaration && declaration.AttributeLists.Count > 0)
+            {
+                Candidates.Add(declaration);
+            }
+        }
+    }
+
+    private sealed class ApiOperation
+    {
+        public ApiOperation(
+            string attributeName,
+            string method,
+            string path,
+            string operationId,
+            string actionName,
+            string[] parameters)
+        {
+            AttributeName = attributeName;
+            Method = method;
+            Path = path;
+            OperationId = operationId;
+            ActionName = actionName;
+            Parameters = parameters;
+        }
+
+        public string AttributeName { get; }
+
+        public string Method { get; }
+
+        public string Path { get; }
+
+        public string OperationId { get; }
+
+        public string ActionName { get; }
+
+        public string[] Parameters { get; }
+    }
+}

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator.ApiSourceGenerator/Microsoft.Azure.WebPubSub.Emulator.ApiSourceGenerator.csproj
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator.ApiSourceGenerator/Microsoft.Azure.WebPubSub.Emulator.ApiSourceGenerator.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator.ApiSourceGenerator/Microsoft.Azure.WebPubSub.Emulator.ApiSourceGenerator.csproj
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator.ApiSourceGenerator/Microsoft.Azure.WebPubSub.Emulator.ApiSourceGenerator.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorApplication.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorApplication.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
+
+namespace Microsoft.Azure.WebPubSub.Emulator;
+
+internal static class EmulatorApplication
+{
+    internal static WebApplicationBuilder CreateBuilder(
+        string[]? args = null)
+    {
+        var builder = WebApplication.CreateBuilder(args ?? []);
+        builder.Configuration[WebHostDefaults.ServerUrlsKey] ??= "http://localhost:8080";
+        return builder;
+    }
+
+    internal static WebApplication Build(string[]? args = null)
+    {
+        return Build(CreateBuilder(args));
+    }
+
+    internal static WebApplication Build(WebApplicationBuilder builder)
+    {
+        var app = builder.Build();
+
+        app.MapGet("/health", () => Results.Ok(new { status = "Healthy" }));
+
+        return app;
+    }
+}

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorApplication.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorApplication.cs
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Reflection;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 namespace Microsoft.Azure.WebPubSub.Emulator;
@@ -14,6 +16,13 @@ internal static class EmulatorApplication
     {
         var builder = WebApplication.CreateBuilder(args ?? []);
         builder.Configuration[WebHostDefaults.ServerUrlsKey] ??= "http://localhost:8080";
+        builder.Services
+            .AddControllers()
+            .AddApplicationPart(typeof(WebPubSubEmulatorController).Assembly)
+            .ConfigureApplicationPartManager(manager =>
+            {
+                manager.FeatureProviders.Add(new EmulatorControllerFeatureProvider());
+            });
         return builder;
     }
 
@@ -26,8 +35,18 @@ internal static class EmulatorApplication
     {
         var app = builder.Build();
 
-        app.MapMethods("/api/health", [HttpMethods.Head], () => Results.Ok());
+        app.MapControllers();
 
         return app;
+    }
+
+    private sealed class EmulatorControllerFeatureProvider : ControllerFeatureProvider
+    {
+        protected override bool IsController(TypeInfo typeInfo)
+        {
+            var isEmulatorController = !typeInfo.IsAbstract &&
+                typeof(WebPubSubEmulatorController).IsAssignableFrom(typeInfo);
+            return isEmulatorController || base.IsController(typeInfo);
+        }
     }
 }

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorApplication.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorApplication.cs
@@ -26,7 +26,7 @@ internal static class EmulatorApplication
     {
         var app = builder.Build();
 
-        app.MapGet("/health", () => Results.Ok(new { status = "Healthy" }));
+        app.MapMethods("/api/health", [HttpMethods.Head], () => Results.Ok());
 
         return app;
     }

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/Microsoft.Azure.WebPubSub.Emulator.csproj
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/Microsoft.Azure.WebPubSub.Emulator.csproj
@@ -24,6 +24,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference
+      Include="..\Microsoft.Azure.WebPubSub.Emulator.ApiSourceGenerator\Microsoft.Azure.WebPubSub.Emulator.ApiSourceGenerator.csproj"
+      OutputItemType="Analyzer"
+      ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>Microsoft.Azure.WebPubSub.Emulator.Tests</_Parameter1>
     </AssemblyAttribute>

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/Microsoft.Azure.WebPubSub.Emulator.csproj
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/Microsoft.Azure.WebPubSub.Emulator.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>Microsoft.Azure.WebPubSub.Emulator</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>awps-emulator</ToolCommandName>
+    <IsPackable>true</IsPackable>
+    <PackageId>Microsoft.Azure.WebPubSub.Emulator</PackageId>
+    <Title>Azure Web PubSub Emulator</Title>
+    <Description>Tool host for the Azure Web PubSub local emulator.</Description>
+    <Authors>Microsoft</Authors>
+    <Copyright>Microsoft Corporation. All rights reserved.</Copyright>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/Azure/azure-webpubsub/tree/main/tools/emulator</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/Azure/azure-webpubsub</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>azure;webpubsub;emulator;dotnet-tool</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Microsoft.Azure.WebPubSub.Emulator.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+    <None Include="..\..\SUPPORTED_FEATURES.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+</Project>

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/Microsoft.Azure.WebPubSub.Emulator.csproj
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/Microsoft.Azure.WebPubSub.Emulator.csproj
@@ -16,7 +16,9 @@
     <Authors>Microsoft</Authors>
     <Copyright>Microsoft Corporation. All rights reserved.</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageIcon>microsoft.png</PackageIcon>
     <PackageProjectUrl>https://github.com/Azure/azure-webpubsub/tree/main/tools/emulator</PackageProjectUrl>
+    <PackageReleaseNotes>See https://github.com/Azure/azure-webpubsub/blob/main/tools/emulator/CHANGELOG.md.</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/Azure/azure-webpubsub</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>azure;webpubsub;emulator;dotnet-tool</PackageTags>
@@ -38,7 +40,9 @@
 
   <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+    <None Include="..\..\CHANGELOG.md" Pack="true" PackagePath="\" />
     <None Include="..\..\SUPPORTED_FEATURES.md" Pack="true" PackagePath="\" />
+    <None Include="..\..\..\..\microsoft.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/Program.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/Program.cs
@@ -32,7 +32,7 @@ static void WriteStartupMessage(WebApplication app)
     Console.WriteLine("Health:");
     foreach (var address in addresses)
     {
-        Console.WriteLine($"  {address.TrimEnd('/')}/api/health?api-version={WebPubSubApiControllerDefinition.ApiVersion}");
+        Console.WriteLine($"  {address.TrimEnd('/')}/api/health");
     }
     Console.WriteLine();
     Console.WriteLine("Press Ctrl+C to stop the emulator.");

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/Program.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/Program.cs
@@ -32,7 +32,7 @@ static void WriteStartupMessage(WebApplication app)
     Console.WriteLine("Health:");
     foreach (var address in addresses)
     {
-        Console.WriteLine($"  {address.TrimEnd('/')}/health");
+        Console.WriteLine($"  {address.TrimEnd('/')}/api/health?api-version=2024-12-01");
     }
     Console.WriteLine();
     Console.WriteLine("Press Ctrl+C to stop the emulator.");

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/Program.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/Program.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Azure.WebPubSub.Emulator;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.Extensions.DependencyInjection;
+
+var app = EmulatorApplication.Build(args);
+app.Lifetime.ApplicationStarted.Register(() => WriteStartupMessage(app));
+await app.RunAsync();
+
+static void WriteStartupMessage(WebApplication app)
+{
+    var server = app.Services.GetRequiredService<IServer>();
+    var addresses = server.Features
+        .Get<IServerAddressesFeature>()?
+        .Addresses
+        .OrderBy(address => address, StringComparer.Ordinal)
+        .ToArray() ?? [];
+
+    Console.WriteLine();
+    Console.WriteLine("===================================================");
+    Console.WriteLine("Azure Web PubSub Emulator is ready.");
+    Console.WriteLine();
+    Console.WriteLine("Listening on:");
+    foreach (var address in addresses)
+    {
+        Console.WriteLine($"  {address}");
+    }
+    Console.WriteLine();
+    Console.WriteLine("Health:");
+    foreach (var address in addresses)
+    {
+        Console.WriteLine($"  {address.TrimEnd('/')}/health");
+    }
+    Console.WriteLine();
+    Console.WriteLine("Press Ctrl+C to stop the emulator.");
+    Console.WriteLine("===================================================");
+    Console.WriteLine();
+}
+
+partial class Program;

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/Program.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/Program.cs
@@ -32,7 +32,7 @@ static void WriteStartupMessage(WebApplication app)
     Console.WriteLine("Health:");
     foreach (var address in addresses)
     {
-        Console.WriteLine($"  {address.TrimEnd('/')}/api/health?api-version=2024-12-01");
+        Console.WriteLine($"  {address.TrimEnd('/')}/api/health?api-version={WebPubSubApiControllerDefinition.ApiVersion}");
     }
     Console.WriteLine();
     Console.WriteLine("Press Ctrl+C to stop the emulator.");

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubApiAttributes.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubApiAttributes.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Azure.WebPubSub.Emulator;
+
+[AttributeUsage(AttributeTargets.Class)]
+internal sealed class WebPubSubApiAttribute(string version) : Attribute
+{
+    public string Version { get; } = version;
+}
+
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+internal sealed class WebPubSubApiOperationAttribute(
+    string method,
+    string path,
+    string operationId) : Attribute
+{
+    public string Method { get; } = method;
+
+    public string Path { get; } = path;
+
+    public string OperationId { get; } = operationId;
+}

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubApiControllerDefinition.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubApiControllerDefinition.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Microsoft.Azure.WebPubSub.Emulator;
+
+[WebPubSubApi("2024-12-01")]
+[WebPubSubApiOperation("HEAD", "/api/health", "HealthApi_GetServiceStatus")]
+internal abstract partial class WebPubSubApiControllerDefinition
+{
+    private const string SupportedApiVersions =
+        "2021-10-01, 2022-11-01, 2023-07-01, 2024-01-01, 2024-12-01";
+
+    [NonAction]
+    public async Task OnActionExecutionAsync(
+        ActionExecutingContext context,
+        ActionExecutionDelegate next)
+    {
+        Response.Headers["api-supported-versions"] = SupportedApiVersions;
+        await next();
+    }
+
+    protected Task<IActionResult> NotImplementedAsync(string operationId)
+    {
+        return Task.FromResult<IActionResult>(StatusCode(
+            StatusCodes.Status501NotImplemented,
+            new
+            {
+                code = "NotImplemented",
+                message = $"Operation '{operationId}' is not implemented by the emulator.",
+            }));
+    }
+}

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubEmulatorController.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubEmulatorController.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.AspNetCore.Mvc;
+
+namespace Microsoft.Azure.WebPubSub.Emulator;
+
+[ApiController]
+internal sealed class WebPubSubEmulatorController : WebPubSubApiControllerDefinition
+{
+    public override Task<IActionResult> GetServiceStatus(
+        CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult<IActionResult>(Ok());
+    }
+}

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/appsettings.json
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Urls": "http://localhost:8080",
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/EmulatorApplicationTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/EmulatorApplicationTests.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Net;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Xunit;
+
+namespace Microsoft.Azure.WebPubSub.Emulator.Tests;
+
+public class EmulatorApplicationTests
+{
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(30);
+
+    [Fact]
+    public async Task HealthEndpoint_ReturnsHealthyStatus()
+    {
+        var builder = EmulatorApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        await using var application = EmulatorApplication.Build(builder);
+        await application.StartAsync().WaitAsync(TestTimeout);
+
+        using var response = await application.GetTestClient().GetAsync("/health").WaitAsync(TestTimeout);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var payload = await response.Content.ReadFromJsonAsync<HealthResponse>();
+        Assert.NotNull(payload);
+        Assert.Equal("Healthy", payload.Status);
+    }
+
+    private sealed record HealthResponse(string Status);
+}

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/EmulatorApplicationTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/EmulatorApplicationTests.cs
@@ -16,7 +16,7 @@ public class EmulatorApplicationTests
     private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(30);
 
     [Fact]
-    public async Task ServiceHealthEndpoint_HeadReturnsOk()
+    public async Task ServiceHealthEndpoint_WithoutApiVersionFallsBackToLatest()
     {
         var builder = EmulatorApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
@@ -25,7 +25,7 @@ public class EmulatorApplicationTests
 
         using var request = new HttpRequestMessage(
             HttpMethod.Head,
-            "/api/health?api-version=2024-12-01");
+            "/api/health");
         using var response = await application.GetTestClient().SendAsync(request).WaitAsync(TestTimeout);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/EmulatorApplicationTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/EmulatorApplicationTests.cs
@@ -29,5 +29,24 @@ public class EmulatorApplicationTests
         using var response = await application.GetTestClient().SendAsync(request).WaitAsync(TestTimeout);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(
+            "2021-10-01, 2022-11-01, 2023-07-01, 2024-01-01, 2024-12-01",
+            Assert.Single(response.Headers.GetValues("api-supported-versions")));
+    }
+
+    [Fact]
+    public async Task OtherServiceApiEndpoint_HeadReturnsNotFound()
+    {
+        var builder = EmulatorApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        await using var application = EmulatorApplication.Build(builder);
+        await application.StartAsync().WaitAsync(TestTimeout);
+
+        using var request = new HttpRequestMessage(
+            HttpMethod.Head,
+            "/api/hubs/chat/connections/connection?api-version=2024-12-01");
+        using var response = await application.GetTestClient().SendAsync(request).WaitAsync(TestTimeout);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 }

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/EmulatorApplicationTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/EmulatorApplicationTests.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Net;
-using System.Net.Http.Json;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
@@ -16,20 +16,18 @@ public class EmulatorApplicationTests
     private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(30);
 
     [Fact]
-    public async Task HealthEndpoint_ReturnsHealthyStatus()
+    public async Task ServiceHealthEndpoint_HeadReturnsOk()
     {
         var builder = EmulatorApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
         await using var application = EmulatorApplication.Build(builder);
         await application.StartAsync().WaitAsync(TestTimeout);
 
-        using var response = await application.GetTestClient().GetAsync("/health").WaitAsync(TestTimeout);
+        using var request = new HttpRequestMessage(
+            HttpMethod.Head,
+            "/api/health?api-version=2024-12-01");
+        using var response = await application.GetTestClient().SendAsync(request).WaitAsync(TestTimeout);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var payload = await response.Content.ReadFromJsonAsync<HealthResponse>();
-        Assert.NotNull(payload);
-        Assert.Equal("Healthy", payload.Status);
     }
-
-    private sealed record HealthResponse(string Status);
 }

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/Microsoft.Azure.WebPubSub.Emulator.Tests.csproj
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/Microsoft.Azure.WebPubSub.Emulator.Tests.csproj
@@ -13,10 +13,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.11" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/Microsoft.Azure.WebPubSub.Emulator.Tests.csproj
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/Microsoft.Azure.WebPubSub.Emulator.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>Microsoft.Azure.WebPubSub.Emulator.Tests</RootNamespace>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.11" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.Azure.WebPubSub.Emulator\Microsoft.Azure.WebPubSub.Emulator.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tools/emulator/version.props
+++ b/tools/emulator/version.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionSuffix>beta.1</VersionSuffix>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Summary

- add a .NET 10 ASP.NET Core host packaged as the `awps-emulator` dotnet tool
- establish the source-generated MVC controller architecture used by the full emulator while declaring only `HEAD /api/health`
- default requests without `api-version` to the latest API contract
- add CI that restores from the repository NuGet configuration, builds, tests, packs, installs, starts, and probes the packaged tool

This is the first reviewable slice split from #1048. It intentionally does not include client protocols, REST messaging and management operations, upstream event handling, authentication, or Event Hubs integration; those capabilities will follow in stacked PRs.

## Validation

- Release build: 0 warnings, 0 errors
- Tests: 2 passed, 0 failed
- Packed and installed `Microsoft.Azure.WebPubSub.Emulator` as an isolated local dotnet tool
- Installed tool routed versionless `HEAD /api/health` through `WebPubSubEmulatorController.GetServiceStatus`, returning `200 OK` and `api-supported-versions`
- A representative later REST route and obsolete `GET /health` both return `404 Not Found`