### PR TITLE
Derive emulator connection string from listener

### DIFF
--- a/tools/emulator/CHANGELOG.md
+++ b/tools/emulator/CHANGELOG.md
@@ -9,3 +9,5 @@
 - Add raw WebSocket client endpoint support for text and binary group messages.
 - Add access-key client authentication, connection-scoped token groups, and role-based raw group send.
 - Add build, test, package, installation, and health-check validation in CI.
+- Add endpoint-derived local connection strings with a configurable `WebPubSub:AccessKey`.
+- Add opt-in unvalidated Entra token compatibility for trusted local server SDK testing.

--- a/tools/emulator/README.md
+++ b/tools/emulator/README.md
@@ -15,8 +15,9 @@ From the repository root, run:
 dotnet run --project tools\emulator\src\Microsoft.Azure.WebPubSub.Emulator
 ```
 
-The tool listens on `http://localhost:8080` by default and prints its connection string and client
-endpoint at startup. To check whether it is ready, open the service health endpoint:
+The tool listens on `http://localhost:8080` by default. At startup, it derives the effective endpoint
+from the bound address and prints the generated connection string and client endpoint. To check
+whether it is ready, open the service health endpoint:
 
 ```powershell
 curl.exe --head "http://localhost:8080/api/health"
@@ -33,9 +34,9 @@ The client endpoint is available at:
 ws://localhost:8080/client/hubs/{hub}?access_token={token}
 ```
 
-The token must be signed with the access key from `WebPubSub:ConnectionString` and have the
-client endpoint URL as its audience. Tokens may provide `sub`, `role`, and `webpubsub.group`
-claims. The default local connection string is:
+The token must be signed with the configured `WebPubSub:AccessKey` and have the client endpoint URL
+as its audience. Tokens may provide `sub`, `role`, and `webpubsub.group` claims. The deterministic
+default local connection string is:
 
 ```text
 Endpoint=http://localhost:8080;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGH;Version=1.0;
@@ -46,19 +47,30 @@ in its token's `webpubsub.group` claims. To publish raw text or binary frames to
 `webpubsub_mode=sendToGroup&group={group}` and use a token with the corresponding
 `webpubsub.sendToGroup` role.
 
-Set the ASP.NET Core `Urls` configuration value to use another address. For example:
+Set the ASP.NET Core `Urls` configuration value to use another address. The generated connection
+string automatically uses the address and port that the emulator actually binds. For example:
 
 ```powershell
 $env:Urls = "http://localhost:8090"
 dotnet run --project tools\emulator\src\Microsoft.Azure.WebPubSub.Emulator
 ```
 
-Set `WebPubSub__ConnectionString` when changing the public endpoint or access key:
+Set `WebPubSub__AccessKey` to customize the local access key. It must be at least 32 UTF-8 bytes and
+cannot contain leading or trailing whitespace, semicolons, or control characters:
 
 ```powershell
-$env:WebPubSub__ConnectionString = `
-  "Endpoint=http://localhost:8090;AccessKey=<local-access-key>;Version=1.0;"
+$env:WebPubSub__AccessKey = "custom-emulator-access-key-1234567890"
+dotnet run --project tools\emulator\src\Microsoft.Azure.WebPubSub.Emulator
 ```
+
+`WebPubSub:AllowUnvalidatedEntraTokens` is disabled by default. Enable it only for trusted local
+server SDK `TokenCredential` testing. This compatibility mode checks the Azure Web PubSub audience
+and token lifetime, but does not validate the signature, algorithm, issuer, tenant, identity, or
+Azure RBAC assignments. It does not change client WebSocket token validation. Server SDKs require
+an HTTPS endpoint when sending bearer tokens.
+
+When multiple listener addresses are configured, the first address in ordinal order is the
+effective endpoint.
 
 ## Pack and install the tool
 

--- a/tools/emulator/SUPPORTED_FEATURES.md
+++ b/tools/emulator/SUPPORTED_FEATURES.md
@@ -8,7 +8,7 @@ for local Azure Web PubSub development.
 | Area | Status | Notes |
 | --- | --- | --- |
 | .NET tool | Implemented | Builds and installs as `Microsoft.Azure.WebPubSub.Emulator`; runs as `awps-emulator`. |
