### PR TITLE
Honor client message TTL in the emulator

### DIFF
--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/LogicalConnection.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/LogicalConnection.cs
@@ -16,7 +16,8 @@ internal sealed class LogicalConnection
     private const string ReliableBufferFullReason = "The reliable message buffer is full.";
 
     private readonly object _stateLock = new();
-    private readonly Queue<(ulong SequenceId, WebSocketPayload Payload)> _unacknowledgedMessages = [];
+    private readonly Queue<(ulong SequenceId, WebSocketPayload Payload, DateTime? ExpireAt)>
+        _unacknowledgedMessages = [];
     private readonly ConnectionManager _manager;
     private readonly ILogger? _logger;
     private readonly EmulatorRuntimeOptions _runtimeOptions;
@@ -147,9 +148,13 @@ internal sealed class LogicalConnection
                 queueCapacity,
                 queueMaxBytes,
                 _logger);
+            RemoveExpiredMessagesLocked(DateTime.UtcNow);
             foreach (var item in _unacknowledgedMessages)
             {
-                if (transport.TryEnqueue(item.Payload.Bytes, item.Payload.MessageType) !=
+                if (transport.TryEnqueue(
+                        item.Payload.Bytes,
+                        item.Payload.MessageType,
+                        item.ExpireAt) !=
                     TransportEnqueueResult.Enqueued)
                 {
                     transport.Abort();
@@ -190,7 +195,8 @@ internal sealed class LogicalConnection
             group,
             fromUserId,
             data,
-            sequenceId));
+            sequenceId),
+            data.ExpireAt);
     }
 
     public void Send(WebSocketPayload payload)
@@ -232,7 +238,9 @@ internal sealed class LogicalConnection
         }
     }
 
-    public void SendData(Func<ulong?, WebSocketPayload> payloadFactory)
+    public void SendData(
+        Func<ulong?, WebSocketPayload> payloadFactory,
+        DateTime? expireAt = null)
     {
         SocketTransport? dropped = null;
         var failureReason = OutboundQueueFullReason;
@@ -245,9 +253,15 @@ internal sealed class LogicalConnection
                 return;
             }
 
+            if (expireAt.HasValue && expireAt.Value < DateTime.UtcNow)
+            {
+                return;
+            }
+
             WebSocketPayload payload;
             if (IsReliable)
             {
+                RemoveExpiredMessagesLocked(DateTime.UtcNow);
                 if (_nextSequenceId == ulong.MaxValue ||
                     _unacknowledgedMessages.Count >= _reliableBufferCapacity)
                 {
@@ -268,7 +282,7 @@ internal sealed class LogicalConnection
                 }
 
                 _nextSequenceId = sequenceId;
-                _unacknowledgedMessages.Enqueue((sequenceId, payload));
+                _unacknowledgedMessages.Enqueue((sequenceId, payload, expireAt));
                 _unacknowledgedBytes += payload.Bytes.Length;
             }
             else
@@ -277,7 +291,7 @@ internal sealed class LogicalConnection
             }
 
             if (_activeTransport is not null &&
-                _activeTransport.TryEnqueue(payload.Bytes, payload.MessageType) ==
+                _activeTransport.TryEnqueue(payload.Bytes, payload.MessageType, expireAt) ==
                 TransportEnqueueResult.Full)
             {
                 dropped = DropTransportLocked();
@@ -387,5 +401,22 @@ internal sealed class LogicalConnection
     {
         _unacknowledgedMessages.Clear();
         _unacknowledgedBytes = 0;
+    }
+
+    private void RemoveExpiredMessagesLocked(DateTime utcNow)
+    {
+        var count = _unacknowledgedMessages.Count;
+        for (var i = 0; i < count; i++)
+        {
+            var item = _unacknowledgedMessages.Dequeue();
+            if (item.ExpireAt.HasValue && item.ExpireAt.Value < utcNow)
+            {
+                _unacknowledgedBytes -= item.Payload.Bytes.Length;
+            }
+            else
+            {
+                _unacknowledgedMessages.Enqueue(item);
+            }
+        }
     }
 }

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/MessageData.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/MessageData.cs
@@ -13,4 +13,5 @@ internal enum MessageDataType
 internal sealed record MessageData(
     MessageDataType Type,
     ReadOnlyMemory<byte> Bytes,
-    IReadOnlyDictionary<string, string>? Metadata = null);
+    IReadOnlyDictionary<string, string>? Metadata = null,
+    DateTime? ExpireAt = null);

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/SocketTransport.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/SocketTransport.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.WebPubSub.Emulator;
 internal readonly record struct OutboundMessage(
     ReadOnlyMemory<byte> Payload,
     WebSocketMessageType MessageType,
+    DateTime? ExpireAt,
     WebSocketCloseStatus? CloseStatus,
     string? CloseDescription);
 
