### PR TITLE
Add reliable delivery sequencing to the emulator

### DIFF
--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientPayloadProcessor.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientPayloadProcessor.cs
@@ -19,7 +19,8 @@ internal interface IClientPayloadProcessor
         LogicalConnection connection,
         string group,
         string? fromUserId,
-        MessageData data);
+        MessageData data,
+        ulong? sequenceId);
 }
 
 internal readonly record struct WebSocketPayload(

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ConnectionManager.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ConnectionManager.cs
@@ -26,7 +26,8 @@ internal sealed class ConnectionManager
         string connectionId,
         string hub,
         ClaimsPrincipal user,
-        string? rawSendToGroup = null)
+        string? rawSendToGroup = null,
+        bool reliable = false)
     {
         return new LogicalConnection(
             connectionId,
@@ -35,6 +36,7 @@ internal sealed class ConnectionManager
             rawSendToGroup,
             this,
             _runtimeOptions,
+            reliable,
             _logger);
     }
 

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorOptions.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorOptions.cs
@@ -35,4 +35,8 @@ internal sealed class EmulatorRuntimeOptions
     public int OutboundQueueCapacity { get; init; } = 1000;
 
     public long MaxOutboundQueueBytes { get; init; } = 16 * 1024 * 1024;
+
+    public int ReliableMessageBufferCapacity { get; init; } = 1000;
+
+    public long MaxReliableMessageBufferBytes { get; init; } = 16 * 1024 * 1024;
 }

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/LogicalConnection.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/LogicalConnection.cs
@@ -253,11 +253,6 @@ internal sealed class LogicalConnection
 
         lock (_stateLock)
         {
-            if (sequenceId > _nextSequenceId)
-            {
-                return;
-            }
-
             while (_unacknowledgedMessages.TryPeek(out var item) &&
                 item.SequenceId <= sequenceId)
             {

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/LogicalConnection.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/LogicalConnection.cs
@@ -11,18 +11,24 @@ namespace Microsoft.Azure.WebPubSub.Emulator;
 internal sealed class LogicalConnection
 {
     private const string OutboundQueueFullReason = "The outbound message queue is full.";
+    private const string ReliableBufferFullReason = "The reliable message buffer is full.";
 
     private readonly object _stateLock = new();
+    private readonly Queue<(ulong SequenceId, WebSocketPayload Payload)> _unacknowledgedMessages = [];
     private readonly ConnectionManager _manager;
     private readonly ILogger? _logger;
     private readonly EmulatorRuntimeOptions _runtimeOptions;
     private readonly int _outboundQueueCapacity;
     private readonly long _outboundQueueMaxBytes;
+    private readonly int _reliableBufferCapacity;
+    private readonly long _reliableBufferMaxBytes;
     private readonly ConnectionRolePermissions _joinLeaveGroupPermissions;
     private readonly ConnectionRolePermissions _sendToGroupPermissions;
 
     private IClientPayloadProcessor? _activePayloadProcessor;
     private SocketTransport? _activeTransport;
+    private ulong _nextSequenceId;
+    private long _unacknowledgedBytes;
     private bool _closed;
 
     public LogicalConnection(
@@ -32,16 +38,20 @@ internal sealed class LogicalConnection
         string? rawSendToGroup,
         ConnectionManager manager,
         EmulatorRuntimeOptions runtimeOptions,
+        bool reliable = false,
         ILogger? logger = null)
     {
         ConnectionId = connectionId;
         Hub = hub;
         RawSendToGroup = rawSendToGroup;
+        IsReliable = reliable;
         _manager = manager;
         _logger = logger;
         _runtimeOptions = runtimeOptions;
         _outboundQueueCapacity = runtimeOptions.OutboundQueueCapacity;
         _outboundQueueMaxBytes = runtimeOptions.MaxOutboundQueueBytes;
+        _reliableBufferCapacity = runtimeOptions.ReliableMessageBufferCapacity;
+        _reliableBufferMaxBytes = runtimeOptions.MaxReliableMessageBufferBytes;
 
         UserId = user.FindFirstValue("sub") ?? user.FindFirstValue(ClaimTypes.NameIdentifier);
 
@@ -75,6 +85,8 @@ internal sealed class LogicalConnection
     public string? RawSendToGroup { get; }
 
     public string? UserId { get; }
+
+    public bool IsReliable { get; }
 
     public AckCache AckIdCache { get; } = new();
 
@@ -129,7 +141,12 @@ internal sealed class LogicalConnection
             }
         }
 
-        Send(payloadProcessor.EncodeGroupData(this, group, fromUserId, data));
+        SendData(sequenceId => payloadProcessor.EncodeGroupData(
+            this,
+            group,
+            fromUserId,
+            data,
+            sequenceId));
     }
 
     public void Send(WebSocketPayload payload)
@@ -167,12 +184,86 @@ internal sealed class LogicalConnection
 
         if (dropped is not null)
         {
-            _manager.Remove(this);
-            _logger?.LogDebug(
-                "Closing connection {ConnectionId}: {Reason}",
-                ConnectionId,
-                OutboundQueueFullReason);
-            dropped.Abort();
+            FailConnection(dropped, OutboundQueueFullReason);
+        }
+    }
+
+    public void SendData(Func<ulong?, WebSocketPayload> payloadFactory)
+    {
+        SocketTransport? dropped = null;
+        var failureReason = OutboundQueueFullReason;
+        lock (_stateLock)
+        {
+            if (_closed || _activeTransport is null)
+            {
+                return;
+            }
+
+            WebSocketPayload payload;
+            if (IsReliable)
+            {
+                if (_nextSequenceId == ulong.MaxValue ||
+                    _unacknowledgedMessages.Count >= _reliableBufferCapacity)
+                {
+                    dropped = DropTransportLocked();
+                    failureReason = ReliableBufferFullReason;
+                    goto Complete;
+                }
+
+                var sequenceId = _nextSequenceId + 1;
+                payload = payloadFactory(sequenceId);
+                if (payload.Bytes.Length > _reliableBufferMaxBytes - _unacknowledgedBytes)
+                {
+                    dropped = DropTransportLocked();
+                    failureReason = ReliableBufferFullReason;
+                    goto Complete;
+                }
+
+                _nextSequenceId = sequenceId;
+                _unacknowledgedMessages.Enqueue((sequenceId, payload));
+                _unacknowledgedBytes += payload.Bytes.Length;
+            }
+            else
+            {
+                payload = payloadFactory(null);
+            }
+
+            if (_activeTransport.TryEnqueue(payload.Bytes, payload.MessageType) ==
+                TransportEnqueueResult.Full)
+            {
+                dropped = DropTransportLocked();
+            }
+
+        Complete:
+            ;
+        }
+
+        if (dropped is not null)
+        {
+            FailConnection(dropped, failureReason);
+        }
+    }
+
+    public void Acknowledge(ulong sequenceId)
+    {
+        if (!IsReliable)
+        {
+            return;
+        }
+
+        lock (_stateLock)
+        {
+            if (sequenceId > _nextSequenceId)
+            {
+                return;
+            }
+
+            while (_unacknowledgedMessages.TryPeek(out var item) &&
+                item.SequenceId <= sequenceId)
+            {
+                _unacknowledgedMessages.Dequeue();
+                _unacknowledgedBytes -= item.Payload.Bytes.Length;
+            }
         }
     }
 