-| Configurable host address | Implemented | Listens on `http://localhost:8080` by default and supports ASP.NET Core `Urls` configuration. |
+| Local connection settings | Implemented | Derives the endpoint from the bound ASP.NET Core `Urls` address and supports a separate `WebPubSub:AccessKey` setting. |
 | Service health | Implemented | `HEAD /api/health` returns `200 OK`. |
 | Client token authentication | Implemented | Validates access-key JWTs supplied by query string or bearer header. |
 | Raw WebSocket | Implemented | Receives group messages and publishes text or binary frames with raw `sendToGroup` mode. |
@@ -28,7 +28,7 @@ The following areas are planned for follow-up changes:
 - Reliable reconnect and message replay
 - Protobuf subprotocols
 - Client message streaming
-- Microsoft Entra ID authentication
+- Production Microsoft Entra ID validation
 
 Raw `sendEvent` mode requires an upstream event handler and is not available in the current
 implementation.

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientWebSocketEndpoint.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientWebSocketEndpoint.cs
@@ -58,7 +58,8 @@ internal sealed class ClientWebSocketEndpoint
         ClaimsPrincipal user;
         try
         {
-            user = _tokenService.ValidateClientToken(hub, accessToken);
+            var endpoint = new Uri($"{context.Request.Scheme}://{context.Request.Host}");
+            user = _tokenService.ValidateClientToken(endpoint, hub, accessToken);
         }
         catch (Exception exception) when (
             exception is SecurityTokenException or ArgumentException)

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorApplication.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorApplication.cs
@@ -22,8 +22,9 @@ internal static class EmulatorApplication
             .AddOptions<EmulatorOptions>()
             .Bind(builder.Configuration.GetSection(EmulatorOptions.SectionName))
             .Validate(
-                options => WebPubSubTokenService.IsValidConnectionString(options.ConnectionString),
-                "WebPubSub:ConnectionString must contain a valid Endpoint and AccessKey.")
+                options => EmulatorOptions.IsValidAccessKey(options.AccessKey),
+                "WebPubSub:AccessKey must be at least 32 UTF-8 bytes and cannot contain " +
+                    "leading or trailing whitespace, semicolons, or control characters.")
             .ValidateOnStart();
         builder.Services.AddSingleton(runtimeOptions ?? new EmulatorRuntimeOptions());
         builder.Services.AddSingleton<WebPubSubTokenService>();

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorOptions.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorOptions.cs
@@ -7,12 +7,25 @@ internal sealed class EmulatorOptions
 {
     public const string SectionName = "WebPubSub";
 
-    public const string DefaultConnectionString =
-        "Endpoint=http://localhost:8080;" +
-        "AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGH;" +
-        "Version=1.0;";
+    public const string DefaultAccessKey = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGH";
 
-    public string ConnectionString { get; set; } = DefaultConnectionString;
+    public string AccessKey { get; set; } = DefaultAccessKey;
+
+    public bool AllowUnvalidatedEntraTokens { get; set; }
+
+    public string GetConnectionString(Uri endpoint)
+    {
+        return $"Endpoint={endpoint.GetLeftPart(UriPartial.Authority)};" +
+            $"AccessKey={AccessKey};Version=1.0;";
+    }
+
+    internal static bool IsValidAccessKey(string? accessKey)
+    {
+        return !string.IsNullOrWhiteSpace(accessKey) &&
+            accessKey.Length == accessKey.Trim().Length &&
+            !accessKey.Any(character => character == ';' || char.IsControl(character)) &&
+            System.Text.Encoding.UTF8.GetByteCount(accessKey) >= 32;
+    }
 }
 
 internal sealed class EmulatorRuntimeOptions

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/Program.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/Program.cs
@@ -13,24 +13,25 @@ await app.RunAsync();
 
 static void WriteStartupMessage(WebApplication app)
 {
-    var server = app.Services.GetRequiredService<IServer>();
-    var addresses = server.Features
+    var addresses = app.Services
+        .GetRequiredService<IServer>()
+        .Features
         .Get<IServerAddressesFeature>()?
         .Addresses
         .OrderBy(address => address, StringComparer.Ordinal)
         .ToArray() ?? [];
+    if (addresses.Length == 0)
+    {
+        throw new InvalidOperationException("The emulator server did not report a bound address.");
+    }
 
+    var endpoint = new Uri(addresses[0]);
     var options = app.Services.GetRequiredService<IOptions<EmulatorOptions>>().Value;
-    var tokenService = app.Services.GetRequiredService<WebPubSubTokenService>();
     StartupMessageWriter.Write(
         Console.Out,
         addresses,
-        options.ConnectionString,
-        tokenService.Endpoint,
-        string.Equals(
-            options.ConnectionString,
-            EmulatorOptions.DefaultConnectionString,
-            StringComparison.Ordinal));
+        options.GetConnectionString(endpoint),
+        endpoint);
 }
 
 partial class Program;

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/StartupMessageWriter.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/StartupMessageWriter.cs
@@ -9,8 +9,7 @@ internal static class StartupMessageWriter
         TextWriter writer,
         IReadOnlyList<string> addresses,
         string connectionString,