@@ -54,7 +55,7 @@ internal sealed class SocketTransport : IDisposable
         _outbound = Channel.CreateBounded<OutboundMessage>(
             new BoundedChannelOptions(_dataCapacity + 1)
             {
-                SingleReader = true,
+                SingleReader = false,
                 SingleWriter = false,
                 AllowSynchronousContinuations = false,
                 FullMode = BoundedChannelFullMode.Wait,
@@ -102,7 +103,8 @@ internal sealed class SocketTransport : IDisposable
 
     public TransportEnqueueResult TryEnqueue(
         ReadOnlyMemory<byte> payload,
-        WebSocketMessageType messageType)
+        WebSocketMessageType messageType,
+        DateTime? expireAt = null)
     {
         lock (_enqueueLock)
         {
@@ -114,12 +116,19 @@ internal sealed class SocketTransport : IDisposable
             if (_queuedDataMessages >= _dataCapacity ||
                 payload.Length > _maxDataBytes - _queuedDataBytes)
             {
+                RemoveExpiredQueuedMessagesLocked(DateTime.UtcNow);
+            }
+
+            if (_queuedDataMessages >= _dataCapacity ||
+                payload.Length > _maxDataBytes - _queuedDataBytes)
+            {
                 return TransportEnqueueResult.Full;
             }
 
             if (_outbound.Writer.TryWrite(new OutboundMessage(
                 payload,
                 messageType,
+                expireAt,
                 null,
                 null)))
             {
@@ -137,6 +146,7 @@ internal sealed class SocketTransport : IDisposable
         QueueClose(new OutboundMessage(
             default,
             WebSocketMessageType.Close,
+            null,
             status,
             description));
     }
@@ -194,9 +204,12 @@ internal sealed class SocketTransport : IDisposable
 
     private void End(bool abortSocket)
     {
-        if (Interlocked.Exchange(ref _ended, 1) == 0)
+        lock (_enqueueLock)
         {
-            _outbound.Writer.TryComplete();
+            if (Interlocked.Exchange(ref _ended, 1) == 0)
+            {
+                _outbound.Writer.TryComplete();
+            }
         }
 
         if (abortSocket)
@@ -263,14 +276,17 @@ internal sealed class SocketTransport : IDisposable
                         return;
                     }
 
+                    if (message.ExpireAt.HasValue &&
+                        message.ExpireAt.Value < DateTime.UtcNow)
+                    {
+                        CompleteDataMessage(message);
+                        continue;
+                    }
+
                     await WebSocket
                         .SendAsync(message.Payload, message.MessageType, endOfMessage: true, _abortToken)
                         .ConfigureAwait(false);
-                    lock (_enqueueLock)
-                    {
-                        _queuedDataMessages--;
-                        _queuedDataBytes -= message.Payload.Length;
-                    }
+                    CompleteDataMessage(message);
                 }
             }
         }