@@ -186,6 +277,7 @@ internal sealed class LogicalConnection
                 _activeTransport = null;
                 _activePayloadProcessor = null;
                 _closed = true;
+                ClearReliableBufferLocked();
                 remove = true;
             }
         }
@@ -202,6 +294,23 @@ internal sealed class LogicalConnection
         _activeTransport = null;
         _activePayloadProcessor = null;
         _closed = true;
+        ClearReliableBufferLocked();
         return transport;
+    }
+
+    private void FailConnection(SocketTransport transport, string reason)
+    {
+        _manager.Remove(this);
+        _logger?.LogDebug(
+            "Closing connection {ConnectionId}: {Reason}",
+            ConnectionId,
+            reason);
+        transport.Abort();
+    }
+
+    private void ClearReliableBufferLocked()
+    {
+        _unacknowledgedMessages.Clear();
+        _unacknowledgedBytes = 0;
     }
 }

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/SimpleWebSocketPayloadProcessor.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/SimpleWebSocketPayloadProcessor.cs
@@ -47,7 +47,8 @@ internal sealed class SimpleWebSocketPayloadProcessor : IClientPayloadProcessor
         LogicalConnection connection,
         string group,
         string? fromUserId,
-        MessageData data)
+        MessageData data,
+        ulong? sequenceId)
     {
         var messageType = data.Type == MessageDataType.Binary
             ? WebSocketMessageType.Binary

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubJsonV1PayloadProcessor.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubJsonV1PayloadProcessor.cs
@@ -67,8 +67,9 @@ internal sealed class WebPubSubJsonV1PayloadProcessor : IClientPayloadProcessor
             return PayloadProcessingResult.Continue;
         }
 
