### PR TITLE
deps: bump api-extractor to 7.58.13 to clear lodash and minimatch CVEs

### DIFF
--- a/sdk/webpubsub-socketio-extension/package.json
+++ b/sdk/webpubsub-socketio-extension/package.json
@@ -58,7 +58,7 @@
     "lint:fix": "eslint src --ext .ts,.javascript,.js --fix"
   },
   "devDependencies": {
-    "@microsoft/api-extractor": "7.47.0",
+    "@microsoft/api-extractor": "7.58.13",
     "@types/debug": "^4.1.7",
     "@types/engine.io": "^3.1.7",
     "@types/expect.js": "^0.3.29",

--- a/sdk/webpubsub-socketio-extension/review/web-pubsub-socket.io.api.md
+++ b/sdk/webpubsub-socketio-extension/review/web-pubsub-socket.io.api.md
@@ -4,8 +4,6 @@
 
 ```ts
 
-/// <reference types="node" />
-
 import { AzureKeyCredential } from '@azure/core-auth';
 import { IncomingMessage } from 'http';
 import { ServerResponse } from 'http';

--- a/sdk/webpubsub-socketio-extension/yarn.lock
+++ b/sdk/webpubsub-socketio-extension/yarn.lock
@@ -670,33 +670,33 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@microsoft/api-extractor-model@7.29.2":
-  version "7.29.2"
-  resolved "https://packagefeedproxy.microsoft.io/npm/@microsoft/api-extractor-model/-/api-extractor-model-7.29.2.tgz"
-  integrity sha512-hAYajOjQan3uslhKJRwvvHIdLJ+ZByKqdSsJ/dgHFxPtEbdKpzMDO8zuW4K5gkSMYl5D0LbNwxkhxr51P2zsmw==
+"@microsoft/api-extractor-model@7.33.11":
+  version "7.33.11"
+  resolved "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@microsoft/api-extractor-model/-/api-extractor-model-7.33.11.tgz#bd0176a07f6aaa02da10c12283347ef7ad890a28"
+  integrity sha1-vQF2oH9qqgLaEMEigzR+962JCig=
   dependencies:
-    "@microsoft/tsdoc" "~0.15.0"
-    "@microsoft/tsdoc-config" "~0.17.0"
-    "@rushstack/node-core-library" "5.4.1"
+    "@microsoft/tsdoc" "~0.16.0"
+    "@microsoft/tsdoc-config" "~0.18.1"
+    "@rushstack/node-core-library" "5.24.0"
 
-"@microsoft/api-extractor@7.47.0":
-  version "7.47.0"
-  resolved "https://packagefeedproxy.microsoft.io/npm/@microsoft/api-extractor/-/api-extractor-7.47.0.tgz"
-  integrity sha512-LT8yvcWNf76EpDC+8/ArTVSYePvuDQ+YbAUrsTcpg3ptiZ93HIcMCozP/JOxDt+rrsFfFHcpfoselKfPyRI0GQ==
+"@microsoft/api-extractor@7.58.13":
+  version "7.58.13"
+  resolved "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@microsoft/api-extractor/-/api-extractor-7.58.13.tgz#423064e174aaf0db821296f271fc530cd3cc5910"
+  integrity sha1-QjBk4XSq8NuCEpbycfxTDNPMWRA=
   dependencies:
-    "@microsoft/api-extractor-model" "7.29.2"
-    "@microsoft/tsdoc" "~0.15.0"
-    "@microsoft/tsdoc-config" "~0.17.0"
-    "@rushstack/node-core-library" "5.4.1"
-    "@rushstack/rig-package" "0.5.2"
-    "@rushstack/terminal" "0.13.0"
-    "@rushstack/ts-command-line" "4.22.0"
-    lodash "~4.17.15"
-    minimatch "~3.0.3"
+    "@microsoft/api-extractor-model" "7.33.11"
+    "@microsoft/tsdoc" "~0.16.0"
+    "@microsoft/tsdoc-config" "~0.18.1"
+    "@rushstack/node-core-library" "5.24.0"
+    "@rushstack/rig-package" "0.7.3"
+    "@rushstack/terminal" "0.24.3"
+    "@rushstack/ts-command-line" "5.3.13"
+    diff "~8.0.2"
+    minimatch "10.2.3"
     resolve "~1.22.1"
-    semver "~7.5.4"
+    semver "~7.7.4"
     source-map "~0.6.1"
-    typescript "5.4.2"
+    typescript "5.9.3"
 
 "@microsoft/tsdoc-config@0.16.2":
   version "0.16.2"
@@ -708,13 +708,13 @@
     jju "~1.4.0"
     resolve "~1.19.0"
 
-"@microsoft/tsdoc-config@~0.17.0":
-  version "0.17.0"
-  resolved "https://packagefeedproxy.microsoft.io/npm/@microsoft/tsdoc-config/-/tsdoc-config-0.17.0.tgz"
-  integrity sha512-v/EYRXnCAIHxOHW+Plb6OWuUoMotxTN0GLatnpOb1xq0KuTNw/WI3pamJx/UbsoJP5k9MCw1QxvvhPcF9pH3Zg==
+"@microsoft/tsdoc-config@~0.18.1":
+  version "0.18.1"
+  resolved "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@microsoft/tsdoc-config/-/tsdoc-config-0.18.1.tgz#7c560bce62abb5f9681e4d231b9ac35553b7e86b"
+  integrity sha1-fFYLzmKrtfloHk0jG5rDVVO36Gs=
   dependencies:
-    "@microsoft/tsdoc" "0.15.0"
-    ajv "~8.12.0"
+    "@microsoft/tsdoc" "0.16.0"
+    ajv "~8.18.0"
     jju "~1.4.0"
     resolve "~1.22.2"
 
@@ -723,10 +723,10 @@
   resolved "https://packagefeedproxy.microsoft.io/npm/@microsoft/tsdoc/-/tsdoc-0.14.2.tgz"
   integrity sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==
 
-"@microsoft/tsdoc@0.15.0", "@microsoft/tsdoc@~0.15.0":
-  version "0.15.0"
-  resolved "https://packagefeedproxy.microsoft.io/npm/@microsoft/tsdoc/-/tsdoc-0.15.0.tgz"
-  integrity sha512-HZpPoABogPvjeJOdzCOSJsXeL/SMCBgBZMVC3X3d7YYp2gf31MfxhUoYUNwf1ERPJOnQc0wkFn9trqI6ZEdZuA==
+"@microsoft/tsdoc@0.16.0", "@microsoft/tsdoc@~0.16.0":
+  version "0.16.0"
+  resolved "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz#2249090633e04063176863a050c8f0808d2b6d2b"
+  integrity sha1-IkkJBjPgQGMXaGOgUMjwgI0rbSs=
 
 "@msgpack/msgpack@^3.0.0-beta2":
   version "3.1.3"
@@ -771,42 +771,48 @@
   resolved "https://packagefeedproxy.microsoft.io/npm/@rtsao/scc/-/scc-1.1.0.tgz"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
-"@rushstack/node-core-library@5.4.1":
-  version "5.4.1"
-  resolved "https://packagefeedproxy.microsoft.io/npm/@rushstack/node-core-library/-/node-core-library-5.4.1.tgz"
-  integrity sha512-WNnwdS8r9NZ/2K3u29tNoSRldscFa7SxU0RT+82B6Dy2I4Hl2MeCSKm4EXLXPKeNzLGvJ1cqbUhTLviSF8E6iA==
+"@rushstack/node-core-library@5.24.0":
+  version "5.24.0"
+  resolved "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rushstack/node-core-library/-/node-core-library-5.24.0.tgz#036c5cfc3b61ed6f5d7f02bfa0a4c6998c88b75c"
+  integrity sha1-A2xc/Dth7W9dfwK/oKTGmYyIt1w=
   dependencies:
-    ajv "~8.13.0"
+    ajv "~8.20.0"
     ajv-draft-04 "~1.0.0"
     ajv-formats "~3.0.1"
-    fs-extra "~7.0.1"
+    fs-extra "~11.3.0"
     import-lazy "~4.0.0"
     jju "~1.4.0"
     resolve "~1.22.1"
-    semver "~7.5.4"
+    semver "~7.7.4"
 
-"@rushstack/rig-package@0.5.2":
-  version "0.5.2"
-  resolved "https://packagefeedproxy.microsoft.io/npm/@rushstack/rig-package/-/rig-package-0.5.2.tgz"
-  integrity sha512-mUDecIJeH3yYGZs2a48k+pbhM6JYwWlgjs2Ca5f2n1G2/kgdgP9D/07oglEGf6mRyXEnazhEENeYTSNDRCwdqA==
+"@rushstack/problem-matcher@0.2.1":
+  version "0.2.1"
+  resolved "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rushstack/problem-matcher/-/problem-matcher-0.2.1.tgz#e9f6cac2dd6a882d60e76a8d4462b7d24b4f17e5"
+  integrity sha1-6fbKwt1qiC1g52qNRGK30ktPF+U=
+
+"@rushstack/rig-package@0.7.3":
+  version "0.7.3"
+  resolved "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rushstack/rig-package/-/rig-package-0.7.3.tgz#d28a5440b1e9f43046727ba7009d18d99314f251"
+  integrity sha1-0opUQLHp9DBGcnunAJ0Y2ZMU8lE=
   dependencies:
+    jju "~1.4.0"
     resolve "~1.22.1"
-    strip-json-comments "~3.1.1"
 
-"@rushstack/terminal@0.13.0":
-  version "0.13.0"
-  resolved "https://packagefeedproxy.microsoft.io/npm/@rushstack/terminal/-/terminal-0.13.0.tgz"
-  integrity sha512-Ou44Q2s81BqJu3dpYedAX54am9vn245F0HzqVrfJCMQk5pGgoKKOBOjkbfZC9QKcGNaECh6pwH2s5noJt7X6ew==
+"@rushstack/terminal@0.24.3":
+  version "0.24.3"
+  resolved "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rushstack/terminal/-/terminal-0.24.3.tgz#008e35748d892789caadb67b0201ec22433df6b1"
+  integrity sha1-AI41dI2JJ4nKrbZ7AgHsIkM99rE=
   dependencies:
-    "@rushstack/node-core-library" "5.4.1"
+    "@rushstack/node-core-library" "5.24.0"
+    "@rushstack/problem-matcher" "0.2.1"
     supports-color "~8.1.1"
 
-"@rushstack/ts-command-line@4.22.0":
-  version "4.22.0"
-  resolved "https://packagefeedproxy.microsoft.io/npm/@rushstack/ts-command-line/-/ts-command-line-4.22.0.tgz"
-  integrity sha512-Qj28t6MO3HRgAZ72FDeFsrpdE6wBWxF3VENgvrXh7JF2qIT+CrXiOJIesW80VFZB9QwObSpkB1ilx794fGQg6g==
+"@rushstack/ts-command-line@5.3.13":
+  version "5.3.13"
+  resolved "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rushstack/ts-command-line/-/ts-command-line-5.3.13.tgz#9fef63098215bb6490ede5bde5345df5d3cc8038"
+  integrity sha1-n+9jCYIVu2SQ7eW95TRd9dPMgDg=
   dependencies:
-    "@rushstack/terminal" "0.13.0"
+    "@rushstack/terminal" "0.24.3"
     "@types/argparse" "1.0.38"
     argparse "~1.0.9"
     string-argv "~0.3.1"
@@ -1292,7 +1298,7 @@ ajv@^6.12.4:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.0:
+ajv@^8.0.0, ajv@~8.20.0:
   version "8.20.0"
   resolved "https://packagefeedproxy.microsoft.io/npm/ajv/-/ajv-8.20.0.tgz"
   integrity sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==
@@ -1312,25 +1318,15 @@ ajv@~6.12.6:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@~8.12.0:
-  version "8.12.0"
-  resolved "https://packagefeedproxy.microsoft.io/npm/ajv/-/ajv-8.12.0.tgz"
-  integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
-  dependencies:
-    fast-deep-equal "^3.1.1"
-    json-schema-traverse "^1.0.0"
-    require-from-string "^2.0.2"
-    uri-js "^4.2.2"
-
-ajv@~8.13.0:
-  version "8.13.0"
-  resolved "https://packagefeedproxy.microsoft.io/npm/ajv/-/ajv-8.13.0.tgz"
-  integrity sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==
+ajv@~8.18.0:
+  version "8.18.0"
+  resolved "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ajv/-/ajv-8.18.0.tgz#8864186b6738d003eb3a933172bb3833e10cefbc"
+  integrity sha1-iGQYa2c40APrOpMxcrs4M+EM77w=
   dependencies:
     fast-deep-equal "^3.1.3"
+    fast-uri "^3.0.1"
     json-schema-traverse "^1.0.0"
     require-from-string "^2.0.2"
-    uri-js "^4.4.1"
 
 ansi-escapes@^4.2.1:
   version "4.3.2"
@@ -1561,6 +1557,11 @@ balanced-match@^1.0.0:
   resolved "https://packagefeedproxy.microsoft.io/npm/balanced-match/-/balanced-match-1.0.2.tgz"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+balanced-match@^4.0.2:
+  version "4.0.4"
+  resolved "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
+  integrity sha1-v7EGYv7tgZaixi58aOF3IMJ0F5o=
+
 base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://packagefeedproxy.microsoft.io/npm/base64-js/-/base64-js-1.5.1.tgz"
@@ -1606,6 +1607,13 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+brace-expansion@^5.0.2:
+  version "5.0.9"
+  resolved "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-5.0.9.tgz#7c72438809b5fa5babf54199a1f1c281a6984fcf"
+  integrity sha1-fHJDiAm1+lur9UGZofHCgaaYT88=
+  dependencies:
+    balanced-match "^4.0.2"
 
 braces@^3.0.3:
   version "3.0.3"
@@ -2029,6 +2037,11 @@ diff-sequences@^29.6.3:
   version "29.6.3"
   resolved "https://packagefeedproxy.microsoft.io/npm/diff-sequences/-/diff-sequences-29.6.3.tgz"
   integrity sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==
+
+diff@~8.0.2:
+  version "8.0.4"
+  resolved "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/diff/-/diff-8.0.4.tgz#4f5baf3188b9b2431117b962eb20ba330fadf696"
+  integrity sha1-T1uvMYi5skMRF7li6yC6Mw+t9pY=
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -2729,14 +2742,14 @@ fresh@~0.5.2:
   resolved "https://packagefeedproxy.microsoft.io/npm/fresh/-/fresh-0.5.2.tgz"
   integrity sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==
 
-fs-extra@~7.0.1:
-  version "7.0.1"
-  resolved "https://packagefeedproxy.microsoft.io/npm/fs-extra/-/fs-extra-7.0.1.tgz"
-  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
+fs-extra@~11.3.0:
+  version "11.3.6"
+  resolved "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fs-extra/-/fs-extra-11.3.6.tgz#f7cb80e9df550cd1db6f537fa5cdd568d3e70d10"
+  integrity sha1-98uA6d9VDNHbb1N/pc3VaNPnDRA=
   dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -2900,7 +2913,7 @@ gopd@^1.0.1, gopd@^1.2.0:
   resolved "https://packagefeedproxy.microsoft.io/npm/gopd/-/gopd-1.2.0.tgz"
   integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.10, graceful-fs@^4.2.9:
+graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.10, graceful-fs@^4.2.9:
   version "4.2.11"
   resolved "https://packagefeedproxy.microsoft.io/npm/graceful-fs/-/graceful-fs-4.2.11.tgz"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -3845,10 +3858,12 @@ json5@^2.2.3:
   resolved "https://packagefeedproxy.microsoft.io/npm/json5/-/json5-2.2.3.tgz"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
-jsonfile@^4.0.0:
-  version "4.0.0"
-  resolved "https://packagefeedproxy.microsoft.io/npm/jsonfile/-/jsonfile-4.0.0.tgz"
-  integrity sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==
+jsonfile@^6.0.1:
+  version "6.2.1"
+  resolved "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jsonfile/-/jsonfile-6.2.1.tgz#b6e31717f22cc37330b081ce0051ed5de53af2f6"
+  integrity sha1-tuMXF/Isw3MwsIHOAFHtXeU68vY=
+  dependencies:
+    universalify "^2.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
 
@@ -3983,11 +3998,6 @@ lodash.once@^4.0.0:
   version "4.1.1"
   resolved "https://packagefeedproxy.microsoft.io/npm/lodash.once/-/lodash.once-4.1.1.tgz"
   integrity sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==
-
-lodash@~4.17.15:
-  version "4.17.21"
-  resolved "https://packagefeedproxy.microsoft.io/npm/lodash/-/lodash-4.17.21.tgz"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 log-symbols@^4.0.0:
   version "4.1.0"
@@ -4157,17 +4167,17 @@ min-indent@^1.0.0:
   resolved "https://packagefeedproxy.microsoft.io/npm/min-indent/-/min-indent-1.0.1.tgz"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
+minimatch@10.2.3:
+  version "10.2.3"
+  resolved "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minimatch/-/minimatch-10.2.3.tgz#c0ef582f21071b0123a5bbf275252ebda921fbf6"
+  integrity sha1-wO9YLyEHGwEjpbvydSUuvakh+/Y=
+  dependencies:
+    brace-expansion "^5.0.2"
+
 minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.5"
   resolved "https://packagefeedproxy.microsoft.io/npm/minimatch/-/minimatch-3.1.5.tgz"
   integrity sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==
-  dependencies:
-    brace-expansion "^1.1.7"
-
-minimatch@~3.0.3:
-  version "3.0.8"
-  resolved "https://packagefeedproxy.microsoft.io/npm/minimatch/-/minimatch-3.0.8.tgz"
-  integrity sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==
   dependencies:
     brace-expansion "^1.1.7"
 
@@ -4830,12 +4840,10 @@ semver@^7.3.4, semver@^7.3.7, semver@^7.3.8, semver@^7.5.3, semver@^7.5.4, semve
   resolved "https://packagefeedproxy.microsoft.io/npm/semver/-/semver-7.8.5.tgz"
   integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
 
-semver@~7.5.4:
-  version "7.5.4"
-  resolved "https://packagefeedproxy.microsoft.io/npm/semver/-/semver-7.5.4.tgz"
-  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
-  dependencies:
-    lru-cache "^6.0.0"
+semver@~7.7.4:
+  version "7.7.4"
+  resolved "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
+  integrity sha1-KEZONgYOmR+noR0CedLT87V6foo=
 
 send@~0.19.0, send@~0.19.1:
   version "0.19.2"
@@ -5161,7 +5169,7 @@ strip-indent@^3.0.0:
   dependencies:
     min-indent "^1.0.0"
 
-strip-json-comments@^3.1.1, strip-json-comments@~3.1.1:
+strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://packagefeedproxy.microsoft.io/npm/strip-json-comments/-/strip-json-comments-3.1.1.tgz"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
@@ -5402,15 +5410,10 @@ typed-array-length@^1.0.7:
     possible-typed-array-names "^1.1.0"
     reflect.getprototypeof "^1.0.10"
 
-typescript@5.4.2:
-  version "5.4.2"
-  resolved "https://packagefeedproxy.microsoft.io/npm/typescript/-/typescript-5.4.2.tgz"
-  integrity sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==
-
-typescript@^5.0.3:
+typescript@5.9.3, typescript@^5.0.3:
   version "5.9.3"
-  resolved "https://packagefeedproxy.microsoft.io/npm/typescript/-/typescript-5.9.3.tgz"
-  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+  resolved "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
+  integrity sha1-W09Z4VMQqxeiFvXWz1PuR27eZw8=
 
 uglify-js@^3.1.4:
   version "3.19.3"
@@ -5446,10 +5449,10 @@ unist-util-stringify-position@^2.0.0:
   dependencies:
     "@types/unist" "^2.0.2"
 
-universalify@^0.1.0:
-  version "0.1.2"
-  resolved "https://packagefeedproxy.microsoft.io/npm/universalify/-/universalify-0.1.2.tgz"
-  integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
+universalify@^2.0.0:
+  version "2.0.1"
+  resolved "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/universalify/-/universalify-2.0.1.tgz#168efc2180964e6386d061e094df61afe239b18d"
+  integrity sha1-Fo78IYCWTmOG0GHglN9hr+I5sY0=
 
 unpipe@~1.0.0:
   version "1.0.0"
@@ -5464,7 +5467,7 @@ update-browserslist-db@^1.2.3:
     escalade "^3.2.0"
     picocolors "^1.1.1"
 
-uri-js@^4.2.2, uri-js@^4.4.1:
+uri-js@^4.2.2:
   version "4.4.1"
   resolved "https://packagefeedproxy.microsoft.io/npm/uri-js/-/uri-js-4.4.1.tgz"
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==


### PR DESCRIPTION
Bumps the `@microsoft/api-extractor` devDependency in `sdk/webpubsub-socketio-extension` from `7.47.0` to `7.58.13`, clearing **all 4** Dependabot alerts in this package (2 High, 2 Moderate).

### Root-cause fix rather than a resolution override

All 4 alerts trace to a single devDependency — `@microsoft/api-extractor@7.47.0` is the only package in this lockfile that pulls in `lodash` and the vulnerable `minimatch`:

```
@microsoft/api-extractor@7.47.0
  ├─ lodash "~4.17.5"    → 4.17.21   (3 alerts)
  └─ minimatch "~3.0.3"  → 3.0.8     (1 alert)
```

Bumping the direct dependency removes both at the source:

| package | before | after |
| --- | --- | --- |
| `lodash` | 4.17.21 | **removed entirely** — no longer in the lockfile or `node_modules` |
| `minimatch@~3.0.3` | 3.0.8 | **gone** — api-extractor now uses `minimatch@10.2.3` |

Overriding with `resolutions` was rejected: `~3.0.3` means `>= 3.0.3 < 3.1.0`, so any patched version would violate api-extractor's own declared range.

### Alerts cleared

| Severity | Package | GHSA | Vulnerable | Patched |
| --- | --- | --- | --- | --- |
| High | lodash | GHSA-r5fr-rjxr-66jc | `>= 4.0.0, <= 4.17.23` | 4.18.0 |
| Moderate | lodash | GHSA-f23m-r3pf-42rh | `<= 4.17.23` | 4.18.0 |
| Moderate | lodash | GHSA-xxjr-mmjv-4gpg | `>= 4.0.0, <= 4.17.22` | 4.17.23 |
| High | minimatch | GHSA-23c5-xmqv-rm74 | `< 3.1.4` | 3.1.4 |

Resulting `minimatch` versions are `10.2.3` and `3.1.5`, both with **0** matching advisories.

> ⚠️ Note for anyone fixing this differently: Dependabot reports the minimatch patch as **3.1.3**, but `GHSA-23c5-xmqv-rm74` covers `< 3.1.4`. Bumping to 3.1.3 would silently leave that High advisory in place. The safe floor for the 3.x line is **3.1.4**.

> ⚠️ Do **not** install `@microsoft/api-extractor@latest`. The `latest` dist-tag on this package points at `8.0.0`, which was published **2019-02-18** and is far older than the 7.x line. `7.58.13` (2026-08-20) is the current release.

### Validation

- **Build output is byte-identical.** Built `dist/` at 7.47.0 and at 7.58.13 and compared SHA-256 of all 44 emitted files — identical. This is a devDependency change with zero runtime impact.
- **No runtime dependency changed.** Every entry in the lockfile diff belongs to api-extractor's own tooling tree (`@microsoft/*`, `@rushstack/*`, `ajv`, `fs-extra`, `diff`, `semver`, …).
- **Project TypeScript version is unchanged.** `typescript@^5.0.3` resolved to `5.9.3` both before and after; only api-extractor's internally bundled compiler moved `5.4.2 → 5.9.3`. That is what removes this pre-existing warning:
  `*** The target project appears to use TypeScript 5.9.3 which is newer than the bundled compiler engine; consider upgrading API Extractor.`
- `yarn build` passes; `yarn lint` passes; `yarn extract-api` completes successfully.
- `yarn test:unit` **skips** — it requires a live Web PubSub resource via `.env.test`, so it provides no signal either way. It is not being claimed as passing coverage for this change.

### About the `review/` change

The 2-line removal of `/// <reference types="node" />` in the API report is **pre-existing drift, not caused by this upgrade**. Running `yarn extract-api` on unmodified `main` at api-extractor 7.47.0 produces the exact same 2-line diff; the report generated at 7.58.13 is identical to it. The committed file was simply stale relative to the current TypeScript version. It is regenerated here so it matches reality.