-        Uri endpoint,
-        bool showConnectionString)
+        Uri endpoint)
     {
         writer.WriteLine();
         writer.WriteLine("===================================================");
@@ -23,9 +22,7 @@ internal static class StartupMessageWriter
         }
         writer.WriteLine();
         writer.WriteLine("Connection string:");
-        writer.WriteLine(showConnectionString
-            ? $"  {connectionString}"
-            : "  Configured (AccessKey hidden).");
+        writer.WriteLine($"  {connectionString}");
         writer.WriteLine();
         writer.WriteLine("Client endpoint:");
         writer.WriteLine($"  {GetClientEndpoint(endpoint)}");

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubTokenService.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubTokenService.cs
@@ -13,28 +13,40 @@ namespace Microsoft.Azure.WebPubSub.Emulator;
 internal sealed class WebPubSubTokenService
 {
     internal const string ClientPathPrefix = "/client/hubs/";
+    private const string WebPubSubAudience = "https://webpubsub.azure.com";
 
     private readonly JwtSecurityTokenHandler _handler = new();
-    private readonly Uri _endpoint;
     private readonly SymmetricSecurityKey _signingKey;
+    private readonly bool _allowUnvalidatedEntraTokens;
     private readonly ILogger<WebPubSubTokenService> _logger;
 
     public WebPubSubTokenService(
         IOptions<EmulatorOptions> options,
         ILogger<WebPubSubTokenService> logger)
     {
-        (_endpoint, var accessKey) = ParseRequiredConnectionString(options.Value.ConnectionString);
-        _signingKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(accessKey));
+        var emulatorOptions = options.Value;
+        _signingKey = new SymmetricSecurityKey(
+            Encoding.UTF8.GetBytes(emulatorOptions.AccessKey));
+        _allowUnvalidatedEntraTokens = emulatorOptions.AllowUnvalidatedEntraTokens;
         _logger = logger;
+
+        if (_allowUnvalidatedEntraTokens)
+        {
+            _logger.LogWarning(
+                "WebPubSub:AllowUnvalidatedEntraTokens is enabled. Azure Web PubSub audience tokens " +
+                "will be accepted without validating their signature, algorithm, issuer, tenant, " +
+                "identity, or RBAC assignments. Use this setting only for trusted local development.");
+        }
     }
 
-    internal Uri Endpoint => _endpoint;
-
-    public ClaimsPrincipal ValidateClientToken(string hub, string token)
+    public ClaimsPrincipal ValidateClientToken(Uri endpoint, string hub, string token)
     {
         try
         {
-            return _handler.ValidateToken(token, CreateValidationParameters(GetClientAudience(hub)), out _);
+            return _handler.ValidateToken(
+                token,
+                CreateValidationParameters(GetClientAudience(endpoint, hub)),
+                out _);
         }
         catch (Exception exception) when (exception is SecurityTokenException or ArgumentException)
         {
@@ -43,20 +55,52 @@ internal sealed class WebPubSubTokenService
         }
     }
 
