### PR TITLE
Retain reliable emulator connections for replay

### DIFF
--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientConnectionHandler.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientConnectionHandler.cs
@@ -33,7 +33,14 @@ internal sealed class ClientConnectionHandler
                 var message = await transport.ReceiveAsync(linkedCancellation.Token);
                 if (message.IsClose)
                 {
-                    await transport.AcknowledgeCloseAsync(message);
+                    if (message.CloseStatus == WebSocketCloseStatus.NormalClosure)
+                    {
+                        await transport.AcknowledgeCloseAsync(message);
+                    }
+                    else
+                    {
+                        transport.Abort();
+                    }
                     break;
                 }
 

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ConnectionManager.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ConnectionManager.cs
@@ -60,6 +60,11 @@ internal sealed class ConnectionManager
         _connections.TryRemove((connection.Hub, connection.ConnectionId), out _);
     }
 
+    public void ScheduleExpiration(LogicalConnection connection, long generation)
+    {
+        _ = ExpireAsync(connection, generation);
+    }
+
     public void SendToGroup(
         string hub,
         string group,
@@ -74,6 +79,25 @@ internal sealed class ConnectionManager
             .Where(connection => !noEcho || connection != sender))
         {
             connection.SendGroupData(group, sender?.UserId, data);
+        }
+    }
+
+    private async Task ExpireAsync(LogicalConnection connection, long generation)
+    {
+        try
+        {
+            await Task.Delay(_runtimeOptions.ReconnectTimeout);
+            if (connection.TryExpire(generation))
+            {
+                Remove(connection);
+            }
+        }
+        catch (Exception exception)
+        {
+            _logger.LogDebug(
+                exception,
+                "Expiring connection {ConnectionId} failed.",
+                connection.ConnectionId);
         }
     }
 }

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorOptions.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorOptions.cs
@@ -36,6 +36,8 @@ internal sealed class EmulatorRuntimeOptions
 
     public long MaxOutboundQueueBytes { get; init; } = 16 * 1024 * 1024;
 
+    public TimeSpan ReconnectTimeout { get; init; } = TimeSpan.FromSeconds(30);
+
     public int ReliableMessageBufferCapacity { get; init; } = 1000;
 
     public long MaxReliableMessageBufferBytes { get; init; } = 16 * 1024 * 1024;

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/LogicalConnection.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/LogicalConnection.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Azure.WebPubSub.Emulator;
 
 internal sealed class LogicalConnection
 {
+    private const long ReliableControlByteAllowance = 64 * 1024;
+    private const int ReliableControlMessageAllowance = 32;
     private const string OutboundQueueFullReason = "The outbound message queue is full.";
     private const string ReliableBufferFullReason = "The reliable message buffer is full.";
 
@@ -27,6 +29,7 @@ internal sealed class LogicalConnection
 
     private IClientPayloadProcessor? _activePayloadProcessor;
     private SocketTransport? _activeTransport;
+    private long _generation;
     private ulong _nextSequenceId;
     private long _unacknowledgedBytes;
     private bool _closed;
@@ -98,7 +101,7 @@ internal sealed class LogicalConnection
     {
         lock (_stateLock)
         {
-            if (_closed || _activeTransport is not null)
+            if (_closed || _activeTransport is not null || _generation != 0)
             {
                 return null;
             }
@@ -110,7 +113,60 @@ internal sealed class LogicalConnection
                 _outboundQueueMaxBytes,
                 _logger);
             _activePayloadProcessor = payloadProcessor;
+            _generation++;
             return _activeTransport;
+        }
+    }
+
+    public ValueTask<SocketTransport?> TryReconnectAsync(
+        WebSocket webSocket,
+        IClientPayloadProcessor payloadProcessor,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        lock (_stateLock)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (_closed || !IsReliable || _activeTransport is not null ||
+                _activePayloadProcessor is null)
+            {
+                return ValueTask.FromResult<SocketTransport?>(null);
+            }
+
+            var dataQueueCapacity = Math.Max(_outboundQueueCapacity, _reliableBufferCapacity);
+            var queueCapacity =
+                Math.Min(Math.Max(dataQueueCapacity, 1), int.MaxValue - ReliableControlMessageAllowance) +
+                ReliableControlMessageAllowance;
+            var dataQueueMaxBytes = Math.Max(_outboundQueueMaxBytes, _reliableBufferMaxBytes);
+            var queueMaxBytes =
+                Math.Min(Math.Max(dataQueueMaxBytes, 1), long.MaxValue - ReliableControlByteAllowance) +
+                ReliableControlByteAllowance;
+            var transport = new SocketTransport(
+                webSocket,
+                _runtimeOptions.MaxMessageSizeBytes,
+                queueCapacity,
+                queueMaxBytes,
+                _logger);
+            foreach (var item in _unacknowledgedMessages)
+            {
+                if (transport.TryEnqueue(item.Payload.Bytes, item.Payload.MessageType) !=
+                    TransportEnqueueResult.Enqueued)
+                {
+                    transport.Abort();
+                    return ValueTask.FromResult<SocketTransport?>(null);
+                }
+            }
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                transport.Abort();
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+
+            _activeTransport = transport;
+            _activePayloadProcessor = payloadProcessor;
+            _generation++;
+            return ValueTask.FromResult<SocketTransport?>(transport);
         }
     }
 