-        if (request is WebPubSubClientSequenceAckRequest)
+        if (request is WebPubSubClientSequenceAckRequest sequenceAck)
         {
+            connection.Acknowledge(sequenceAck.SequenceId);
             return PayloadProcessingResult.Continue;
         }
 
@@ -128,9 +129,10 @@ internal sealed class WebPubSubJsonV1PayloadProcessor : IClientPayloadProcessor
         LogicalConnection connection,
         string group,
         string? fromUserId,
-        MessageData data)
+        MessageData data,
+        ulong? sequenceId)
     {
-        return _protocol.WriteGroupData(group, fromUserId, data);
+        return _protocol.WriteGroupData(group, fromUserId, data, sequenceId);
     }
 
     private void DispatchClientRequest(
@@ -179,7 +181,8 @@ internal sealed class WebPubSubJsonV1PayloadProcessor : IClientPayloadProcessor
                 cancellationToken);
             if (result.Response is not null)
             {
-                connection.Send(_protocol.WriteServerData(result.Response));
+                connection.SendData(
+                    sequenceId => _protocol.WriteServerData(result.Response, sequenceId));
             }
             if (request.AckId is { } ackId)
             {

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubJsonV1Protocol.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubJsonV1Protocol.cs
@@ -180,7 +180,8 @@ internal sealed partial class WebPubSubJsonV1Protocol
     public WebSocketPayload WriteGroupData(
         string group,
         string? fromUserId,
-        MessageData data)
+        MessageData data,
+        ulong? sequenceId = null)
     {
         return WriteJson(writer =>
         {
@@ -190,11 +191,17 @@ internal sealed partial class WebPubSubJsonV1Protocol
             writer.WriteString("group", group);
             writer.WriteString("fromUserId", fromUserId);
             WriteData(writer, data);
+            if (sequenceId is not null)
+            {
+                writer.WriteNumber("sequenceId", sequenceId.Value);
+            }
             writer.WriteEndObject();
         });
     }
 
-    public WebSocketPayload WriteServerData(MessageData data)
+    public WebSocketPayload WriteServerData(
+        MessageData data,
+        ulong? sequenceId = null)
     {
         return WriteJson(writer =>
         {
@@ -202,6 +209,10 @@ internal sealed partial class WebPubSubJsonV1Protocol
             writer.WriteString("type", "message");
             writer.WriteString("from", "server");
             WriteData(writer, data);
+            if (sequenceId is not null)
+            {
+                writer.WriteNumber("sequenceId", sequenceId.Value);
+            }
             writer.WriteEndObject();
         });
     }

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/LogicalConnectionTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/LogicalConnectionTests.cs
@@ -187,7 +187,7 @@ public class LogicalConnectionTests
     }
 
     [Fact]
-    public void FutureSequenceAckDoesNotReleaseReliableBufferCapacity()
+    public void FutureSequenceAckReleasesReliableBufferCapacity()
     {
         using var application = EmulatorApplication.Build(
             EmulatorApplication.CreateBuilder(
@@ -213,7 +213,7 @@ public class LogicalConnectionTests
             fromUserId: null,
             new MessageData(MessageDataType.Text, "second"u8.ToArray()));
 
-        Assert.False(manager.TryGet(connection.Hub, connection.ConnectionId, out _));
+        Assert.True(manager.TryGet(connection.Hub, connection.ConnectionId, out _));
     }
 
     [Fact]

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/LogicalConnectionTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/LogicalConnectionTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Net.WebSockets;
 using System.Security.Claims;
 using System.Threading;
@@ -99,10 +100,157 @@ public class LogicalConnectionTests
         Assert.Null(connection.TryAttach(new TestWebSocket(), TestClientPayloadProcessor.Instance));
     }
 
