### PR TITLE
Add JSON client protocol support to Web PubSub emulator

### DIFF
--- a/tools/emulator/SUPPORTED_FEATURES.md
+++ b/tools/emulator/SUPPORTED_FEATURES.md
@@ -1,7 +1,7 @@
 # Supported Features and Gaps
 
-The current implementation provides the executable foundation and raw WebSocket client endpoint
-for local Azure Web PubSub development.
+The current implementation provides raw WebSocket and non-reliable JSON client endpoints for
+local Azure Web PubSub development.
 
 ## Current support
 
@@ -12,8 +12,9 @@ for local Azure Web PubSub development.
 | Service health | Implemented | `HEAD /api/health` returns `200 OK`. |
 | Client token authentication | Implemented | Validates access-key JWTs supplied by query string or bearer header. |
 | Raw WebSocket | Implemented | Receives group messages and publishes text or binary frames with raw `sendToGroup` mode. |
+| JSON WebSocket | Implemented | Supports `json.webpubsub.azure.v1` negotiation, connection messages, group operations, acknowledgements, ping, metadata, and message TTL validation. |
 | Connection state | Implemented | Tracks active connections and removes their state when the WebSocket disconnects. |
-| Groups and roles | Implemented | Supports connection-scoped token groups and authorized raw group send, including wildcard roles. |
+| Groups and roles | Implemented | Supports connection-scoped token groups and authorized join, leave, and group send, including wildcard roles. |
 | Outbound delivery | Implemented | Uses a bounded, single-writer queue for each WebSocket connection. |
 
 ## Not yet implemented
@@ -22,13 +23,14 @@ The following areas are planned for follow-up changes:
 
 - REST APIs and server SDK compatibility
 - HTTP upstream event handlers
+- Tunnel connections (`tunnel://` upstream URLs)
 - Event Hubs listeners
-- JSON and reliable JSON subprotocols
-- Client join, leave, acknowledgement, metadata, and message TTL
+- Reliable JSON subprotocol
 - Reliable reconnect and message replay
 - Protobuf subprotocols
 - Client message streaming
 - Production Microsoft Entra ID validation
 