-    internal static bool IsValidConnectionString(string? connectionString)
+    public bool ValidateRestToken(Uri requestUri, string token)
     {
-        if (string.IsNullOrWhiteSpace(connectionString))
+        JwtSecurityToken jwt;
+        try
         {
+            jwt = _handler.ReadJwtToken(token);
+        }
+        catch (ArgumentException exception)
+        {
+            _logger.LogDebug(
+                exception,
+                "REST access token could not be parsed for {Path}.",
+                requestUri.AbsolutePath);
             return false;
+        }
+
+        if (jwt.Audiences.Contains(WebPubSubAudience, StringComparer.Ordinal))
+        {
+            if (!_allowUnvalidatedEntraTokens)
+            {
+                _logger.LogDebug(
+                    "Rejected an Azure Web PubSub audience token because unvalidated Entra token " +
+                    "compatibility is disabled.");
+                return false;
+            }
+
+            var now = DateTime.UtcNow;
+            return jwt.ValidFrom <= now.AddMinutes(5) &&
+                jwt.ValidTo >= now.Subtract(TimeSpan.FromMinutes(5));
         }
 
         try
         {
-            _ = ParseRequiredConnectionString(connectionString);
+            _handler.ValidateToken(
+                token,
+                CreateValidationParameters(requestUri.AbsoluteUri),
+                out _);
             return true;
         }
-        catch (Exception exception) when (exception is InvalidOperationException or UriFormatException)
+        catch (Exception exception) when (
+            exception is SecurityTokenException or ArgumentException)
         {
+            _logger.LogDebug(
+                exception,
+                "REST access token validation failed for {Path}.",
+                requestUri.AbsolutePath);
             return false;
         }
     }
@@ -76,47 +120,10 @@ internal sealed class WebPubSubTokenService
         };
     }
 