+    [Fact]
+    public void ReliableGroupDataUsesIncreasingSequenceIds()
+    {
+        using var application = EmulatorApplication.Build();
+        var manager = application.Services.GetRequiredService<ConnectionManager>();
+        var connection = CreateConnection(manager, "connection", reliable: true);
+        var processor = new RecordingSequencePayloadProcessor();
+        using var transport = connection.TryAttach(new TestWebSocket(), processor);
+        Assert.NotNull(transport);
+
+        connection.SendGroupData(
+            "room",
+            fromUserId: null,
+            new MessageData(MessageDataType.Text, "first"u8.ToArray()));
+        connection.SendGroupData(
+            "room",
+            fromUserId: null,
+            new MessageData(MessageDataType.Text, "second"u8.ToArray()));
+
+        Assert.Equal(new ulong?[] { 1, 2 }, processor.SequenceIds);
+    }
+
+    [Fact]
+    public void SequenceAckReleasesReliableBufferCapacity()
+    {
+        using var application = EmulatorApplication.Build(
+            EmulatorApplication.CreateBuilder(
+                runtimeOptions: new EmulatorRuntimeOptions
+                {
+                    ReliableMessageBufferCapacity = 1,
+                }));
+        var manager = application.Services.GetRequiredService<ConnectionManager>();
+        var connection = CreateConnection(manager, "connection", reliable: true);
+        using var transport = connection.TryAttach(
+            new TestWebSocket(),
+            TestClientPayloadProcessor.Instance);
+        Assert.NotNull(transport);
+        Assert.True(manager.TryActivate(connection));
+
+        connection.SendGroupData(
+            "room",
+            fromUserId: null,
+            new MessageData(MessageDataType.Text, "first"u8.ToArray()));
+        connection.Acknowledge(1);
+        connection.SendGroupData(
+            "room",
+            fromUserId: null,
+            new MessageData(MessageDataType.Text, "second"u8.ToArray()));
+
+        Assert.True(manager.TryGet(connection.Hub, connection.ConnectionId, out _));
+    }
+
+    [Fact]
+    public void CumulativeSequenceAckReleasesReliableBufferBytes()
+    {
+        using var application = EmulatorApplication.Build(
+            EmulatorApplication.CreateBuilder(
+                runtimeOptions: new EmulatorRuntimeOptions
+                {
+                    MaxReliableMessageBufferBytes = 8,
+                }));
+        var manager = application.Services.GetRequiredService<ConnectionManager>();
+        var connection = CreateConnection(manager, "connection", reliable: true);
+        using var transport = connection.TryAttach(
+            new TestWebSocket(),
+            TestClientPayloadProcessor.Instance);
+        Assert.NotNull(transport);
+        Assert.True(manager.TryActivate(connection));
+
+        connection.SendGroupData(
+            "room",
+            fromUserId: null,
+            new MessageData(MessageDataType.Binary, new byte[4]));
+        connection.SendGroupData(
+            "room",
+            fromUserId: null,
+            new MessageData(MessageDataType.Binary, new byte[4]));
+        connection.Acknowledge(2);
+        connection.SendGroupData(
+            "room",
+            fromUserId: null,
+            new MessageData(MessageDataType.Binary, new byte[8]));
+
+        Assert.True(manager.TryGet(connection.Hub, connection.ConnectionId, out _));
+    }
+
+    [Fact]
+    public void FutureSequenceAckDoesNotReleaseReliableBufferCapacity()
+    {
+        using var application = EmulatorApplication.Build(
+            EmulatorApplication.CreateBuilder(
+                runtimeOptions: new EmulatorRuntimeOptions
+                {
+                    ReliableMessageBufferCapacity = 1,
+                }));
+        var manager = application.Services.GetRequiredService<ConnectionManager>();
+        var connection = CreateConnection(manager, "connection", reliable: true);
+        using var transport = connection.TryAttach(
+            new TestWebSocket(),
+            TestClientPayloadProcessor.Instance);
+        Assert.NotNull(transport);
+        Assert.True(manager.TryActivate(connection));
+
+        connection.SendGroupData(
+            "room",
+            fromUserId: null,
+            new MessageData(MessageDataType.Text, "first"u8.ToArray()));
+        connection.Acknowledge(ulong.MaxValue);
+        connection.SendGroupData(
+            "room",
+            fromUserId: null,
+            new MessageData(MessageDataType.Text, "second"u8.ToArray()));
+
+        Assert.False(manager.TryGet(connection.Hub, connection.ConnectionId, out _));
+    }
+
+    [Fact]
+    public void ReliableBufferByteLimitAbortsAndRemovesConnection()
+    {
+        using var application = EmulatorApplication.Build(
+            EmulatorApplication.CreateBuilder(
+                runtimeOptions: new EmulatorRuntimeOptions
+                {
+                    MaxReliableMessageBufferBytes = 6,
+                }));
+        var manager = application.Services.GetRequiredService<ConnectionManager>();
+        var connection = CreateConnection(manager, "connection", reliable: true);
+        using var transport = connection.TryAttach(
+            new TestWebSocket(),
+            TestClientPayloadProcessor.Instance);
+        Assert.NotNull(transport);
+        Assert.True(manager.TryActivate(connection));
+
+        connection.SendGroupData(
+            "room",
+            fromUserId: null,
+            new MessageData(MessageDataType.Binary, new byte[4]));
+        connection.SendGroupData(
+            "room",
+            fromUserId: null,
+            new MessageData(MessageDataType.Binary, new byte[3]));
+
+        Assert.False(manager.TryGet(connection.Hub, connection.ConnectionId, out _));
+        Assert.True(transport.Aborted.IsCancellationRequested);
+    }
+
     private static LogicalConnection CreateConnection(
         ConnectionManager manager,
         string connectionId,
-        string? group = null)
+        string? group = null,
+        bool reliable = false)
     {
         var claims = group is null
             ? []
@@ -110,7 +258,8 @@ public class LogicalConnectionTests
         return manager.Create(
             connectionId,
             "chat",
-            new ClaimsPrincipal(new ClaimsIdentity(claims)));
+            new ClaimsPrincipal(new ClaimsIdentity(claims)),
+            reliable: reliable);
     }
 
     private sealed class TestClientPayloadProcessor : IClientPayloadProcessor