-Raw `sendEvent` mode requires an upstream event handler and is not available in the current
-implementation.
+Client events require an upstream event handler. Until upstream handlers are implemented, JSON
+events with an `ackId` receive an `InternalServerError` acknowledgement; events without an
+`ackId` are logged without closing the client connection. Raw `sendEvent` mode is not available.

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/AckCache.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/AckCache.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Azure.WebPubSub.Emulator;
+
+internal sealed class AckCache
+{
+    private const int Capacity = 1000;
+
+    private readonly object _lock = new();
+    private readonly HashSet<ulong> _ackIds = new(Capacity);
+    private readonly Queue<ulong> _insertionOrder = new(Capacity);
+
+    public bool Contains(ulong ackId)
+    {
+        lock (_lock)
+        {
+            return _ackIds.Contains(ackId);
+        }
+    }
+
+    public void Add(ulong ackId)
+    {
+        lock (_lock)
+        {
+            if (!_ackIds.Add(ackId))
+            {
+                return;
+            }
+
+            _insertionOrder.Enqueue(ackId);
+            if (_ackIds.Count > Capacity)
+            {
+                _ackIds.Remove(_insertionOrder.Dequeue());
+            }
+        }
+    }
+}

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientConnectionHandler.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientConnectionHandler.cs
@@ -27,6 +27,7 @@ internal sealed class ClientConnectionHandler
             transport.Aborted);
         try
         {
+            processor.OnConnected(connection);
             while (!linkedCancellation.IsCancellationRequested)
             {
                 var message = await transport.ReceiveAsync(linkedCancellation.Token);

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientPayloadProcessor.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientPayloadProcessor.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Azure.WebPubSub.Emulator;
 
 internal interface IClientPayloadProcessor
 {
+    void OnConnected(LogicalConnection connection);
+
     ValueTask<PayloadProcessingResult> ProcessAsync(
         LogicalConnection connection,
         WebSocketMessageType messageType,
@@ -41,14 +43,23 @@ internal readonly record struct PayloadProcessingResult(
 internal sealed class ClientPayloadProcessorFactory
 {
     private readonly SimpleWebSocketPayloadProcessor _defaultProcessor;
+    private readonly WebPubSubJsonV1PayloadProcessor _jsonV1Processor;
 
-    public ClientPayloadProcessorFactory(SimpleWebSocketPayloadProcessor defaultProcessor)
+    public ClientPayloadProcessorFactory(
+        SimpleWebSocketPayloadProcessor defaultProcessor,
+        WebPubSubJsonV1PayloadProcessor jsonV1Processor)
     {
         _defaultProcessor = defaultProcessor;
+        _jsonV1Processor = jsonV1Processor;
     }
 
     public IClientPayloadProcessor Get(string? subprotocol)
     {
-        return _defaultProcessor;
+        return string.Equals(
+            subprotocol,
+            WebPubSubJsonV1PayloadProcessor.SubprotocolName,
+            StringComparison.OrdinalIgnoreCase)
+            ? _jsonV1Processor
+            : _defaultProcessor;
     }
 }

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientWebSocketEndpoint.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientWebSocketEndpoint.cs
@@ -76,14 +76,16 @@ internal sealed class ClientWebSocketEndpoint
             return;
         }
 
-        if (!TryGetRawSendToGroup(context, out var rawSendToGroup, out var error))
+        var selectedSubprotocol = SelectSubprotocol(context);
+        string? rawSendToGroup = null;
+        if (selectedSubprotocol is null &&
+            !TryGetRawSendToGroup(context, out rawSendToGroup, out var error))
         {
             context.Response.StatusCode = StatusCodes.Status400BadRequest;
             await context.Response.WriteAsync(error);
             return;
         }
 
-        string? selectedSubprotocol = null;
         var connection = _connections.Create(
             Guid.NewGuid().ToString("N"),
             hub,
@@ -175,5 +177,14 @@ internal sealed class ClientWebSocketEndpoint
         return authorization.StartsWith(bearerPrefix, StringComparison.OrdinalIgnoreCase)
             ? authorization[bearerPrefix.Length..].Trim()
             : null;
+    }
+
+    private static string? SelectSubprotocol(HttpContext context)
+    {
+        return context.WebSockets.WebSocketRequestedProtocols.FirstOrDefault(
+            protocol => string.Equals(
+                protocol,
+                WebPubSubJsonV1PayloadProcessor.SubprotocolName,
+                StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorApplication.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorApplication.cs
@@ -30,6 +30,11 @@ internal static class EmulatorApplication
         builder.Services.AddSingleton<WebPubSubTokenService>();
         builder.Services.AddSingleton<ConnectionManager>();
         builder.Services.AddSingleton<SimpleWebSocketPayloadProcessor>();
+        builder.Services.AddSingleton<WebPubSubJsonV1Protocol>();
+        builder.Services.AddSingleton<
+            IWebPubSubConnectionLifetimeHandler,
+            WebPubSubClientConnectionLifetimeHandler>();
+        builder.Services.AddSingleton<WebPubSubJsonV1PayloadProcessor>();
         builder.Services.AddSingleton<ClientPayloadProcessorFactory>();
         builder.Services.AddSingleton<ClientConnectionHandler>();
         builder.Services.AddSingleton<ClientWebSocketEndpoint>();

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/LogicalConnection.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/LogicalConnection.cs
@@ -18,6 +18,7 @@ internal sealed class LogicalConnection
     private readonly EmulatorRuntimeOptions _runtimeOptions;
     private readonly int _outboundQueueCapacity;
     private readonly long _outboundQueueMaxBytes;
+    private readonly ConnectionRolePermissions _joinLeaveGroupPermissions;
     private readonly ConnectionRolePermissions _sendToGroupPermissions;
 
     private IClientPayloadProcessor? _activePayloadProcessor;
@@ -57,6 +58,10 @@ internal sealed class LogicalConnection
             .Where(claim => claim.Type is "role" or ClaimTypes.Role)
             .Select(claim => claim.Value)
             .ToHashSet(StringComparer.Ordinal);
+        _joinLeaveGroupPermissions = new(
+            roles,
+            "webpubsub.joinLeaveGroup",
+            "webpubsub.joinLeaveGroups.");
         _sendToGroupPermissions = new(
             roles,
             "webpubsub.sendToGroup",
@@ -70,6 +75,8 @@ internal sealed class LogicalConnection
     public string? RawSendToGroup { get; }
 
     public string? UserId { get; }
+
+    public AckCache AckIdCache { get; } = new();
 
     public ConcurrentDictionary<string, byte> Groups { get; } = new(StringComparer.Ordinal);
 
@@ -100,6 +107,11 @@ internal sealed class LogicalConnection
         return _sendToGroupPermissions.Check(group);
     }
 
+    public bool CanJoinLeaveGroup(string group)
+    {
+        return _joinLeaveGroupPermissions.Check(group);
+    }
+
     public void SendGroupData(
         string group,
         string? fromUserId,
@@ -117,7 +129,23 @@ internal sealed class LogicalConnection
             }
         }
 
-        var payload = payloadProcessor.EncodeGroupData(this, group, fromUserId, data);
+        Send(payloadProcessor.EncodeGroupData(this, group, fromUserId, data));
+    }
+
+    public void Send(WebSocketPayload payload)
+    {
+        IClientPayloadProcessor? payloadProcessor;
+        SocketTransport? transport;
+        lock (_stateLock)
+        {
+            payloadProcessor = _activePayloadProcessor;
+            transport = _activeTransport;
+            if (_closed || payloadProcessor is null || transport is null)
+            {
+                return;
+            }
+        }
+
         SocketTransport? dropped;
         lock (_stateLock)
         {

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/MessageData.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/MessageData.cs
@@ -7,8 +7,10 @@ internal enum MessageDataType
 {
     Text,
     Binary,
+    Json,
 }
 
 internal sealed record MessageData(
     MessageDataType Type,
-    ReadOnlyMemory<byte> Bytes);
+    ReadOnlyMemory<byte> Bytes,
+    IReadOnlyDictionary<string, string>? Metadata = null);

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/SimpleWebSocketPayloadProcessor.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/SimpleWebSocketPayloadProcessor.cs
@@ -13,6 +13,10 @@ internal sealed class SimpleWebSocketPayloadProcessor : IClientPayloadProcessor
         _connections = connections;
     }
 
+    public void OnConnected(LogicalConnection connection)
+    {
+    }
+
     public ValueTask<PayloadProcessingResult> ProcessAsync(
         LogicalConnection connection,
         WebSocketMessageType messageType,

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubClientConnectionLifetimeHandler.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubClientConnectionLifetimeHandler.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Azure.WebPubSub.Emulator;
+
+internal interface IWebPubSubConnectionLifetimeHandler
+{
+    Task<UpstreamEventResult> SendMessageAsync(
+        LogicalConnection connection,
+        ClientMessagePayload message,
+        CancellationToken cancellationToken = default);
+}
+
+internal sealed record ClientMessagePayload(
+    string EventName,
+    MessageData Data);
+
+internal sealed record UpstreamEventResult(MessageData? Response = null);
+
+internal sealed class WebPubSubClientConnectionLifetimeHandler :
+    IWebPubSubConnectionLifetimeHandler
+{
+    public Task<UpstreamEventResult> SendMessageAsync(
+        LogicalConnection connection,
+        ClientMessagePayload message,
+        CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException(
+            "HTTP upstream event handlers are not implemented.");
+    }
+}

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubJsonV1PayloadProcessor.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubJsonV1PayloadProcessor.cs
@@ -1,0 +1,228 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Net.WebSockets;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebPubSub.Emulator;
+
+internal sealed class WebPubSubJsonV1PayloadProcessor : IClientPayloadProcessor
+{
+    public const string SubprotocolName = "json.webpubsub.azure.v1";
+
+    private readonly ConnectionManager _connections;
+    private readonly IWebPubSubConnectionLifetimeHandler _lifetimeHandler;
+    private readonly ILogger<WebPubSubJsonV1PayloadProcessor> _logger;
+    private readonly WebPubSubJsonV1Protocol _protocol;
+
+    public WebPubSubJsonV1PayloadProcessor(
+        ConnectionManager connections,
+        IWebPubSubConnectionLifetimeHandler lifetimeHandler,
+        WebPubSubJsonV1Protocol protocol,
+        ILogger<WebPubSubJsonV1PayloadProcessor> logger)
+    {
+        _connections = connections;
+        _lifetimeHandler = lifetimeHandler;
+        _protocol = protocol;
+        _logger = logger;
+    }
+
+    public void OnConnected(LogicalConnection connection)
+    {
+        connection.Send(_protocol.WriteConnected(connection));
+    }
+
+    public async ValueTask<PayloadProcessingResult> ProcessAsync(
+        LogicalConnection connection,
+        WebSocketMessageType messageType,
+        byte[] payload,
+        CancellationToken cancellationToken)
+    {
+        if (messageType != WebSocketMessageType.Text)
+        {
+            return PayloadProcessingResult.Close(
+                WebSocketCloseStatus.InvalidMessageType,
+                "The JSON subprotocol requires text messages.");
+        }
+
+        WebPubSubClientRequest request;
+        try
+        {
+            request = _protocol.ParseMessage(payload);
+        }
+        catch (InvalidDataException exception)
+        {
+            _logger.LogWarning(
+                exception,
+                "Connection {ConnectionId} sent an invalid JSON protocol message.",
+                connection.ConnectionId);
+            return PayloadProcessingResult.Close(
+                WebSocketCloseStatus.InvalidPayloadData,
+                "The client message is not a valid JSON protocol message.");
+        }
+
+        if (request is WebPubSubClientPingRequest)
+        {
+            connection.Send(_protocol.WritePong());
+            return PayloadProcessingResult.Continue;
+        }
+
+        if (request is WebPubSubClientSequenceAckRequest)
+        {
+            return PayloadProcessingResult.Continue;
+        }
+
+        if (request.AckId is { } ackId && connection.AckIdCache.Contains(ackId))
+        {
+            connection.Send(_protocol.WriteErrorAck(
+                ackId,
+                WebPubSubAckErrorName.Duplicate,
+                $"Message with ack-id: {ackId} has been processed"));
+            return PayloadProcessingResult.Continue;
+        }
+
+        if (request is WebPubSubClientSendEventRequest eventRequest)
+        {
+            await HandleEventAsync(connection, eventRequest, cancellationToken);
+            return PayloadProcessingResult.Continue;
+        }
+
+        try
+        {
+            DispatchClientRequest(connection, request);
+            if (request.AckId is { } successfulAckId)
+            {
+                connection.AckIdCache.Add(successfulAckId);
+                connection.Send(_protocol.WriteAck(successfulAckId));
+            }
+        }
+        catch (UnauthorizedAccessException exception)
+        {
+            _logger.LogWarning(
+                "Connection {ConnectionId} failed to process a client message: {Reason}",
+                connection.ConnectionId,
+                exception.Message);
+            WriteErrorAck(
+                connection,
+                request.AckId,
+                WebPubSubAckErrorName.Forbidden,
+                exception.Message);
+        }
+        catch (Exception exception)
+        {
+            _logger.LogWarning(
+                exception,
+                "Connection {ConnectionId} failed to process a client message.",
+                connection.ConnectionId);
+            WriteErrorAck(
+                connection,
+                request.AckId,
+                WebPubSubAckErrorName.InternalServerError,
+                "Internal server error");
+        }
+
+        return PayloadProcessingResult.Continue;
+    }
+
+    public WebSocketPayload EncodeGroupData(
+        LogicalConnection connection,
+        string group,
+        string? fromUserId,
+        MessageData data)
+    {
+        return _protocol.WriteGroupData(group, fromUserId, data);
+    }
+
+    private void DispatchClientRequest(
+        LogicalConnection connection,
+        WebPubSubClientRequest request)
+    {
+        switch (request)
+        {
+            case WebPubSubClientJoinGroupRequest join:
+                EnsureJoinLeavePermission(connection, join.Group, "join");
+                connection.Groups.TryAdd(join.Group, 0);
+                break;
+            case WebPubSubClientLeaveGroupRequest leave:
+                EnsureJoinLeavePermission(connection, leave.Group, "leave");
+                connection.Groups.TryRemove(leave.Group, out _);
+                break;
+            case WebPubSubClientSendToGroupRequest send:
+                if (!connection.CanSendToGroup(send.Group))
+                {
+                    throw new UnauthorizedAccessException(
+                        $"The client does not have permission to send to group '{send.Group}'.");
+                }
+                _connections.SendToGroup(
+                    connection.Hub,
+                    send.Group,
+                    send.Data,
+                    connection,
+                    send.NoEcho);
+                break;
+            default:
+                throw new InvalidOperationException(
+                    $"Unsupported client request '{request.GetType().Name}'.");
+        }
+    }
+
+    private async Task HandleEventAsync(
+        LogicalConnection connection,
+        WebPubSubClientSendEventRequest request,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await _lifetimeHandler.SendMessageAsync(
+                connection,
+                new ClientMessagePayload(request.EventName, request.Data),
+                cancellationToken);
+            if (result.Response is not null)
+            {
+                connection.Send(_protocol.WriteServerData(result.Response));
+            }
+            if (request.AckId is { } ackId)
+            {
+                connection.AckIdCache.Add(ackId);
+                connection.Send(_protocol.WriteAck(ackId));
+            }
+        }
+        catch (Exception exception)
+        {
+            _logger.LogWarning(
+                exception,
+                "Connection {ConnectionId} failed to send event {EventName}.",
+                connection.ConnectionId,
+                request.EventName);
+            WriteErrorAck(
+                connection,
+                request.AckId,
+                WebPubSubAckErrorName.InternalServerError,
+                "Internal server error");
+        }
+    }
+
+    private void WriteErrorAck(
+        LogicalConnection connection,
+        ulong? ackId,
+        WebPubSubAckErrorName errorName,
+        string message)
+    {
+        if (ackId is { } value)
+        {
+            connection.Send(_protocol.WriteErrorAck(value, errorName, message));
+        }
+    }
+
+    private static void EnsureJoinLeavePermission(
+        LogicalConnection connection,
+        string group,
+        string action)
+    {
+        if (!connection.CanJoinLeaveGroup(group))
+        {
+            throw new UnauthorizedAccessException(
+                $"The client does not have permission to {action} group '{group}'.");
+        }
+    }
+}

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubJsonV1Protocol.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubJsonV1Protocol.cs
@@ -1,0 +1,447 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.Azure.WebPubSub.Emulator;
+
+internal abstract record WebPubSubClientRequest(ulong? AckId);
+
+internal sealed record WebPubSubClientJoinGroupRequest(
+    string Group,
+    ulong? AckId) : WebPubSubClientRequest(AckId);
+
+internal sealed record WebPubSubClientLeaveGroupRequest(
+    string Group,
+    ulong? AckId) : WebPubSubClientRequest(AckId);
+
+internal sealed record WebPubSubClientSendToGroupRequest(
+    string Group,
+    MessageData Data,
+    bool NoEcho,
+    uint TtlSeconds,
+    ulong? AckId) : WebPubSubClientRequest(AckId);
+
+internal sealed record WebPubSubClientSendEventRequest(
+    string EventName,
+    MessageData Data,
+    ulong? AckId) : WebPubSubClientRequest(AckId);
+
+internal sealed record WebPubSubClientPingRequest() :
+    WebPubSubClientRequest((ulong?)null);
+
+internal sealed record WebPubSubClientSequenceAckRequest(ulong SequenceId) :
+    WebPubSubClientRequest((ulong?)null);
+
+internal enum WebPubSubAckErrorName
+{
+    BadRequest,
+    Forbidden,
+    InternalServerError,
+    Duplicate,
+}
+
+internal sealed partial class WebPubSubJsonV1Protocol
+{
+    private const int MaximumMessageTtlSeconds = 300;
+    private const int MaximumMetadataBytes = 8 * 1024;
+    private const int MaximumMetadataKeyBytes = 256;
+    private const int MaximumMetadataValueBytes = 1024;
+
+    public WebPubSubClientRequest ParseMessage(byte[] payload)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(payload);
+            var root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+            {
+                throw new InvalidDataException("Expected a JSON object.");
+            }
+
+            var type = GetRequiredString(root, "type");
+            var ackId = GetOptionalUInt64(root, "ackId");
+            if (type.Equals("ping", StringComparison.OrdinalIgnoreCase))
+            {
+                return new WebPubSubClientPingRequest();
+            }
+
+            if (type.Equals("sequenceAck", StringComparison.OrdinalIgnoreCase))
+            {
+                return new WebPubSubClientSequenceAckRequest(
+                    GetRequiredUInt64(root, "sequenceId"));
+            }
+
+            if (type.Equals("joinGroup", StringComparison.OrdinalIgnoreCase))
+            {
+                return new WebPubSubClientJoinGroupRequest(
+                    GetRequiredGroup(root),
+                    ackId);
+            }
+
+            if (type.Equals("leaveGroup", StringComparison.OrdinalIgnoreCase))
+            {
+                return new WebPubSubClientLeaveGroupRequest(
+                    GetRequiredGroup(root),
+                    ackId);
+            }
+
+            if (type.Equals("sendToGroup", StringComparison.OrdinalIgnoreCase))
+            {
+                var metadata = ReadMetadata(root);
+                return new WebPubSubClientSendToGroupRequest(
+                    GetRequiredGroup(root),
+                    ReadData(root, metadata),
+                    GetOptionalBoolean(root, "noEcho"),
+                    GetMessageTtl(root),
+                    ackId);
+            }
+
+            if (type.Equals("event", StringComparison.OrdinalIgnoreCase))
+            {
+                var eventName = GetRequiredString(root, "event");
+                if (!WebPubSubNameValidator.IsValidEventName(eventName))
+                {
+                    throw new InvalidDataException("The event name is invalid.");
+                }
+
+                var metadata = ReadMetadata(root);
+                return new WebPubSubClientSendEventRequest(
+                    eventName,
+                    ReadData(root, metadata),
+                    ackId);
+            }
+
+            throw new InvalidDataException($"Unknown 'type': {type}.");
+        }
+        catch (JsonException exception)
+        {
+            throw new InvalidDataException("Error reading JSON.", exception);
+        }
+    }
+
+    public WebSocketPayload WriteConnected(LogicalConnection connection)
+    {
+        return WriteJson(writer =>
+        {
+            writer.WriteStartObject();
+            writer.WriteString("type", "system");
+            writer.WriteString("event", "connected");
+            writer.WriteString("userId", connection.UserId);
+            writer.WriteString("connectionId", connection.ConnectionId);
+            writer.WriteEndObject();
+        });
+    }
+
+    public WebSocketPayload WritePong()
+    {
+        return WriteJson(writer =>
+        {
+            writer.WriteStartObject();
+            writer.WriteString("type", "pong");
+            writer.WriteEndObject();
+        });
+    }
+
+    public WebSocketPayload WriteAck(ulong ackId)
+    {
+        return WriteJson(writer =>
+        {
+            writer.WriteStartObject();
+            writer.WriteString("type", "ack");
+            writer.WriteNumber("ackId", ackId);
+            writer.WriteBoolean("success", true);
+            writer.WriteEndObject();
+        });
+    }
+
+    public WebSocketPayload WriteErrorAck(
+        ulong ackId,
+        WebPubSubAckErrorName errorName,
+        string message)
+    {
+        return WriteJson(writer =>
+        {
+            writer.WriteStartObject();
+            writer.WriteString("type", "ack");
+            writer.WriteNumber("ackId", ackId);
+            writer.WriteBoolean("success", false);
+            writer.WriteStartObject("error");
+            writer.WriteString("name", errorName.ToString());
+            writer.WriteString("message", message);
+            writer.WriteEndObject();
+            writer.WriteEndObject();
+        });
+    }
+
+    public WebSocketPayload WriteGroupData(
+        string group,
+        string? fromUserId,
+        MessageData data)
+    {
+        return WriteJson(writer =>
+        {
+            writer.WriteStartObject();
+            writer.WriteString("type", "message");
+            writer.WriteString("from", "group");
+            writer.WriteString("group", group);
+            writer.WriteString("fromUserId", fromUserId);
+            WriteData(writer, data);
+            writer.WriteEndObject();
+        });
+    }
+
+    public WebSocketPayload WriteServerData(MessageData data)
+    {
+        return WriteJson(writer =>
+        {
+            writer.WriteStartObject();
+            writer.WriteString("type", "message");
+            writer.WriteString("from", "server");
+            WriteData(writer, data);
+            writer.WriteEndObject();
+        });
+    }
+
+    private static MessageData ReadData(
+        JsonElement root,
+        IReadOnlyDictionary<string, string>? metadata)
+    {
+        if (!root.TryGetProperty("data", out var data))
+        {
+            if (metadata is not null)
+            {
+                return new MessageData(MessageDataType.Text, ReadOnlyMemory<byte>.Empty, metadata);
+            }
+
+            throw new InvalidDataException("Missing required property 'data'.");
+        }
+
+        var dataType = root.TryGetProperty("dataType", out var dataTypeElement)
+            ? GetString(dataTypeElement, "dataType")
+            : "json";
+        if (dataType.Equals("text", StringComparison.OrdinalIgnoreCase))
+        {
+            if (data.ValueKind != JsonValueKind.String)
+            {
+                throw new InvalidDataException("'data' should be a string when 'dataType' is 'text'.");
+            }
+
+            return new MessageData(
+                MessageDataType.Text,
+                Encoding.UTF8.GetBytes(data.GetString()!),
+                metadata);
+        }
+
+        if (dataType.Equals("binary", StringComparison.OrdinalIgnoreCase))
+        {
+            if (data.ValueKind != JsonValueKind.String ||
+                !data.TryGetBytesFromBase64(out var bytes))
+            {
+                throw new InvalidDataException("'data' is not a valid base64 encoded string.");
+            }
+
+            return new MessageData(MessageDataType.Binary, bytes, metadata);
+        }
+
+        if (!dataType.Equals("json", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidDataException($"Unknown 'dataType': {dataType}.");
+        }
+
+        if (data.ValueKind == JsonValueKind.Null)
+        {
+            throw new InvalidDataException("Invalid value for 'data': null.");
+        }
+
+        return new MessageData(
+            MessageDataType.Json,
+            Encoding.UTF8.GetBytes(data.GetRawText()),
+            metadata);
+    }
+
+    private static IReadOnlyDictionary<string, string>? ReadMetadata(JsonElement root)
+    {
+        if (!root.TryGetProperty("metadata", out var metadata) ||
+            metadata.ValueKind == JsonValueKind.Null)
+        {
+            return null;
+        }
+
+        if (metadata.ValueKind != JsonValueKind.Object)
+        {
+            throw new InvalidDataException("'metadata' must be a JSON object.");
+        }
+
+        var result = new Dictionary<string, string>(StringComparer.Ordinal);
+        var totalBytes = 0;
+        foreach (var property in metadata.EnumerateObject())
+        {
+            if (property.Value.ValueKind != JsonValueKind.String)
+            {
+                throw new InvalidDataException(
+                    $"Metadata value for key '{property.Name}' must be a string.");
+            }
+
+            var value = property.Value.GetString()!;
+            if (!MetadataKeyRegex().IsMatch(property.Name))
+            {
+                throw new InvalidDataException(
+                    $"Metadata key '{property.Name}' contains invalid characters.");
+            }
+            if (!property.Name.All(character => character <= 0x7f) ||
+                !value.All(character => character <= 0x7f))
+            {
+                throw new InvalidDataException("Metadata keys and values must be ASCII.");
+            }
+            if (property.Name.Length > MaximumMetadataKeyBytes)
+            {
+                throw new InvalidDataException(
+                    $"Metadata key '{property.Name}' exceeds {MaximumMetadataKeyBytes} bytes.");
+            }
+            if (value.Length > MaximumMetadataValueBytes)
+            {
+                throw new InvalidDataException(
+                    $"Metadata value for key '{property.Name}' exceeds {MaximumMetadataValueBytes} bytes.");
+            }
+
+            totalBytes += property.Name.Length + value.Length;
+            if (totalBytes > MaximumMetadataBytes)
+            {
+                throw new InvalidDataException($"Metadata exceeds {MaximumMetadataBytes} bytes.");
+            }
+            if (!result.TryAdd(property.Name, value))
+            {
+                throw new InvalidDataException(
+                    $"Duplicate key '{property.Name}' found within 'metadata'.");
+            }
+        }
+
+        return result;
+    }
+
+    private static void WriteData(Utf8JsonWriter writer, MessageData data)
+    {
+        writer.WriteString("dataType", data.Type.ToString().ToLowerInvariant());
+        switch (data.Type)
+        {
+            case MessageDataType.Text:
+                writer.WriteString("data", Encoding.UTF8.GetString(data.Bytes.Span));
+                break;
+            case MessageDataType.Binary:
+                writer.WriteBase64String("data", data.Bytes.Span);
+                break;
+            case MessageDataType.Json:
+                writer.WritePropertyName("data");
+                writer.WriteRawValue(data.Bytes.Span);
+                break;
+            default:
+                throw new InvalidOperationException($"Unknown message data type '{data.Type}'.");
+        }
+
+        if (data.Metadata is not null)
+        {
+            writer.WriteStartObject("metadata");
+            foreach (var item in data.Metadata)
+            {
+                writer.WriteString(item.Key, item.Value);
+            }
+            writer.WriteEndObject();
+        }
+    }
+
+    private static WebSocketPayload WriteJson(Action<Utf8JsonWriter> write)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            write(writer);
+        }
+        return new WebSocketPayload(stream.ToArray(), WebSocketMessageType.Text);
+    }
+
+    private static string GetRequiredGroup(JsonElement root)
+    {
+        var group = GetRequiredString(root, "group");
+        if (!WebPubSubNameValidator.IsValidGroupName(group))
+        {
+            throw new InvalidDataException("The group name is invalid.");
+        }
+        return group;
+    }
+
+    private static string GetRequiredString(JsonElement root, string propertyName)
+    {
+        if (!root.TryGetProperty(propertyName, out var value))
+        {
+            throw new InvalidDataException($"Missing required property '{propertyName}'.");
+        }
+        return GetString(value, propertyName);
+    }
+
+    private static string GetString(JsonElement value, string propertyName)
+    {
+        if (value.ValueKind != JsonValueKind.String)
+        {
+            throw new InvalidDataException($"Expected '{propertyName}' to be a string.");
+        }
+        return value.GetString()!;
+    }
+
+    private static ulong? GetOptionalUInt64(JsonElement root, string propertyName)
+    {
+        if (!root.TryGetProperty(propertyName, out var value) ||
+            value.ValueKind == JsonValueKind.Null)
+        {
+            return null;
+        }
+        if (value.ValueKind != JsonValueKind.Number || !value.TryGetUInt64(out var result))
+        {
+            throw new InvalidDataException($"'{propertyName}' is not a valid uint64 value.");
+        }
+        return result;
+    }
+
+    private static ulong GetRequiredUInt64(JsonElement root, string propertyName)
+    {
+        return GetOptionalUInt64(root, propertyName) ??
+            throw new InvalidDataException($"Missing required property '{propertyName}'.");
+    }
+
+    private static bool GetOptionalBoolean(JsonElement root, string propertyName)
+    {
+        if (!root.TryGetProperty(propertyName, out var value))
+        {
+            return false;
+        }
+        return value.ValueKind switch
+        {
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            _ => throw new InvalidDataException($"Expected '{propertyName}' to be a boolean."),
+        };
+    }
+
+    private static uint GetMessageTtl(JsonElement root)
+    {
+        if (!root.TryGetProperty("ttlSeconds", out var value) ||
+            value.ValueKind == JsonValueKind.Null)
+        {
+            return 0;
+        }
+        if (value.ValueKind != JsonValueKind.Number ||
+            !value.TryGetUInt32(out var result) ||
+            result > MaximumMessageTtlSeconds)
+        {
+            throw new InvalidDataException(
+                "'ttlSeconds' is out of range. Allowed range is [0,300].");
+        }
+        return result;
+    }
+
+    [GeneratedRegex("^[!#$%&'*+\\-.^_`|~0-9a-z]+$", RegexOptions.IgnoreCase)]
+    private static partial Regex MetadataKeyRegex();
+}

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubNameValidator.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubNameValidator.cs
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Text.RegularExpressions;
+
 namespace Microsoft.Azure.WebPubSub.Emulator;
 
-internal static class WebPubSubNameValidator
+internal static partial class WebPubSubNameValidator
 {
     public const int MaximumGroupNameLength = 1024;
 
@@ -11,4 +13,14 @@ internal static class WebPubSubNameValidator
     {
         return !string.IsNullOrWhiteSpace(group) && group.Length <= MaximumGroupNameLength;
     }
+
+    public static bool IsValidEventName(string? eventName)
+    {
+        return !string.IsNullOrEmpty(eventName) && EventNameRegex().IsMatch(eventName);
+    }
+
+    [GeneratedRegex(
+        "^[a-z][a-z0-9_.-]{0,127}$",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex EventNameRegex();
 }

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/AckCacheTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/AckCacheTests.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Xunit;
+
+namespace Microsoft.Azure.WebPubSub.Emulator.Tests;
+
+public class AckCacheTests
+{
+    [Fact]
+    public void CacheRetainsMostRecentThousandAckIds()
+    {
+        var cache = new AckCache();
+
+        for (ulong ackId = 1; ackId <= 1001; ackId++)
+        {
+            cache.Add(ackId);
+        }
+
+        Assert.False(cache.Contains(1));
+        Assert.True(cache.Contains(2));
+        Assert.True(cache.Contains(1001));
+    }
+
+}

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/ClientWebSocketEndpointTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/ClientWebSocketEndpointTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Net.WebSockets;
 using System.Security.Claims;
 using System.Text;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
@@ -107,18 +108,53 @@ public class ClientWebSocketEndpointTests
         Assert.Equal(WebSocketCloseStatus.PolicyViolation, result.CloseStatus);
     }
 
-    [Fact]
-    public async Task RequestedSubprotocolIsNotSelectedWithoutConnectUpstream()
+    [Theory]
+    [InlineData("custom.protocol")]
+    [InlineData("json.reliable.webpubsub.azure.v1")]
+    [InlineData("protobuf.webpubsub.azure.v1")]
+    public async Task UnsupportedSubprotocolIsNotSelected(string subprotocol)
     {
         await using var application = await StartApplicationAsync();
         var client = application.GetTestServer().CreateWebSocketClient();
-        client.SubProtocols.Add("custom.protocol");
+        client.SubProtocols.Add(subprotocol);
         var uri = CreateClientUri();
 
         using var webSocket = await client.ConnectAsync(uri, CancellationToken.None)
             .WaitAsync(TestTimeout);
 
         Assert.Null(webSocket.SubProtocol);
+    }
+
+    [Fact]
+    public async Task JsonSubprotocolReceivesConnectedMessage()
+    {
+        await using var application = await StartApplicationAsync();
+        using var webSocket = await ConnectAsync(
+            application,
+            subprotocol: WebPubSubJsonV1PayloadProcessor.SubprotocolName);
+
+        var message = await ReceiveJsonAsync(webSocket);
+
+        Assert.Equal(WebPubSubJsonV1PayloadProcessor.SubprotocolName, webSocket.SubProtocol);
+        Assert.Equal("system", message.RootElement.GetProperty("type").GetString());
+        Assert.Equal("connected", message.RootElement.GetProperty("event").GetString());
+        Assert.False(string.IsNullOrEmpty(
+            message.RootElement.GetProperty("connectionId").GetString()));
+    }
+
+    [Fact]
+    public async Task JsonSubprotocolNegotiationIsCaseInsensitive()
+    {
+        const string requestedSubprotocol = "JSON.WEBPUBSUB.AZURE.V1";
+        await using var application = await StartApplicationAsync();
+        using var webSocket = await ConnectAsync(
+            application,
+            subprotocol: requestedSubprotocol);
+
+        using var message = await ReceiveJsonAsync(webSocket);
+
+        Assert.Equal(requestedSubprotocol, webSocket.SubProtocol);
+        Assert.Equal("connected", message.RootElement.GetProperty("event").GetString());
     }
 
     [Fact]
@@ -188,11 +224,26 @@ public class ClientWebSocketEndpointTests
         WebApplication application,
         IEnumerable<string>? roles = null,
         IEnumerable<string>? groups = null,
-        string? query = null)
+        string? query = null,
+        string? subprotocol = null)
     {
         var uri = CreateClientUri(roles, groups, query);
         var client = application.GetTestServer().CreateWebSocketClient();
+        if (subprotocol is not null)
+        {
+            client.SubProtocols.Add(subprotocol);
+        }
         return await client.ConnectAsync(uri, CancellationToken.None).WaitAsync(TestTimeout);
+    }
+
+    private static async Task<JsonDocument> ReceiveJsonAsync(WebSocket webSocket)
+    {
+        var buffer = new byte[4096];
+        var result = await webSocket.ReceiveAsync(buffer, CancellationToken.None)
+            .WaitAsync(TestTimeout);
+        Assert.Equal(WebSocketMessageType.Text, result.MessageType);
+        Assert.True(result.EndOfMessage);
+        return JsonDocument.Parse(buffer.AsMemory(0, result.Count));
     }
 
     private static Uri CreateClientUri(

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/LogicalConnectionTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/LogicalConnectionTests.cs
@@ -125,6 +125,10 @@ public class LogicalConnectionTests
             _webSocketPayload = webSocketPayload;
         }
 
+        public void OnConnected(LogicalConnection connection)
+        {
+        }
+
         public ValueTask<PayloadProcessingResult> ProcessAsync(
             LogicalConnection connection,
             WebSocketMessageType messageType,

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/WebPubSubJsonV1IntegrationTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/WebPubSubJsonV1IntegrationTests.cs
@@ -1,0 +1,624 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Net.WebSockets;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Microsoft.Azure.WebPubSub.Emulator.Tests;
+
+public class WebPubSubJsonV1IntegrationTests
+{
+    private const string Hub = "chat";
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(10);
+
+    [Fact]
+    public async Task JsonClientsJoinPublishAndLeaveGroup()
+    {
+        await using var application = await StartApplicationAsync();
+        using var receiver = await ConnectJsonAsync(
+            application,
+            roles: ["webpubsub.joinLeaveGroup.room"]);
+        using var sender = await ConnectJsonAsync(
+            application,
+            roles: ["webpubsub.sendToGroup.room"],
+            userId: "alice");
+
+        await SendJsonAsync(receiver, new
+        {
+            type = "joinGroup",
+            group = "room",
+            ackId = 1,
+        });
+        using (var joinAck = await ReceiveJsonAsync(receiver))
+        {
+            AssertSuccessAck(joinAck.RootElement, 1);
+        }
+
+        await SendJsonAsync(sender, new
+        {
+            type = "sendToGroup",
+            group = "room",
+            dataType = "text",
+            data = "hello",
+            ackId = 1,
+            ttlSeconds = 300,
+        });
+        using (var sendAck = await ReceiveJsonAsync(sender))
+        {
+            AssertSuccessAck(sendAck.RootElement, 1);
+        }
+        using (var message = await ReceiveJsonAsync(receiver))
+        {
+            Assert.Equal("message", message.RootElement.GetProperty("type").GetString());
+            Assert.Equal("group", message.RootElement.GetProperty("from").GetString());
+            Assert.Equal("room", message.RootElement.GetProperty("group").GetString());
+            Assert.Equal("alice", message.RootElement.GetProperty("fromUserId").GetString());
+            Assert.Equal("text", message.RootElement.GetProperty("dataType").GetString());
+            Assert.Equal("hello", message.RootElement.GetProperty("data").GetString());
+        }
+
+        await SendJsonAsync(receiver, new
+        {
+            type = "leaveGroup",
+            group = "room",
+            ackId = 2,
+        });
+        using var leaveAck = await ReceiveJsonAsync(receiver);
+        AssertSuccessAck(leaveAck.RootElement, 2);
+
+        await SendJsonAsync(sender, new
+        {
+            type = "sendToGroup",
+            group = "room",
+            data = "after-leave",
+            ackId = 2,
+        });
+        using (var sendAfterLeaveAck = await ReceiveJsonAsync(sender))
+        {
+            AssertSuccessAck(sendAfterLeaveAck.RootElement, 2);
+        }
+        await SendJsonAsync(receiver, new { type = "ping" });
+        using var pong = await ReceiveJsonAsync(receiver);
+        Assert.Equal("pong", pong.RootElement.GetProperty("type").GetString());
+    }
+
+    [Fact]
+    public async Task JsonGroupMessagesPreserveDataTypesMetadataAndNoEcho()
+    {
+        await using var application = await StartApplicationAsync();
+        using var receiver = await ConnectJsonAsync(application, groups: ["room"]);
+        using var sender = await ConnectJsonAsync(
+            application,
+            roles: ["webpubsub.sendToGroup.room"],
+            groups: ["room"]);
+        var requests = new[]
+        {
+            """{"type":"sendToGroup","group":"room","dataType":"text","data":"hello","noEcho":true,"ackId":1,"metadata":{"trace-id":"one"}}""",
+            """{"type":"sendToGroup","group":"room","dataType":"binary","data":"AQID","noEcho":true,"ackId":2,"metadata":{"trace-id":"two"}}""",
+            """{"type":"sendToGroup","group":"room","data":{"value":42},"noEcho":true,"ackId":3,"metadata":{"trace-id":"three"}}""",
+        };
+
+        for (ulong ackId = 1; ackId <= (ulong)requests.Length; ackId++)
+        {
+            await SendTextAsync(sender, requests[ackId - 1]);
+            using var ack = await ReceiveJsonAsync(sender);
+            AssertSuccessAck(ack.RootElement, ackId);
+            using var message = await ReceiveJsonAsync(receiver);
+            Assert.Equal(
+                ackId == 1 ? "text" : ackId == 2 ? "binary" : "json",
+                message.RootElement.GetProperty("dataType").GetString());
+            Assert.Equal(
+                ackId == 1 ? "one" : ackId == 2 ? "two" : "three",
+                message.RootElement.GetProperty("metadata").GetProperty("trace-id").GetString());
+            if (ackId == 1)
+            {
+                Assert.Equal("hello", message.RootElement.GetProperty("data").GetString());
+            }
+            else if (ackId == 2)
+            {
+                Assert.Equal(
+                    new byte[] { 1, 2, 3 },
+                    message.RootElement.GetProperty("data").GetBytesFromBase64());
+            }
+            else
+            {
+                Assert.Equal(42, message.RootElement.GetProperty("data").GetProperty("value").GetInt32());
+            }
+        }
+
+        await SendJsonAsync(sender, new { type = "ping" });
+        using var pong = await ReceiveJsonAsync(sender);
+        Assert.Equal("pong", pong.RootElement.GetProperty("type").GetString());
+    }
+
+    [Fact]
+    public async Task DuplicateMetadataKeyClosesJsonConnection()
+    {
+        await using var application = await StartApplicationAsync();
+        using var client = await ConnectJsonAsync(
+            application,
+            roles: ["webpubsub.sendToGroup.room"]);
+
+        await SendTextAsync(
+            client,
+            """{"type":"sendToGroup","group":"room","data":"hello","metadata":{"trace":"one","trace":"two"}}""");
+        var result = await client.ReceiveAsync(new byte[512], CancellationToken.None)
+            .WaitAsync(TestTimeout);
+
+        Assert.Equal(WebSocketMessageType.Close, result.MessageType);
+        Assert.Equal(WebSocketCloseStatus.InvalidPayloadData, result.CloseStatus);
+    }
+
+    [Fact]
+    public async Task MetadataKeysAreCaseSensitive()
+    {
+        await using var application = await StartApplicationAsync();
+        using var receiver = await ConnectJsonAsync(application, groups: ["room"]);
+        using var sender = await ConnectJsonAsync(
+            application,
+            roles: ["webpubsub.sendToGroup.room"]);
+
+        await SendTextAsync(
+            sender,
+            """{"type":"sendToGroup","group":"room","data":"hello","ackId":1,"metadata":{"Trace":"one","trace":"two"}}""");
+        using (var ack = await ReceiveJsonAsync(sender))
+        {
+            AssertSuccessAck(ack.RootElement, 1);
+        }
+        using var message = await ReceiveJsonAsync(receiver);
+        var metadata = message.RootElement.GetProperty("metadata");
+        Assert.Equal("one", metadata.GetProperty("Trace").GetString());
+        Assert.Equal("two", metadata.GetProperty("trace").GetString());
+    }
+
+    [Theory]
+    [InlineData("event-name_1.2")]
+    [InlineData("E")]
+    public async Task ValidEventNamesReachLifetimeHandler(string eventName)
+    {
+        var handler = new SuccessfulLifetimeHandler();
+        await using var application = await StartApplicationAsync(handler);
+        using var client = await ConnectJsonAsync(application);
+
+        await SendJsonAsync(client, new
+        {
+            type = "event",
+            @event = eventName,
+            data = "hello",
+            ackId = 1,
+        });
+        using var ack = await ReceiveJsonAsync(client);
+
+        AssertSuccessAck(ack.RootElement, 1);
+        Assert.Equal(eventName, handler.Message?.EventName);
+    }
+
+    [Fact]
+    public async Task EventNameLengthMatchesProductionBoundary()
+    {
+        var handler = new SuccessfulLifetimeHandler();
+        await using var application = await StartApplicationAsync(handler);
+        using var validClient = await ConnectJsonAsync(application);
+        var validEventName = "a" + new string('b', 127);
+
+        await SendJsonAsync(validClient, new
+        {
+            type = "event",
+            @event = validEventName,
+            data = "hello",
+            ackId = 1,
+        });
+        using (var ack = await ReceiveJsonAsync(validClient))
+        {
+            AssertSuccessAck(ack.RootElement, 1);
+        }
+
+        using var invalidClient = await ConnectJsonAsync(application);
+        await SendJsonAsync(invalidClient, new
+        {
+            type = "event",
+            @event = validEventName + "c",
+            data = "hello",
+        });
+        var result = await invalidClient.ReceiveAsync(new byte[512], CancellationToken.None)
+            .WaitAsync(TestTimeout);
+        Assert.Equal(WebSocketMessageType.Close, result.MessageType);
+        Assert.Equal(WebSocketCloseStatus.InvalidPayloadData, result.CloseStatus);
+    }
+
+    [Theory]
+    [InlineData("1event")]
+    [InlineData("bad/event")]
+    [InlineData("bad event")]
+    public async Task InvalidEventNamesCloseJsonConnection(string eventName)
+    {
+        await using var application = await StartApplicationAsync();
+        using var client = await ConnectJsonAsync(application);
+
+        await SendJsonAsync(client, new
+        {
+            type = "event",
+            @event = eventName,
+            data = "hello",
+        });
+        var result = await client.ReceiveAsync(new byte[512], CancellationToken.None)
+            .WaitAsync(TestTimeout);
+
+        Assert.Equal(WebSocketMessageType.Close, result.MessageType);
+        Assert.Equal(WebSocketCloseStatus.InvalidPayloadData, result.CloseStatus);
+    }
+
+    [Fact]
+    public async Task SequenceAckIsAcceptedWithoutEnablingReliableDelivery()
+    {
+        await using var application = await StartApplicationAsync();
+        using var client = await ConnectJsonAsync(application);
+
+        await SendJsonAsync(client, new { type = "sequenceAck", sequenceId = 1 });
+        await SendJsonAsync(client, new { type = "ping" });
+        using var pong = await ReceiveJsonAsync(client);
+
+        Assert.Equal("pong", pong.RootElement.GetProperty("type").GetString());
+    }
+
+    [Fact]
+    public async Task JsonAckReportsForbiddenAndDuplicateRequests()
+    {
+        await using var application = await StartApplicationAsync();
+        using var unauthorized = await ConnectJsonAsync(application);
+        await SendJsonAsync(unauthorized, new
+        {
+            type = "joinGroup",
+            group = "room",
+            ackId = 1,
+        });
+        using (var forbidden = await ReceiveJsonAsync(unauthorized))
+        {
+            AssertErrorAck(
+                forbidden.RootElement,
+                1,
+                "Forbidden",
+                "The client does not have permission to join group 'room'.");
+        }
+
+        using var authorized = await ConnectJsonAsync(
+            application,
+            roles: ["webpubsub.joinLeaveGroup.room"]);
+        var join = new { type = "joinGroup", group = "room", ackId = 1 };
+        await SendJsonAsync(authorized, join);
+        using (var success = await ReceiveJsonAsync(authorized))
+        {
+            AssertSuccessAck(success.RootElement, 1);
+        }
+        await SendJsonAsync(authorized, join);
+        using var duplicate = await ReceiveJsonAsync(authorized);
+        AssertErrorAck(
+            duplicate.RootElement,
+            1,
+            "Duplicate",
+            "Message with ack-id: 1 has been processed");
+    }
+
+    [Fact]
+    public async Task EventFailureWithAckReturnsErrorAndKeepsConnectionOpen()
+    {
+        await using var application = await StartApplicationAsync();
+        using var client = await ConnectJsonAsync(application);
+        var request = new
+        {
+            type = "event",
+            @event = "message",
+            dataType = "text",
+            data = "hello",
+            ackId = 7,
+        };
+
+        await SendJsonAsync(client, request);
+        using (var error = await ReceiveJsonAsync(client))
+        {
+            AssertErrorAck(
+                error.RootElement,
+                7,
+                "InternalServerError",
+                "Internal server error");
+        }
+
+        await SendJsonAsync(client, request);
+        using (var retried = await ReceiveJsonAsync(client))
+        {
+            AssertErrorAck(
+                retried.RootElement,
+                7,
+                "InternalServerError",
+                "Internal server error");
+        }
+
+        await SendJsonAsync(client, new { type = "ping" });
+        using var pong = await ReceiveJsonAsync(client);
+        Assert.Equal("pong", pong.RootElement.GetProperty("type").GetString());
+    }
+
+    [Fact]
+    public async Task EventFailureWithoutAckLogsAndKeepsConnectionOpen()
+    {
+        var logs = new TestLoggerProvider();
+        await using var application = await StartApplicationAsync(loggerProvider: logs);
+        using var client = await ConnectJsonAsync(application);
+
+        await SendJsonAsync(client, new
+        {
+            type = "event",
+            @event = "message",
+            dataType = "text",
+            data = "hello",
+        });
+        await SendJsonAsync(client, new { type = "ping" });
+        using var pong = await ReceiveJsonAsync(client);
+
+        Assert.Equal("pong", pong.RootElement.GetProperty("type").GetString());
+        Assert.Contains(
+            logs.Messages,
+            message => message.Contains(
+                "failed to send event message",
+                StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task EventHandlerResponsePrecedesSuccessAck()
+    {
+        var handler = new SuccessfulLifetimeHandler(
+            new MessageData(MessageDataType.Json, "{\"accepted\":true}"u8.ToArray()));
+        await using var application = await StartApplicationAsync(handler);
+        using var client = await ConnectJsonAsync(application);
+
+        await SendJsonAsync(client, new
+        {
+            type = "event",
+            @event = "message",
+            data = new { value = 42 },
+            ackId = 9,
+            metadata = new { trace = "test" },
+        });
+        using (var response = await ReceiveJsonAsync(client))
+        {
+            Assert.Equal("message", response.RootElement.GetProperty("type").GetString());
+            Assert.Equal("server", response.RootElement.GetProperty("from").GetString());
+            Assert.True(response.RootElement.GetProperty("data").GetProperty("accepted").GetBoolean());
+        }
+        using var ack = await ReceiveJsonAsync(client);
+        AssertSuccessAck(ack.RootElement, 9);
+        Assert.Equal("message", handler.Message?.EventName);
+        Assert.Equal(
+            "test",
+            handler.Message?.Data.Metadata?["trace"]);
+    }
+
+    [Fact]
+    public async Task InvalidMessageTtlClosesJsonConnection()
+    {
+        await using var application = await StartApplicationAsync();
+        using var client = await ConnectJsonAsync(
+            application,
+            roles: ["webpubsub.sendToGroup.room"]);
+
+        await SendJsonAsync(client, new
+        {
+            type = "sendToGroup",
+            group = "room",
+            data = "hello",
+            ttlSeconds = 301,
+            ackId = 1,
+        });
+        var result = await client.ReceiveAsync(new byte[512], CancellationToken.None)
+            .WaitAsync(TestTimeout);
+
+        Assert.Equal(WebSocketMessageType.Close, result.MessageType);
+        Assert.Equal(WebSocketCloseStatus.InvalidPayloadData, result.CloseStatus);
+    }
+
+    [Fact]
+    public async Task LongInvalidTypeClosesJsonConnectionGracefully()
+    {
+        await using var application = await StartApplicationAsync();
+        using var client = await ConnectJsonAsync(application);
+
+        await SendJsonAsync(client, new { type = new string('x', 1024) });
+        var result = await client.ReceiveAsync(new byte[512], CancellationToken.None)
+            .WaitAsync(TestTimeout);
+
+        Assert.Equal(WebSocketMessageType.Close, result.MessageType);
+        Assert.Equal(WebSocketCloseStatus.InvalidPayloadData, result.CloseStatus);
+        Assert.Equal(
+            "The client message is not a valid JSON protocol message.",
+            result.CloseStatusDescription);
+    }
+
+    private static async Task<WebApplication> StartApplicationAsync(
+        IWebPubSubConnectionLifetimeHandler? lifetimeHandler = null,
+        ILoggerProvider? loggerProvider = null)
+    {
+        var builder = EmulatorApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        if (lifetimeHandler is not null)
+        {
+            builder.Services.AddSingleton(lifetimeHandler);
+        }
+        if (loggerProvider is not null)
+        {
+            builder.Logging.AddProvider(loggerProvider);
+        }
+        var application = EmulatorApplication.Build(builder);
+        await application.StartAsync().WaitAsync(TestTimeout);
+        return application;
+    }
+
+    private static async Task<WebSocket> ConnectJsonAsync(
+        WebApplication application,
+        IEnumerable<string>? roles = null,
+        IEnumerable<string>? groups = null,
+        string? userId = null)
+    {
+        var client = application.GetTestServer().CreateWebSocketClient();
+        client.SubProtocols.Add(WebPubSubJsonV1PayloadProcessor.SubprotocolName);
+        var token = CreateToken(roles ?? [], groups ?? [], userId);
+        var uri = new Uri(
+            $"ws://localhost{WebPubSubTokenService.ClientPathPrefix}{Hub}?access_token={Uri.EscapeDataString(token)}");
+        var webSocket = await client.ConnectAsync(uri, CancellationToken.None)
+            .WaitAsync(TestTimeout);
+        using var connected = await ReceiveJsonAsync(webSocket);
+        Assert.Equal("connected", connected.RootElement.GetProperty("event").GetString());
+        return webSocket;
+    }
+
+    private static Task SendJsonAsync(WebSocket webSocket, object message)
+    {
+        return webSocket.SendAsync(
+            JsonSerializer.SerializeToUtf8Bytes(message),
+            WebSocketMessageType.Text,
+            endOfMessage: true,
+            CancellationToken.None).WaitAsync(TestTimeout);
+    }
+
+    private static Task SendTextAsync(WebSocket webSocket, string message)
+    {
+        return webSocket.SendAsync(
+            Encoding.UTF8.GetBytes(message),
+            WebSocketMessageType.Text,
+            endOfMessage: true,
+            CancellationToken.None).WaitAsync(TestTimeout);
+    }
+
+    private static async Task<JsonDocument> ReceiveJsonAsync(WebSocket webSocket)
+    {
+        var buffer = new byte[4096];
+        var result = await webSocket.ReceiveAsync(buffer, CancellationToken.None)
+            .WaitAsync(TestTimeout);
+        Assert.Equal(WebSocketMessageType.Text, result.MessageType);
+        Assert.True(result.EndOfMessage);
+        return JsonDocument.Parse(buffer.AsMemory(0, result.Count));
+    }
+
+    private static void AssertSuccessAck(JsonElement message, ulong ackId)
+    {
+        Assert.Equal("ack", message.GetProperty("type").GetString());
+        Assert.Equal(ackId, message.GetProperty("ackId").GetUInt64());
+        Assert.True(message.GetProperty("success").GetBoolean());
+    }
+
+    private static void AssertErrorAck(
+        JsonElement message,
+        ulong ackId,
+        string errorName,
+        string errorMessage)
+    {
+        Assert.Equal("ack", message.GetProperty("type").GetString());
+        Assert.Equal(ackId, message.GetProperty("ackId").GetUInt64());
+        Assert.False(message.GetProperty("success").GetBoolean());
+        Assert.Equal(errorName, message.GetProperty("error").GetProperty("name").GetString());
+        Assert.Equal(errorMessage, message.GetProperty("error").GetProperty("message").GetString());
+    }
+
+    private static string CreateToken(
+        IEnumerable<string> roles,
+        IEnumerable<string> groups,
+        string? userId)
+    {
+        var claims = roles
+            .Select(role => new Claim("role", role))
+            .Concat(groups.Select(group => new Claim("webpubsub.group", group)))
+            .Concat(userId is null ? [] : [new Claim("sub", userId)]);
+        var token = new JwtSecurityToken(
+            audience: $"http://localhost{WebPubSubTokenService.ClientPathPrefix}{Hub}",
+            claims: claims,
+            expires: DateTime.UtcNow.AddHours(1),
+            signingCredentials: new SigningCredentials(
+                new SymmetricSecurityKey(Encoding.UTF8.GetBytes(EmulatorOptions.DefaultAccessKey)),
+                SecurityAlgorithms.HmacSha256));
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    private sealed class SuccessfulLifetimeHandler : IWebPubSubConnectionLifetimeHandler
+    {
+        private readonly MessageData? _response;
+
+        public SuccessfulLifetimeHandler()
+        {
+        }
+
+        public SuccessfulLifetimeHandler(MessageData response)
+        {
+            _response = response;
+        }
+
+        public ClientMessagePayload? Message { get; private set; }
+
+        public Task<UpstreamEventResult> SendMessageAsync(
+            LogicalConnection connection,
+            ClientMessagePayload message,
+            CancellationToken cancellationToken = default)
+        {
+            Message = message;
+            return Task.FromResult(new UpstreamEventResult(_response));
+        }
+    }
+
+    private sealed class TestLoggerProvider : ILoggerProvider
+    {
+        public ConcurrentQueue<string> Messages { get; } = new();
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            return new TestLogger(Messages);
+        }
+
+        public void Dispose()
+        {
+        }
+
+        private sealed class TestLogger : ILogger
+        {
+            private readonly ConcurrentQueue<string> _messages;
+
+            public TestLogger(ConcurrentQueue<string> messages)
+            {
+                _messages = messages;
+            }
+
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull
+            {
+                return null;
+            }
+
+            public bool IsEnabled(LogLevel logLevel)
+            {
+                return true;
+            }
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                _messages.Enqueue(formatter(state, exception));
+            }
+        }
+    }
+}


### PR DESCRIPTION
﻿## Summary
- Add non-reliable JSON Web PubSub client subprotocol support to the local emulator.
- Support connected messages, group join/leave/send, ping/pong, ACK deduplication, text/binary/JSON data, metadata, TTL validation, and noEcho.
- Add a runtime-aligned connection lifetime handler boundary for future HTTP upstream support.
- Document reliable protocols, streaming, HTTP upstream, and tunnel connections as unsupported.

## Testing
- dotnet test tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/Microsoft.Azure.WebPubSub.Emulator.Tests.csproj (47 passed)
- dotnet build tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/Microsoft.Azure.WebPubSub.Emulator.csproj --configuration Release (0 warnings, 0 errors)