-    private string GetClientAudience(string hub)
+    private static string GetClientAudience(Uri endpoint, string hub)
     {
         return new Uri(
-            _endpoint,
+            endpoint,
             $"{ClientPathPrefix.TrimStart('/')}{Uri.EscapeDataString(hub)}").AbsoluteUri;
-    }
-
-    private static (Uri Endpoint, string AccessKey) ParseRequiredConnectionString(string connectionString)
-    {
-        var values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var part in connectionString.Split(';', StringSplitOptions.RemoveEmptyEntries))
-        {
-            var separator = part.IndexOf('=');
-            if (separator <= 0 || separator == part.Length - 1)
-            {
-                throw new InvalidOperationException("ConnectionString is invalid.");
-            }
-
-            values[part[..separator].Trim()] = part[(separator + 1)..].Trim();
-        }
-
-        if (!values.TryGetValue("Endpoint", out var endpoint) || string.IsNullOrWhiteSpace(endpoint))
-        {
-            throw new InvalidOperationException("ConnectionString must contain Endpoint.");
-        }
-        if (!values.TryGetValue("AccessKey", out var accessKey) || string.IsNullOrWhiteSpace(accessKey))
-        {
-            throw new InvalidOperationException("ConnectionString must contain AccessKey.");
-        }
-
-        var endpointUri = new Uri(endpoint, UriKind.Absolute);
-        if ((!endpointUri.Scheme.Equals(Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) &&
-            !endpointUri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)) ||
-            endpointUri.AbsolutePath != "/" ||
-            !string.IsNullOrEmpty(endpointUri.Query) ||
-            !string.IsNullOrEmpty(endpointUri.Fragment))
-        {
-            throw new InvalidOperationException(
-                "ConnectionString Endpoint must be an HTTP or HTTPS origin without a path, query, or fragment.");
-        }
-
-        return (endpointUri, accessKey);
     }
 }

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/appsettings.json
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/appsettings.json
@@ -1,7 +1,8 @@
 {
   "Urls": "http://localhost:8080",
   "WebPubSub": {
-    "ConnectionString": "Endpoint=http://localhost:8080;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGH;Version=1.0;"
+    "AccessKey": "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGH",
+    "AllowUnvalidatedEntraTokens": false
   },
   "Logging": {
     "LogLevel": {

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/ClientWebSocketEndpointTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/ClientWebSocketEndpointTests.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Azure.WebPubSub.Emulator.Tests;
 public class ClientWebSocketEndpointTests
 {
     private const string Hub = "chat";
-    private const string AccessKey = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGH";
     private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(10);
 
     [Fact]
@@ -114,7 +113,7 @@ public class ClientWebSocketEndpointTests
         await using var application = await StartApplicationAsync();
         var client = application.GetTestServer().CreateWebSocketClient();
         client.SubProtocols.Add("custom.protocol");
-        var uri = CreateClientUri(application);
+        var uri = CreateClientUri();
 
         using var webSocket = await client.ConnectAsync(uri, CancellationToken.None)
             .WaitAsync(TestTimeout);
@@ -127,7 +126,7 @@ public class ClientWebSocketEndpointTests
     {
         await using var application = await StartApplicationAsync();
         var client = application.GetTestServer().CreateWebSocketClient();
-        var uri = CreateClientUri(application, query: "webpubsub_mode=");
+        var uri = CreateClientUri(query: "webpubsub_mode=");
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
             () => client.ConnectAsync(uri, CancellationToken.None));
@@ -191,13 +190,12 @@ public class ClientWebSocketEndpointTests
         IEnumerable<string>? groups = null,
         string? query = null)
     {
-        var uri = CreateClientUri(application, roles, groups, query);
+        var uri = CreateClientUri(roles, groups, query);
         var client = application.GetTestServer().CreateWebSocketClient();
         return await client.ConnectAsync(uri, CancellationToken.None).WaitAsync(TestTimeout);
     }
 
     private static Uri CreateClientUri(
-        WebApplication application,
         IEnumerable<string>? roles = null,
         IEnumerable<string>? groups = null,
         string? query = null)
@@ -219,11 +217,11 @@ public class ClientWebSocketEndpointTests
             .Select(role => new Claim("role", role))
             .Concat(groups.Select(group => new Claim("webpubsub.group", group)));
         var token = new JwtSecurityToken(
-            audience: $"http://localhost:8080/client/hubs/{Hub}",
+            audience: $"http://localhost{WebPubSubTokenService.ClientPathPrefix}{Hub}",
             claims: claims,
             expires: DateTime.UtcNow.AddHours(1),
             signingCredentials: new SigningCredentials(
-                new SymmetricSecurityKey(Encoding.UTF8.GetBytes(AccessKey)),
+                new SymmetricSecurityKey(Encoding.UTF8.GetBytes(EmulatorOptions.DefaultAccessKey)),
                 SecurityAlgorithms.HmacSha256));
         return new JwtSecurityTokenHandler().WriteToken(token);
     }

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/EmulatorApplicationTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/EmulatorApplicationTests.cs
@@ -2,11 +2,16 @@
 // Licensed under the MIT License.
 
 using System;
+using System.IdentityModel.Tokens.Jwt;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace Microsoft.Azure.WebPubSub.Emulator.Tests;
@@ -15,13 +20,79 @@ public class EmulatorApplicationTests
 {
     private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(30);
 
-    [Theory]
-    [InlineData("Endpoint=http://localhost:8080/base;AccessKey=key;Version=1.0;")]
-    [InlineData("Endpoint=http://localhost:8080?query=value;AccessKey=key;Version=1.0;")]
-    [InlineData("Endpoint=ftp://localhost:8080;AccessKey=key;Version=1.0;")]
-    public void ConnectionStringEndpointMustBeAnOrigin(string connectionString)
+    [Fact]
+    public async Task EffectiveEndpointComesFromBoundAddress()
     {
-        Assert.False(WebPubSubTokenService.IsValidConnectionString(connectionString));
+        const string accessKey = "custom-emulator-access-key-1234567890";
+        await using var application = EmulatorApplication.Build(
+            [
+                "--urls=http://127.0.0.1:0",
+                $"--WebPubSub:AccessKey={accessKey}",
+            ]);
+        await application.StartAsync().WaitAsync(TestTimeout);
+
+        var server = application.Services.GetRequiredService<IServer>();
+        var address = Assert.Single(
+            server.Features.Get<IServerAddressesFeature>()!.Addresses);
+        var options = application.Services
+            .GetRequiredService<IOptions<EmulatorOptions>>()
+            .Value;
+
+        Assert.NotEqual(0, new Uri(address).Port);
+        Assert.Equal(
+            $"Endpoint={new Uri(address).GetLeftPart(UriPartial.Authority)};" +
+                $"AccessKey={accessKey};Version=1.0;",
+            options.GetConnectionString(new Uri(address)));
+    }
+
+    [Theory]
+    [InlineData(false, 60, false)]
+    [InlineData(true, 60, true)]
+    [InlineData(true, -10, false)]
+    public async Task WebPubSubAudienceTokenRequiresExplicitCompatibilityMode(
+        bool allowUnvalidatedEntraTokens,
+        int expiresInMinutes,
+        bool expected)
+    {
+        var builder = EmulatorApplication.CreateBuilder(
+            [$"--WebPubSub:AllowUnvalidatedEntraTokens={allowUnvalidatedEntraTokens}"]);
+        builder.WebHost.UseTestServer();
+        await using var application = EmulatorApplication.Build(builder);
+        await application.StartAsync().WaitAsync(TestTimeout);
+        var now = DateTime.UtcNow;
+        var token = new JwtSecurityToken(
+            audience: "https://webpubsub.azure.com",
+            notBefore: now.AddMinutes(Math.Min(-1, expiresInMinutes - 1)),
+            expires: now.AddMinutes(expiresInMinutes));
+        var encodedToken = new JwtSecurityTokenHandler().WriteToken(token);
+        var tokenService =
+            application.Services.GetRequiredService<WebPubSubTokenService>();
+
+        var actual = tokenService.ValidateRestToken(
+            new Uri("http://localhost/api/hubs/chat/:send"),
+            encodedToken);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData("too-short")]
+    [InlineData("custom-emulator-access-key-12345;67890")]
+    [InlineData(" custom-emulator-access-key-1234567890")]
+    public async Task InvalidAccessKeyConfigurationIsRejected(string accessKey)
+    {
+        var builder = EmulatorApplication.CreateBuilder(
+            [$"--WebPubSub:AccessKey={accessKey}"]);
+        builder.WebHost.UseTestServer();
+        await using var application = EmulatorApplication.Build(builder);
+
+        var exception = await Assert.ThrowsAsync<OptionsValidationException>(
+            () => application.StartAsync());
+
+        Assert.Contains(
+            "WebPubSub:AccessKey must be at least 32 UTF-8 bytes",
+            exception.Message,
+            StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/StartupMessageWriterTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/StartupMessageWriterTests.cs
@@ -20,14 +20,12 @@ public class StartupMessageWriterTests
             writer,
             ["http://127.0.0.1:8090"],
             connectionString,
-            new Uri("https://localhost:8443"),
-            showConnectionString: false);
+            new Uri("https://localhost:8443"));
 
         var message = writer.ToString();
         Assert.Contains(
-            "Connection string:" + Environment.NewLine + "  Configured (AccessKey hidden).",
+            "Connection string:" + Environment.NewLine + $"  {connectionString}",
             message);
-        Assert.DoesNotContain("local-key", message);
         Assert.Contains(
             "Client endpoint:" + Environment.NewLine +
                 "  wss://localhost:8443/client/hubs/{hub}?access_token={token}",
@@ -36,17 +34,19 @@ public class StartupMessageWriterTests
     }
 
     [Fact]
-    public void WriteIncludesBuiltInConnectionString()
+    public void WriteIncludesGeneratedDefaultConnectionString()
     {
+        const string connectionString =
+            "Endpoint=http://localhost:8080;" +
+            $"AccessKey={EmulatorOptions.DefaultAccessKey};Version=1.0;";
         using var writer = new StringWriter();
 
         StartupMessageWriter.Write(
             writer,
             ["http://localhost:8080"],
-            EmulatorOptions.DefaultConnectionString,
-            new Uri("http://localhost:8080"),
-            showConnectionString: true);
+            connectionString,
+            new Uri("http://localhost:8080"));
 
-        Assert.Contains(EmulatorOptions.DefaultConnectionString, writer.ToString());
+        Assert.Contains(connectionString, writer.ToString());
     }
 }


### PR DESCRIPTION
## Summary

- derive the emulator endpoint and displayed connection string from the actual bound listener address
- configure `WebPubSub:AccessKey` independently with a deterministic local default and validate client tokens against the request authority
- add opt-in `WebPubSub:AllowUnvalidatedEntraTokens` compatibility for trusted local server SDK testing
- update emulator configuration, startup output, documentation, and targeted tests

`DisableLocalAuth` is intentionally not added because the current emulator surface has no server REST operations where disabling key-based server authentication would be meaningful.

## Testing

- `dotnet test tools\emulator\tests\Microsoft.Azure.WebPubSub.Emulator.Tests\Microsoft.Azure.WebPubSub.Emulator.Tests.csproj --configuration Release --no-restore` (29 passed)
- verified a live dynamic-port startup prints the bound port in the generated connection string and returns `200` from `/api/health`