@@ -283,6 +299,48 @@ internal sealed class SocketTransport : IDisposable
         finally
         {
             End(abortSocket: !closedGracefully);
+        }
+    }
+
+    private void CompleteDataMessage(OutboundMessage message)
+    {
+        lock (_enqueueLock)
+        {
+            _queuedDataMessages--;
+            _queuedDataBytes -= message.Payload.Length;
+        }
+    }
+
+    private void RemoveExpiredQueuedMessagesLocked(DateTime utcNow)
+    {
+        List<OutboundMessage>? retained = null;
+        while (_outbound.Reader.TryRead(out var message))
+        {
+            if (message.CloseStatus is null &&
+                message.ExpireAt.HasValue &&
+                message.ExpireAt.Value < utcNow)
+            {
+                _queuedDataMessages--;
+                _queuedDataBytes -= message.Payload.Length;
+            }
+            else
+            {
+                retained ??= [];
+                retained.Add(message);
+            }
+        }
+
+        if (retained is null)
+        {
+            return;
+        }
+
+        foreach (var message in retained)
+        {
+            if (!_outbound.Writer.TryWrite(message))
+            {
+                throw new InvalidOperationException("Failed to compact the outbound queue.");
+            }
         }
     }
 }

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubJsonV1PayloadProcessor.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubJsonV1PayloadProcessor.cs
@@ -158,7 +158,12 @@ internal sealed class WebPubSubJsonV1PayloadProcessor : IClientPayloadProcessor
                 _connections.SendToGroup(
                     connection.Hub,
                     send.Group,
-                    send.Data,
+                    send.TtlSeconds == 0
+                        ? send.Data
+                        : send.Data with
+                        {
+                            ExpireAt = DateTime.UtcNow.AddSeconds(send.TtlSeconds),
+                        },
                     connection,
                     send.NoEcho);
                 break;

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/LogicalConnectionTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/LogicalConnectionTests.cs
@@ -248,6 +248,63 @@ public class LogicalConnectionTests
     }
 
     [Fact]
+    public async Task ExpiredNonReliableMessagesDoNotConsumeOutboundCapacity()
+    {
+        using var application = EmulatorApplication.Build(
+            EmulatorApplication.CreateBuilder(
+                runtimeOptions: new EmulatorRuntimeOptions
+                {
+                    OutboundQueueCapacity = 2,
+                    MaxOutboundQueueBytes = 12,
+                }));
+        var manager = application.Services.GetRequiredService<ConnectionManager>();
+        var jsonProcessor = application.Services
+            .GetRequiredService<WebPubSubJsonV1PayloadProcessor>();
+        var sender = manager.Create(
+            "sender",
+            "chat",
+            new ClaimsPrincipal(new ClaimsIdentity(
+                [new Claim("role", "webpubsub.sendToGroup")])),
+            reliable: false);
+        var connection = CreateConnection(manager, "connection", "room");
+        var webSocket = new GatedQueueingSendWebSocket();
+        using var transport = connection.TryAttach(
+            webSocket,
+            TestClientPayloadProcessor.Instance);
+        Assert.NotNull(transport);
+        Assert.True(manager.TryActivate(connection));
+
+        connection.SendGroupData(
+            "room",
+            fromUserId: null,
+            new MessageData(MessageDataType.Text, "first"u8.ToArray()));
+        await webSocket.SendStarted.Task.WaitAsync(TestTimeout);
+        connection.SendGroupData(
+            "room",
+            fromUserId: null,
+            new MessageData(
+                MessageDataType.Text,
+                "expired"u8.ToArray(),
+                ExpireAt: DateTime.UtcNow.AddSeconds(-1)));
+        await jsonProcessor.ProcessAsync(
+            sender,
+            WebSocketMessageType.Text,
+            """{"type":"sendToGroup","group":"room","dataType":"text","data":"expired","ttlSeconds":1}"""u8.ToArray(),
+            CancellationToken.None);
+        await Task.Delay(1100);
+        connection.SendGroupData(
+            "room",
+            fromUserId: null,
+            new MessageData(MessageDataType.Text, "third"u8.ToArray()));
+
+        Assert.True(manager.TryGet(connection.Hub, connection.ConnectionId, out _));
+        Assert.False(transport.Aborted.IsCancellationRequested);
+        webSocket.Release.TrySetResult();
+        Assert.Equal("first"u8.ToArray(), await webSocket.ReadAsync());
+        Assert.Equal("third"u8.ToArray(), await webSocket.ReadAsync());
+    }
+
+    [Fact]
     public async Task ReliableDetachBuffersAndReplaysUnacknowledgedDataInOrder()
     {
         using var application = EmulatorApplication.Build();
@@ -337,6 +394,50 @@ public class LogicalConnectionTests
             new MessageData(MessageDataType.Text, "second"u8.ToArray()));
 
         Assert.False(manager.TryGet(connection.Hub, connection.ConnectionId, out _));
