### PR TITLE
deps: bump lodash to 4.18.0 in awps-tunnel client

### DIFF
--- a/tools/awps-tunnel/client/package.json
+++ b/tools/awps-tunnel/client/package.json
@@ -97,7 +97,7 @@
     "jsonpath": "1.3.0",
     "launch-editor": "2.14.1",
     "linkify-it": "5.0.2",
-    "lodash": "4.17.21",
+    "lodash": "4.18.0",
     "markdown-it": "14.2.0",
     "mdast-util-to-hast": "13.2.1",
     "micromatch": "4.0.8",

--- a/tools/awps-tunnel/client/yarn.lock
+++ b/tools/awps-tunnel/client/yarn.lock
@@ -9112,10 +9112,10 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==
 
-lodash@4.17.21, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
-  version "4.17.21"
-  resolved "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw=
+lodash@4.18.0, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
+  version "4.18.0"
+  resolved "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lodash/-/lodash-4.18.0.tgz#dfd726f07ab2e39dd763de28fcf66e395c03e440"
+  integrity sha1-39cm8Hqy453XY94o/PZuOVwD5EA=
 
 longest-streak@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
Bumps the `lodash` resolution in `tools/awps-tunnel/client` from `4.17.21` to `4.18.0`, clearing 3 Dependabot alerts (1 High, 2 Moderate).

### Why this is needed even though #1050 already bumped lodash

#1050 bumped the **root** `resolutions`. That does **not** cover this package:

| location | lodash on disk |
| --- | --- |
| `node_modules/lodash` (root) | 4.18.0 |
| `tools/awps-tunnel/client/node_modules/lodash` | **4.17.21** |

Although `tools/awps-tunnel/client/` is listed in the root `workspaces` field, it also has its **own** `package.json` (with its own 39-entry `resolutions` block) and its **own** `yarn.lock`, and CI runs a separate `yarn` install there. Node resolves the nearest `node_modules` first, so the client's React bundle was still being built against vulnerable lodash.

### The pin was itself the vulnerability

`resolutions.lodash` was pinned at `4.17.21` — a pin added for an older advisory that had since drifted **inside** the vulnerable range:

```
pinned    : 4.17.21
advisory  : vulnerable >= 4.0.0, <= 4.17.23 ; patched 4.18.0
```

So the resolution was actively *holding* lodash on a vulnerable version rather than protecting it.

### Alerts cleared

| Severity | GHSA | Vulnerable range | Patched |
| --- | --- | --- | --- |
| High | GHSA-r5fr-rjxr-66jc | `>= 4.0.0, <= 4.17.23` | 4.18.0 |
| Moderate | GHSA-f23m-r3pf-42rh | `<= 4.17.23` | 4.18.0 |
| Moderate | GHSA-xxjr-mmjv-4gpg | `>= 4.0.0, <= 4.17.22` | 4.17.23 |

`lodash@4.18.0` has **0** matching advisories.

### Validation

- `yarn install` → lockfile collapses all 5 lodash requesters to a single `lodash@4.18.0`
- on-disk `node_modules/lodash/package.json` → `4.18.0` (verified, not inferred)
- `yarn build` → passes; bundle `450.68 kB` (+613 B, expected size delta for 4.18.0)
- `yarn test --watchAll=false` → 1/1 passed
- `yarn lint` → passes
- no other lockfile in the repo is modified (diff is 2 files / 5 lines)

### Deliberately not included

These alerts in the same lockfile are **not** safe to fix by a resolution and are left for separate work:

- **`webpack-dev-server`** (6 moderate) — installed 4.15.2; every patch is 5.x. `react-scripts@5.0.1` declares `^4.6.0` and its `config/webpackDevServer.config.js` uses `https:`, `onBeforeSetupMiddleware` and `onAfterSetupMiddleware`, all **removed** in WDS 5. Forcing it keeps CI green (`react-scripts build` never loads the dev server) while silently breaking `react-scripts start` for every developer.
- **`react-router` / `react-router-dom`** (3 moderate) — `react-router-dom@6.30.4` is a direct dependency with **no patched 6.x** available; the only fix is the 7.x major, which needs a real v6→v7 migration.
- **`@tootallnate/once`** (1 low) — parent `http-proxy-agent@^4.0.1` declares `@tootallnate/once@1`; forcing 2.x would violate its declared range.
