### PR TITLE
ci: remove duplicate path filters in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,17 +8,14 @@ on:
     branches: [ "main" ]
     paths:
       - '.github/workflows/build.yml'
+      # Root workspace manifests: they pin the dependency versions used by
+      # tools/awps-tunnel/client and tools/awps-tunnel/server.
       - 'package.json'
       - 'yarn.lock'
       - 'sdk/**'
       - 'tools/**'
       - 'samples/**'
       - 'experimental/**'
-      # Root workspace manifests: they pin the dependency versions used by
-      # tools/awps-tunnel/client and tools/awps-tunnel/server.
-      - 'package.json'
-      - 'yarn.lock'
-      - '.github/workflows/build.yml'
   pull_request:
     branches: [ "main" ]
     paths:
@@ -29,9 +26,6 @@ on:
       - 'tools/**'
       - 'samples/**'
       - 'experimental/**'
-      - 'package.json'
-      - 'yarn.lock'
-      - '.github/workflows/build.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
Removes duplicated entries in the `build.yml` trigger paths.

#1050 added `package.json`, `yarn.lock` and `.github/workflows/build.yml` to the trigger paths at the same time as the `dorny/paths-filter` refactor added the same three near the top of the block. Both landed, so each entry ended up listed twice in both `push` and `pull_request`.

No behaviour change — verified by parsing the YAML before and after and comparing the resulting path sets:

```
push          set equal: True   (10 raw entries -> 7)
pull_request  set equal: True   (10 raw entries -> 7)
```

The explanatory comment about root workspace manifests is kept, moved next to the entries it describes.