+    }
+
+    [Fact]
+    public async Task ExpiredReliableMessageIsRemovedBeforeReplayAndCapacityCheck()
+    {
+        using var application = EmulatorApplication.Build(
+            EmulatorApplication.CreateBuilder(
+                runtimeOptions: new EmulatorRuntimeOptions
+                {
+                    ReliableMessageBufferCapacity = 1,
+                    MaxReliableMessageBufferBytes = 7,
+                }));
+        var manager = application.Services.GetRequiredService<ConnectionManager>();
+        var connection = CreateConnection(manager, "connection", reliable: true);
+        var processor = new RecordingSequencePayloadProcessor();
+        using var original = connection.TryAttach(
+            new TestWebSocket(),
+            processor);
+        Assert.NotNull(original);
+        Assert.True(manager.TryActivate(connection));
+        connection.Detach(original);
+        connection.SendGroupData(
+            "room",
+            fromUserId: null,
+            new MessageData(
+                MessageDataType.Text,
+                "expired"u8.ToArray(),
+                ExpireAt: DateTime.UtcNow.AddMilliseconds(10)));
+        await Task.Delay(100);
+
+        connection.SendGroupData(
+            "room",
+            fromUserId: null,
+            new MessageData(MessageDataType.Text, "live"u8.ToArray()));
+        var recoveredSocket = new QueueingSendWebSocket();
+        using var recovered = await connection.TryReconnectAsync(
+            recoveredSocket,
+            TestClientPayloadProcessor.Instance,
+            CancellationToken.None);
+
+        Assert.NotNull(recovered);
+        Assert.Equal("live"u8.ToArray(), await recoveredSocket.ReadAsync());
+        Assert.Equal(new ulong?[] { 1, 2 }, processor.SequenceIds);
+        Assert.True(manager.TryGet(connection.Hub, connection.ConnectionId, out _));
     }
 
     [Fact]
@@ -630,6 +731,38 @@ public class LogicalConnectionTests
         {
             Sent.TrySetResult((buffer.ToArray(), messageType));
             return Task.CompletedTask;
+        }
+    }
+
+    private sealed class GatedQueueingSendWebSocket : TestWebSocket
+    {
+        private readonly Channel<byte[]> _sent = Channel.CreateUnbounded<byte[]>();
+        private int _sendCount;
+
+        public TaskCompletionSource SendStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource Release { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public override async Task SendAsync(
+            ArraySegment<byte> buffer,
+            WebSocketMessageType messageType,
+            bool endOfMessage,
+            CancellationToken cancellationToken)
+        {
+            if (Interlocked.Increment(ref _sendCount) == 1)
+            {
+                SendStarted.TrySetResult();
+                await Release.Task.WaitAsync(cancellationToken);
+            }
+
+            _sent.Writer.TryWrite(buffer.ToArray());
+        }
+
+        public async Task<byte[]> ReadAsync()
+        {
+            return await _sent.Reader.ReadAsync().AsTask().WaitAsync(TestTimeout);
         }
     }
 


### PR DESCRIPTION
## Summary
- propagate client `ttlSeconds` as an absolute message expiration time
- discard expired data before enqueue, replay, and transport delivery
- reclaim expired reliable and outbound queue capacity while preserving FIFO sequence IDs

## Validation
- `dotnet test tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/Microsoft.Azure.WebPubSub.Emulator.Tests.csproj --configuration Release --no-restore`
- 68 tests passed