@@ -142,7 +291,8 @@ public class LogicalConnectionTests
             LogicalConnection connection,
             string group,
             string? fromUserId,
-            MessageData data)
+            MessageData data,
+            ulong? sequenceId)
         {
             return _webSocketPayload.Bytes.IsEmpty
                 ? new WebSocketPayload(
@@ -151,6 +301,35 @@ public class LogicalConnectionTests
                         ? WebSocketMessageType.Binary
                         : WebSocketMessageType.Text)
                 : _webSocketPayload;
+        }
+    }
+
+    private sealed class RecordingSequencePayloadProcessor : IClientPayloadProcessor
+    {
+        public List<ulong?> SequenceIds { get; } = [];
+
+        public void OnConnected(LogicalConnection connection)
+        {
+        }
+
+        public ValueTask<PayloadProcessingResult> ProcessAsync(
+            LogicalConnection connection,
+            WebSocketMessageType messageType,
+            byte[] payload,
+            CancellationToken cancellationToken)
+        {
+            return ValueTask.FromResult(PayloadProcessingResult.Continue);
+        }
+
+        public WebSocketPayload EncodeGroupData(
+            LogicalConnection connection,
+            string group,
+            string? fromUserId,
+            MessageData data,
+            ulong? sequenceId)
+        {
+            SequenceIds.Add(sequenceId);
+            return new WebSocketPayload(data.Bytes, WebSocketMessageType.Text);
         }
     }
 

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/WebPubSubJsonV1ProtocolTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/WebPubSubJsonV1ProtocolTests.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using Xunit;
+
+namespace Microsoft.Azure.WebPubSub.Emulator.Tests;
+
+public class WebPubSubJsonV1ProtocolTests
+{
+    private readonly WebPubSubJsonV1Protocol _protocol = new();
+
+    [Fact]
+    public void GroupDataIncludesSequenceId()
+    {
+        var payload = _protocol.WriteGroupData(
+            "room",
+            "user",
+            new MessageData(MessageDataType.Text, "hello"u8.ToArray()),
+            sequenceId: 42);
+
+        using var document = JsonDocument.Parse(payload.Bytes);
+
+        Assert.Equal(42UL, document.RootElement.GetProperty("sequenceId").GetUInt64());
+    }
+
+    [Fact]
+    public void ServerDataOmitsSequenceIdWhenNotReliable()
+    {
+        var payload = _protocol.WriteServerData(
+            new MessageData(MessageDataType.Text, "hello"u8.ToArray()));
+
+        using var document = JsonDocument.Parse(payload.Bytes);
+
+        Assert.False(document.RootElement.TryGetProperty("sequenceId", out _));
+    }
+
+    [Fact]
+    public void ServerDataIncludesSequenceId()
+    {
+        var payload = _protocol.WriteServerData(
+            new MessageData(MessageDataType.Text, "hello"u8.ToArray()),
+            sequenceId: 42);
+
+        using var document = JsonDocument.Parse(payload.Bytes);
+
+        Assert.Equal(42UL, document.RootElement.GetProperty("sequenceId").GetUInt64());
+    }
+}


### PR DESCRIPTION
## Summary

- add internal monotonic sequence assignment for reliable group and server messages
- process cumulative `sequenceAck` messages and reject future acknowledgements
- bound reliable delivery buffering by message count and encoded byte size

This PR intentionally does **not** negotiate the reliable subprotocol or expose reconnect behavior. Connection retention, replay, transport handoff, tokens, and endpoint activation are split into follow-up PRs.

## Testing

- Release build: 0 warnings, 0 errors
- Emulator tests: 59 passed