@@ -129,19 +185,7 @@ internal sealed class LogicalConnection
         string? fromUserId,
         MessageData data)
     {
-        IClientPayloadProcessor? payloadProcessor;
-        SocketTransport? transport;
-        lock (_stateLock)
-        {
-            payloadProcessor = _activePayloadProcessor;
-            transport = _activeTransport;
-            if (_closed || payloadProcessor is null || transport is null)
-            {
-                return;
-            }
-        }
-
-        SendData(sequenceId => payloadProcessor.EncodeGroupData(
+        SendData(sequenceId => _activePayloadProcessor!.EncodeGroupData(
             this,
             group,
             fromUserId,
@@ -192,9 +236,11 @@ internal sealed class LogicalConnection
     {
         SocketTransport? dropped = null;
         var failureReason = OutboundQueueFullReason;
+        var failed = false;
         lock (_stateLock)
         {
-            if (_closed || _activeTransport is null)
+            if (_closed || _activePayloadProcessor is null ||
+                (!IsReliable && _activeTransport is null))
             {
                 return;
             }
@@ -206,6 +252,7 @@ internal sealed class LogicalConnection
                     _unacknowledgedMessages.Count >= _reliableBufferCapacity)
                 {
                     dropped = DropTransportLocked();
+                    failed = true;
                     failureReason = ReliableBufferFullReason;
                     goto Complete;
                 }
@@ -215,6 +262,7 @@ internal sealed class LogicalConnection
                 if (payload.Bytes.Length > _reliableBufferMaxBytes - _unacknowledgedBytes)
                 {
                     dropped = DropTransportLocked();
+                    failed = true;
                     failureReason = ReliableBufferFullReason;
                     goto Complete;
                 }
@@ -228,17 +276,19 @@ internal sealed class LogicalConnection
                 payload = payloadFactory(null);
             }
 
-            if (_activeTransport.TryEnqueue(payload.Bytes, payload.MessageType) ==
+            if (_activeTransport is not null &&
+                _activeTransport.TryEnqueue(payload.Bytes, payload.MessageType) ==
                 TransportEnqueueResult.Full)
             {
                 dropped = DropTransportLocked();
+                failed = true;
             }
 
         Complete:
             ;
         }
 
-        if (dropped is not null)
+        if (failed)
         {
             FailConnection(dropped, failureReason);
         }
@@ -265,21 +315,51 @@ internal sealed class LogicalConnection
     public void Detach(SocketTransport transport)
     {
         var remove = false;
+        var expire = false;
+        long generation = 0;
         lock (_stateLock)
         {
             if (ReferenceEquals(_activeTransport, transport))
             {
                 _activeTransport = null;
-                _activePayloadProcessor = null;
-                _closed = true;
-                ClearReliableBufferLocked();
-                remove = true;
+                if (!IsReliable || transport.IsClosing)
+                {
+                    _activePayloadProcessor = null;
+                    _closed = true;
+                    ClearReliableBufferLocked();
+                    remove = true;
+                }
+                else
+                {
+                    generation = _generation;
+                    expire = true;
+                }
             }
         }
 
         if (remove)
         {
             _manager.Remove(this);
+        }
+        else if (expire)
+        {
+            _manager.ScheduleExpiration(this, generation);
+        }
+    }
+
+    public bool TryExpire(long generation)
+    {
+        lock (_stateLock)
+        {
+            if (_closed || _activeTransport is not null || _generation != generation)
+            {
+                return false;
+            }
+
+            _closed = true;
+            _activePayloadProcessor = null;
+            ClearReliableBufferLocked();
+            return true;
         }
     }
 
@@ -293,14 +373,14 @@ internal sealed class LogicalConnection
         return transport;
     }
 
-    private void FailConnection(SocketTransport transport, string reason)
+    private void FailConnection(SocketTransport? transport, string reason)
     {
         _manager.Remove(this);
         _logger?.LogDebug(
             "Closing connection {ConnectionId}: {Reason}",
             ConnectionId,
             reason);
-        transport.Abort();
+        transport?.Abort();
     }
 
     private void ClearReliableBufferLocked()

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/LogicalConnectionTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/LogicalConnectionTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Net.WebSockets;
 using System.Security.Claims;
 using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
@@ -246,6 +247,196 @@ public class LogicalConnectionTests
         Assert.True(transport.Aborted.IsCancellationRequested);
     }
 
+    [Fact]
+    public async Task ReliableDetachBuffersAndReplaysUnacknowledgedDataInOrder()
+    {
+        using var application = EmulatorApplication.Build();
+        var manager = application.Services.GetRequiredService<ConnectionManager>();
+        var connection = CreateConnection(manager, "connection", "room", reliable: true);
+        using var original = connection.TryAttach(
+            new TestWebSocket(),
+            TestClientPayloadProcessor.Instance);
+        Assert.NotNull(original);
+        Assert.True(manager.TryActivate(connection));
+        connection.SendGroupData(
+            "room",
+            fromUserId: null,
+            new MessageData(MessageDataType.Text, "acknowledged"u8.ToArray()));
+        connection.Acknowledge(1);
+        connection.Detach(original);
+
+        connection.SendGroupData(
+            "room",
+            fromUserId: null,
+            new MessageData(MessageDataType.Text, "second"u8.ToArray()));
+        connection.SendGroupData(
+            "room",
+            fromUserId: null,
+            new MessageData(MessageDataType.Text, "third"u8.ToArray()));
+        var recoveredSocket = new QueueingSendWebSocket();
+        using var recovered = await connection.TryReconnectAsync(
+            recoveredSocket,
+            TestClientPayloadProcessor.Instance,
+            CancellationToken.None);
+
+        Assert.NotNull(recovered);
+        Assert.True(connection.Groups.ContainsKey("room"));
+        Assert.Equal("second"u8.ToArray(), await recoveredSocket.ReadAsync());
+        Assert.Equal("third"u8.ToArray(), await recoveredSocket.ReadAsync());
+    }
+
+    [Fact]
+    public async Task ReliableRecoveryRequiresDetachedConnectionLifecycle()
+    {
+        using var application = EmulatorApplication.Build();
+        var manager = application.Services.GetRequiredService<ConnectionManager>();
+        var connection = CreateConnection(manager, "connection", reliable: true);
+
+        using var prematureRecovery = await connection.TryReconnectAsync(
+            new TestWebSocket(),
+            TestClientPayloadProcessor.Instance,
+            CancellationToken.None);
+        using var original = connection.TryAttach(
+            new TestWebSocket(),
+            TestClientPayloadProcessor.Instance);
+        Assert.NotNull(original);
+        connection.Detach(original);
+        using var bypass = connection.TryAttach(
+            new TestWebSocket(),
+            TestClientPayloadProcessor.Instance);
+
+        Assert.Null(prematureRecovery);
+        Assert.Null(bypass);
+    }
+
+    [Fact]
+    public void ReliableBufferOverflowWhileDetachedRemovesConnection()
+    {
+        using var application = EmulatorApplication.Build(
+            EmulatorApplication.CreateBuilder(
+                runtimeOptions: new EmulatorRuntimeOptions
+                {
+                    ReliableMessageBufferCapacity = 1,
+                }));
+        var manager = application.Services.GetRequiredService<ConnectionManager>();
+        var connection = CreateConnection(manager, "connection", reliable: true);
+        using var transport = connection.TryAttach(
+            new TestWebSocket(),
+            TestClientPayloadProcessor.Instance);
+        Assert.NotNull(transport);
+        Assert.True(manager.TryActivate(connection));
+        connection.Detach(transport);
+
+        connection.SendGroupData(
+            "room",
+            fromUserId: null,
+            new MessageData(MessageDataType.Text, "first"u8.ToArray()));
+        connection.SendGroupData(
+            "room",
+            fromUserId: null,
+            new MessageData(MessageDataType.Text, "second"u8.ToArray()));
+
+        Assert.False(manager.TryGet(connection.Hub, connection.ConnectionId, out _));
+    }
+
+    [Fact]
+    public void ReliableNormalCloseRemovesConnection()
+    {
+        using var application = EmulatorApplication.Build();
+        var manager = application.Services.GetRequiredService<ConnectionManager>();
+        var connection = CreateConnection(manager, "connection", reliable: true);
+        using var transport = connection.TryAttach(
+            new TestWebSocket(),
+            TestClientPayloadProcessor.Instance);
+        Assert.NotNull(transport);
+        Assert.True(manager.TryActivate(connection));
+
+        transport.CloseOutput(WebSocketCloseStatus.NormalClosure, "done");
+        connection.Detach(transport);
+
+        Assert.False(manager.TryGet(connection.Hub, connection.ConnectionId, out _));
+    }
+
+    [Fact]
+    public async Task ReliableNonNormalCloseCanReconnect()
+    {
+        using var application = EmulatorApplication.Build();
+        var manager = application.Services.GetRequiredService<ConnectionManager>();
+        var handler = application.Services.GetRequiredService<ClientConnectionHandler>();
+        var connection = CreateConnection(manager, "connection", reliable: true);
+        using var original = connection.TryAttach(
+            new NonNormalClosingWebSocket(),
+            TestClientPayloadProcessor.Instance);
+        Assert.NotNull(original);
+        Assert.True(manager.TryActivate(connection));
+
+        await handler.RunAsync(
+            connection.ConnectionId,
+            connection,
+            original,
+            TestClientPayloadProcessor.Instance,
+            CancellationToken.None);
+        connection.Detach(original);
+        using var recovered = await connection.TryReconnectAsync(
+            new TestWebSocket(),
+            TestClientPayloadProcessor.Instance,
+            CancellationToken.None);
+
+        Assert.NotNull(recovered);
+        Assert.True(manager.TryGet(connection.Hub, connection.ConnectionId, out _));
+    }
+
+    [Fact]
+    public async Task ReliableDetachExpiresWithoutReconnect()
+    {
+        using var application = EmulatorApplication.Build(
+            EmulatorApplication.CreateBuilder(
+                runtimeOptions: new EmulatorRuntimeOptions
+                {
+                    ReconnectTimeout = TimeSpan.FromMilliseconds(50),
+                }));
+        var manager = application.Services.GetRequiredService<ConnectionManager>();
+        var connection = CreateConnection(manager, "connection", reliable: true);
+        using var transport = connection.TryAttach(
+            new TestWebSocket(),
+            TestClientPayloadProcessor.Instance);
+        Assert.NotNull(transport);
+        Assert.True(manager.TryActivate(connection));
+
+        connection.Detach(transport);
+        await Task.Delay(250);
+
+        Assert.False(manager.TryGet(connection.Hub, connection.ConnectionId, out _));
+    }
+
+    [Fact]
+    public async Task ReconnectFencesPreviousExpiration()
+    {
+        using var application = EmulatorApplication.Build(
+            EmulatorApplication.CreateBuilder(
+                runtimeOptions: new EmulatorRuntimeOptions
+                {
+                    ReconnectTimeout = TimeSpan.FromMilliseconds(50),
+                }));
+        var manager = application.Services.GetRequiredService<ConnectionManager>();
+        var connection = CreateConnection(manager, "connection", reliable: true);
+        using var original = connection.TryAttach(
+            new TestWebSocket(),
+            TestClientPayloadProcessor.Instance);
+        Assert.NotNull(original);
+        Assert.True(manager.TryActivate(connection));
+        connection.Detach(original);
+
+        using var recovered = await connection.TryReconnectAsync(
+            new TestWebSocket(),
+            TestClientPayloadProcessor.Instance,
+            CancellationToken.None);
+        await Task.Delay(250);
+
+        Assert.NotNull(recovered);
+        Assert.True(manager.TryGet(connection.Hub, connection.ConnectionId, out _));
+    }
+
     private static LogicalConnection CreateConnection(
         ConnectionManager manager,
         string connectionId,
@@ -406,6 +597,26 @@ public class LogicalConnectionTests
         }
     }
 
+    private sealed class NonNormalClosingWebSocket : TestWebSocket
+    {
+        public override WebSocketCloseStatus? CloseStatus =>
+            WebSocketCloseStatus.EndpointUnavailable;
+
+        public override WebSocketState State => WebSocketState.CloseReceived;
+
+        public override Task<WebSocketReceiveResult> ReceiveAsync(
+            ArraySegment<byte> buffer,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new WebSocketReceiveResult(
+                0,
+                WebSocketMessageType.Close,
+                endOfMessage: true,
+                CloseStatus,
+                "unavailable"));
+        }
+    }
+
     private sealed class RecordingSendWebSocket : TestWebSocket
     {
         public TaskCompletionSource<(byte[] Payload, WebSocketMessageType MessageType)> Sent { get; } =
@@ -419,6 +630,26 @@ public class LogicalConnectionTests
         {
             Sent.TrySetResult((buffer.ToArray(), messageType));
             return Task.CompletedTask;
+        }
+    }
+
+    private sealed class QueueingSendWebSocket : TestWebSocket
+    {
+        private readonly Channel<byte[]> _sent = Channel.CreateUnbounded<byte[]>();
+
+        public override Task SendAsync(
+            ArraySegment<byte> buffer,
+            WebSocketMessageType messageType,
+            bool endOfMessage,
+            CancellationToken cancellationToken)
+        {
+            _sent.Writer.TryWrite(buffer.ToArray());
+            return Task.CompletedTask;
+        }
+
+        public async Task<byte[]> ReadAsync()
+        {
+            return await _sent.Reader.ReadAsync().AsTask().WaitAsync(TestTimeout);
         }
     }
 }


### PR DESCRIPTION
## Summary

- retain reliable logical connections after an unexpected transport drop
- buffer messages while detached and replay unacknowledged messages in sequence order
- preserve group membership across recovery and fence stale expiration tasks

## Scope

Builds on #1059. Transport handoff concurrency, recovery authentication, and endpoint activation remain in follow-up PRs.

## Testing

- `dotnet test tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/Microsoft.Azure.WebPubSub.Emulator.Tests.csproj --configuration Release --no-restore`
- 65 passed, 0 failed, 0 skipped