### PR TITLE
Safely hand off reliable transports in emulator

### DIFF
--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientConnectionHandler.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientConnectionHandler.cs
@@ -27,38 +27,115 @@ internal sealed class ClientConnectionHandler
             transport.Aborted);
         try
         {
-            processor.OnConnected(connection);
+            if (!await connection.ProcessIfCurrentAsync(
+                transport,
+                () =>
+                {
+                    processor.OnConnected(connection);
+                    return ValueTask.CompletedTask;
+                },
+                linkedCancellation.Token))
+            {
+                return;
+            }
+
             while (!linkedCancellation.IsCancellationRequested)
             {
-                var message = await transport.ReceiveAsync(linkedCancellation.Token);
-                if (message.IsClose)
+                ReceivedWebSocketMessage? message = null;
+                WebSocketCloseStatus? terminalCloseStatus = null;
+                string terminalCloseDescription = string.Empty;
+                var current = await connection.ProcessIfCurrentAsync(
+                    transport,
+                    async () =>
+                    {
+                        try
+                        {
+                            message = await transport.ReceiveAsync(linkedCancellation.Token);
+                        }
+                        catch (WebSocketMessageTooLargeException exception)
+                        {
+                            _logger.LogDebug(
+                                exception,
+                                "WebSocket connection {ConnectionId} exceeded the message size limit.",
+                                connectionId);
+                            terminalCloseStatus = WebSocketCloseStatus.MessageTooBig;
+                            terminalCloseDescription = "The client message is too large.";
+                            connection.CloseIfCurrent(
+                                transport,
+                                terminalCloseStatus.Value,
+                                terminalCloseDescription);
+                            return;
+                        }
+                        catch (InvalidDataException exception)
+                        {
+                            _logger.LogDebug(
+                                exception,
+                                "WebSocket connection {ConnectionId} received an invalid frame.",
+                                connectionId);
+                            terminalCloseStatus = WebSocketCloseStatus.ProtocolError;
+                            terminalCloseDescription = "The client frame is invalid.";
+                            connection.CloseIfCurrent(
+                                transport,
+                                terminalCloseStatus.Value,
+                                terminalCloseDescription);
+                            return;
+                        }
+
+                        if (message.IsClose)
+                        {
+                            if (message.CloseStatus == WebSocketCloseStatus.NormalClosure)
+                            {
+                                terminalCloseStatus = WebSocketCloseStatus.NormalClosure;
+                                terminalCloseDescription =
+                                    message.CloseStatusDescription ?? string.Empty;
+                                connection.CloseIfCurrent(
+                                    transport,
+                                    terminalCloseStatus.Value,
+                                    terminalCloseDescription);
+                            }
+                            else
+                            {
+                                transport.Abort();
+                            }
+                            return;
+                        }
+
+                        if (transport.IsClosing)
+                        {
+                            return;
+                        }
+
+                        var result = await processor.ProcessAsync(
+                            connection,
+                            message.MessageType,
+                            message.Payload,
+                            linkedCancellation.Token);
+                        if (result.CloseStatus is { } closeStatus)
+                        {
+                            terminalCloseStatus = closeStatus;
+                            terminalCloseDescription = result.CloseDescription ?? string.Empty;
+                            connection.CloseIfCurrent(
+                                transport,
+                                terminalCloseStatus.Value,
+                                terminalCloseDescription);
+                        }
+                    },
+                    linkedCancellation.Token);
+                if (!current)
                 {
-                    if (message.CloseStatus == WebSocketCloseStatus.NormalClosure)
-                    {
-                        await transport.AcknowledgeCloseAsync(message);
-                    }
-                    else
-                    {
-                        transport.Abort();
-                    }
                     break;
                 }
 
-                if (transport.IsClosing)
-                {
-                    continue;
-                }
-
-                var result = await processor.ProcessAsync(
-                    connection,
-                    message.MessageType,
-                    message.Payload,
-                    linkedCancellation.Token);
-                if (result.CloseStatus is { } closeStatus)
+                if (terminalCloseStatus is { } closeStatus)
                 {
                     await transport.CloseAsync(
                         closeStatus,
-                        result.CloseDescription ?? string.Empty);
+                        terminalCloseDescription);
+                    break;
+                }
+
+                if (message?.IsClose == true)
+                {
                     break;
                 }
             }
@@ -72,6 +149,10 @@ internal sealed class ClientConnectionHandler
                 exception,
                 "WebSocket connection {ConnectionId} exceeded the message size limit.",
                 connectionId);
+            connection.CloseIfCurrent(
+                transport,
+                WebSocketCloseStatus.MessageTooBig,
+                "The client message is too large.");
             await transport.CloseAsync(
                 WebSocketCloseStatus.MessageTooBig,
                 "The client message is too large.");
@@ -82,6 +163,10 @@ internal sealed class ClientConnectionHandler
                 exception,
                 "WebSocket connection {ConnectionId} received an invalid frame.",
                 connectionId);
+            connection.CloseIfCurrent(
+                transport,
+                WebSocketCloseStatus.ProtocolError,
+                "The client frame is invalid.");
             await transport.CloseAsync(
                 WebSocketCloseStatus.ProtocolError,
                 "The client frame is invalid.");

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/LogicalConnection.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/LogicalConnection.cs
@@ -15,6 +15,7 @@ internal sealed class LogicalConnection
     private const string OutboundQueueFullReason = "The outbound message queue is full.";
     private const string ReliableBufferFullReason = "The reliable message buffer is full.";
 
+    private readonly SemaphoreSlim _processingGate = new(1, 1);
     private readonly object _stateLock = new();
     private readonly Queue<(ulong SequenceId, WebSocketPayload Payload)> _unacknowledgedMessages = [];
     private readonly ConnectionManager _manager;
@@ -29,10 +30,12 @@ internal sealed class LogicalConnection
 
     private IClientPayloadProcessor? _activePayloadProcessor;
     private SocketTransport? _activeTransport;
+    private SocketTransport? _detachedTransport;
     private long _generation;
     private ulong _nextSequenceId;
     private long _unacknowledgedBytes;
     private bool _closed;
+    private bool _reconnecting;
 
     public LogicalConnection(
         string connectionId,
@@ -106,68 +109,121 @@ internal sealed class LogicalConnection
                 return null;
             }
 
-            _activeTransport = new SocketTransport(
-                webSocket,
-                _runtimeOptions.MaxMessageSizeBytes,
-                _outboundQueueCapacity,
-                _outboundQueueMaxBytes,
-                _logger);
-            _activePayloadProcessor = payloadProcessor;
-            _generation++;
-            return _activeTransport;
+            return AttachLocked(webSocket, payloadProcessor, replay: false);
         }
     }
 
-    public ValueTask<SocketTransport?> TryReconnectAsync(
+    public async ValueTask<SocketTransport?> TryReconnectAsync(
         WebSocket webSocket,
         IClientPayloadProcessor payloadProcessor,
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
+        SocketTransport? previousTransport;
         lock (_stateLock)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (_closed || !IsReliable || _activeTransport is not null ||
-                _activePayloadProcessor is null)
+            if (_closed || !IsReliable || _activePayloadProcessor is null || _reconnecting)
             {
-                return ValueTask.FromResult<SocketTransport?>(null);
+                return null;
             }
 
-            var dataQueueCapacity = Math.Max(_outboundQueueCapacity, _reliableBufferCapacity);
-            var queueCapacity =
-                Math.Min(Math.Max(dataQueueCapacity, 1), int.MaxValue - ReliableControlMessageAllowance) +
-                ReliableControlMessageAllowance;
-            var dataQueueMaxBytes = Math.Max(_outboundQueueMaxBytes, _reliableBufferMaxBytes);
-            var queueMaxBytes =
-                Math.Min(Math.Max(dataQueueMaxBytes, 1), long.MaxValue - ReliableControlByteAllowance) +
-                ReliableControlByteAllowance;
-            var transport = new SocketTransport(
-                webSocket,
-                _runtimeOptions.MaxMessageSizeBytes,
-                queueCapacity,
-                queueMaxBytes,
-                _logger);
+            previousTransport = _activeTransport ?? _detachedTransport;
+            if (previousTransport is not null && !previousTransport.TryAbortForReconnect())
+            {
+                return null;
+            }
+
+            _reconnecting = true;
+        }
+
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(_runtimeOptions.ReconnectTimeout);
+        try
+        {
+            if (previousTransport is not null)
+            {
+                await previousTransport.WaitForCompletionAsync(timeout.Token);
+            }
+
+            await _processingGate.WaitAsync(timeout.Token);
+            try
+            {
+                timeout.Token.ThrowIfCancellationRequested();
+                lock (_stateLock)
+                {
+                    timeout.Token.ThrowIfCancellationRequested();
+                    if (_closed || _activePayloadProcessor is null ||
+                        (_activeTransport is not null &&
+                            !ReferenceEquals(_activeTransport, previousTransport)))
+                    {
+                        return null;
+                    }
+
+                    return AttachLocked(webSocket, payloadProcessor, replay: true);
+                }
+            }
+            finally
+            {
+                _processingGate.Release();
+            }
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            throw new TimeoutException("Timed out waiting to recover the connection.");
+        }
+        finally
+        {
+            lock (_stateLock)
+            {
+                _reconnecting = false;
+            }
+        }
+    }
+
+    private SocketTransport? AttachLocked(
+        WebSocket webSocket,
+        IClientPayloadProcessor payloadProcessor,
+        bool replay)
+    {
+        var dataQueueCapacity = IsReliable
+            ? Math.Max(_outboundQueueCapacity, _reliableBufferCapacity)
+            : _outboundQueueCapacity;
+        var queueCapacity = IsReliable
+            ? Math.Min(Math.Max(dataQueueCapacity, 1), int.MaxValue - ReliableControlMessageAllowance) +
+                ReliableControlMessageAllowance
+            : dataQueueCapacity;
+        var dataQueueMaxBytes = IsReliable
+            ? Math.Max(_outboundQueueMaxBytes, _reliableBufferMaxBytes)
+            : _outboundQueueMaxBytes;
+        var queueMaxBytes = IsReliable
+            ? Math.Min(Math.Max(dataQueueMaxBytes, 1), long.MaxValue - ReliableControlByteAllowance) +
+                ReliableControlByteAllowance
+            : dataQueueMaxBytes;
+        var transport = new SocketTransport(
+            webSocket,
+            _runtimeOptions.MaxMessageSizeBytes,
+            queueCapacity,
+            queueMaxBytes,
+            _logger);
+        if (replay)
+        {
             foreach (var item in _unacknowledgedMessages)
             {
                 if (transport.TryEnqueue(item.Payload.Bytes, item.Payload.MessageType) !=
                     TransportEnqueueResult.Enqueued)
                 {
                     transport.Abort();
-                    return ValueTask.FromResult<SocketTransport?>(null);
+                    return null;
                 }
             }
-
-            if (cancellationToken.IsCancellationRequested)
-            {
-                transport.Abort();
-                cancellationToken.ThrowIfCancellationRequested();
-            }
-
-            _activeTransport = transport;
-            _activePayloadProcessor = payloadProcessor;
-            _generation++;
-            return ValueTask.FromResult<SocketTransport?>(transport);
         }
+
+        _activeTransport = transport;
+        _detachedTransport = null;
+        _activePayloadProcessor = payloadProcessor;
+        _generation++;
+        return transport;
     }
 
     public bool CanSendToGroup(string group)
@@ -312,6 +368,86 @@ internal sealed class LogicalConnection
         }
     }
 
+    public async ValueTask<bool> ProcessIfCurrentAsync(
+        SocketTransport transport,
+        Func<ValueTask> process,
+        CancellationToken cancellationToken)
+    {
+        await _processingGate.WaitAsync(cancellationToken);
+        try
+        {
+            lock (_stateLock)
+            {
+                if (_closed || !ReferenceEquals(_activeTransport, transport))
+                {
+                    return false;
+                }
+            }
+
+            await process();
+            return true;
+        }
+        finally
+        {
+            _processingGate.Release();
+        }
+    }
+
+    public async ValueTask<PayloadProcessingResult?> ProcessMessageIfCurrentAsync(
+        SocketTransport transport,
+        Func<ValueTask<PayloadProcessingResult>> process,
+        CancellationToken cancellationToken)
+    {
+        await _processingGate.WaitAsync(cancellationToken);
+        try
+        {
+            lock (_stateLock)
+            {
+                if (_closed || !ReferenceEquals(_activeTransport, transport))
+                {
+                    return null;
+                }
+            }
+
+            var result = await process();
+            if (result.CloseStatus is { } closeStatus && !CloseIfCurrent(
+                transport,
+                closeStatus,
+                result.CloseDescription ?? string.Empty))
+            {
+                return null;
+            }
+
+            return result;
+        }
+        finally
+        {
+            _processingGate.Release();
+        }
+    }
+
+    public bool CloseIfCurrent(
+        SocketTransport transport,
+        WebSocketCloseStatus closeStatus,
+        string closeDescription)
+    {
+        lock (_stateLock)
+        {
+            if (_closed || !ReferenceEquals(_activeTransport, transport))
+            {
+                return false;
+            }
+
+            transport.TryCloseOutput(closeStatus, closeDescription);
+            _closed = true;
+            _activePayloadProcessor = null;
+            ClearReliableBufferLocked();
+        }
+
+        _manager.Remove(this);
+        return true;
+    }
+
     public void Detach(SocketTransport transport)
     {
         var remove = false;
@@ -322,15 +458,17 @@ internal sealed class LogicalConnection
             if (ReferenceEquals(_activeTransport, transport))
             {
                 _activeTransport = null;
-                if (!IsReliable || transport.IsClosing)
+                if (_closed || !IsReliable || transport.IsClosing)
                 {
                     _activePayloadProcessor = null;
+                    _detachedTransport = null;
                     _closed = true;
                     ClearReliableBufferLocked();
                     remove = true;
                 }
                 else
                 {
+                    _detachedTransport = transport;
                     generation = _generation;
                     expire = true;
                 }
@@ -358,6 +496,8 @@ internal sealed class LogicalConnection
 
             _closed = true;
             _activePayloadProcessor = null;
+            _detachedTransport?.Abort();
+            _detachedTransport = null;
             ClearReliableBufferLocked();
             return true;
         }
@@ -365,8 +505,9 @@ internal sealed class LogicalConnection
 
     private SocketTransport? DropTransportLocked()
     {
-        var transport = _activeTransport;
+        var transport = _activeTransport ?? _detachedTransport;
         _activeTransport = null;
+        _detachedTransport = null;
         _activePayloadProcessor = null;
         _closed = true;
         ClearReliableBufferLocked();

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/SocketTransport.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/SocketTransport.cs
@@ -77,10 +77,10 @@ internal sealed class SocketTransport : IDisposable
         }
     }
 
-    public ValueTask<ReceivedWebSocketMessage> ReceiveAsync(
+    public async ValueTask<ReceivedWebSocketMessage> ReceiveAsync(
         CancellationToken cancellationToken)
     {
-        return WebSocketMessageReader.ReadAsync(
+        return await WebSocketMessageReader.ReadAsync(
             WebSocket,
             _maxMessageSizeBytes,
             cancellationToken);
@@ -134,7 +134,12 @@ internal sealed class SocketTransport : IDisposable
 
     public void CloseOutput(WebSocketCloseStatus status, string description)
     {
-        QueueClose(new OutboundMessage(
+        TryCloseOutput(status, description);
+    }
+
+    public bool TryCloseOutput(WebSocketCloseStatus status, string description)
+    {
+        return QueueClose(new OutboundMessage(
             default,
             WebSocketMessageType.Close,
             status,
@@ -144,6 +149,37 @@ internal sealed class SocketTransport : IDisposable
     public void Abort()
     {
         End(abortSocket: true);
+    }
+
+    public bool TryAbortForReconnect()
+    {
+        var abort = false;
+        lock (_enqueueLock)
+        {
+            if (_closeQueued)
+            {
+                return false;
+            }
+
+            if (Volatile.Read(ref _ended) == 0)
+            {
+                Interlocked.Exchange(ref _ended, 1);
+                _outbound.Writer.TryComplete();
+                abort = true;
+            }
+        }
+
+        if (abort)
+        {
+            End(abortSocket: true);
+        }
+
+        return true;
+    }
+
+    public Task WaitForCompletionAsync(CancellationToken cancellationToken)
+    {
+        return _writeLoop.WaitAsync(cancellationToken);
     }
 
     public async Task CloseAsync(WebSocketCloseStatus status, string description)
@@ -172,14 +208,14 @@ internal sealed class SocketTransport : IDisposable
         }
     }
 
-    private void QueueClose(OutboundMessage close)
+    private bool QueueClose(OutboundMessage close)
     {
         var abort = false;
         lock (_enqueueLock)
         {
             if (Volatile.Read(ref _ended) != 0 || _closeQueued)
             {
-                return;
+                return _closeQueued;
             }
 
             _closeQueued = true;
@@ -190,6 +226,8 @@ internal sealed class SocketTransport : IDisposable
         {
             Abort();
         }
+
+        return true;
     }
 
     private void End(bool abortSocket)

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/LogicalConnectionTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/LogicalConnectionTests.cs
@@ -437,6 +437,293 @@ public class LogicalConnectionTests
         Assert.True(manager.TryGet(connection.Hub, connection.ConnectionId, out _));
     }
 
+    [Fact]
+    public async Task ReconnectWaitsForProcessingAndFencesOldTransport()
+    {
+        using var application = EmulatorApplication.Build();
+        var manager = application.Services.GetRequiredService<ConnectionManager>();
+        var connection = CreateConnection(manager, "connection", reliable: true);
+        using var original = connection.TryAttach(
+            new TestWebSocket(),
+            TestClientPayloadProcessor.Instance);
+        Assert.NotNull(original);
+        Assert.True(manager.TryActivate(connection));
+        var processingStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseProcessing = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var processing = connection.ProcessIfCurrentAsync(
+            original,
+            async () =>
+            {
+                processingStarted.TrySetResult();
+                await releaseProcessing.Task;
+            },
+            CancellationToken.None).AsTask();
+        await processingStarted.Task.WaitAsync(TestTimeout);
+
+        var reconnect = connection.TryReconnectAsync(
+            new TestWebSocket(),
+            TestClientPayloadProcessor.Instance,
+            CancellationToken.None).AsTask();
+        Assert.False(reconnect.IsCompleted);
+        releaseProcessing.TrySetResult();
+        Assert.True(await processing.WaitAsync(TestTimeout));
+        using var recovered = await reconnect.WaitAsync(TestTimeout);
+
+        Assert.NotNull(recovered);
+        Assert.False(await connection.ProcessIfCurrentAsync(
+            original,
+            () => ValueTask.CompletedTask,
+            CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ReconnectWaitsForOldWriterBeforeReplay()
+    {
+        using var application = EmulatorApplication.Build();
+        var manager = application.Services.GetRequiredService<ConnectionManager>();
+        var connection = CreateConnection(manager, "connection", reliable: true);
+        var originalSocket = new GatedSendWebSocket();
+        using var original = connection.TryAttach(
+            originalSocket,
+            TestClientPayloadProcessor.Instance);
+        Assert.NotNull(original);
+        connection.SendGroupData(
+            "room",
+            fromUserId: null,
+            new MessageData(MessageDataType.Text, "message"u8.ToArray()));
+        await originalSocket.SendStarted.Task.WaitAsync(TestTimeout);
+        var recoveredSocket = new QueueingSendWebSocket();
+
+        var reconnect = connection.TryReconnectAsync(
+            recoveredSocket,
+            TestClientPayloadProcessor.Instance,
+            CancellationToken.None).AsTask();
+
+        Assert.False(reconnect.IsCompleted);
+        originalSocket.Release.TrySetResult();
+        using var recovered = await reconnect.WaitAsync(TestTimeout);
+        Assert.NotNull(recovered);
+        Assert.Equal("message"u8.ToArray(), await recoveredSocket.ReadAsync());
+    }
+
+    [Fact]
+    public async Task ReconnectWaitsForDetachedWriterBeforeReplay()
+    {
+        using var application = EmulatorApplication.Build();
+        var manager = application.Services.GetRequiredService<ConnectionManager>();
+        var connection = CreateConnection(manager, "connection", reliable: true);
+        var originalSocket = new GatedSendWebSocket();
+        using var original = connection.TryAttach(
+            originalSocket,
+            TestClientPayloadProcessor.Instance);
+        Assert.NotNull(original);
+        connection.SendGroupData(
+            "room",
+            fromUserId: null,
+            new MessageData(MessageDataType.Text, "message"u8.ToArray()));
+        await originalSocket.SendStarted.Task.WaitAsync(TestTimeout);
+        connection.Detach(original);
+        var recoveredSocket = new QueueingSendWebSocket();
+
+        var reconnect = connection.TryReconnectAsync(
+            recoveredSocket,
+            TestClientPayloadProcessor.Instance,
+            CancellationToken.None).AsTask();
+
+        Assert.False(reconnect.IsCompleted);
+        originalSocket.Release.TrySetResult();
+        using var recovered = await reconnect.WaitAsync(TestTimeout);
+        Assert.NotNull(recovered);
+        Assert.Equal("message"u8.ToArray(), await recoveredSocket.ReadAsync());
+    }
+
+    [Fact]
+    public async Task ReconnectWaitsForReceivedMessageProcessing()
+    {
+        using var application = EmulatorApplication.Build();
+        var manager = application.Services.GetRequiredService<ConnectionManager>();
+        var handler = application.Services.GetRequiredService<ClientConnectionHandler>();
+        var connection = CreateConnection(manager, "connection", reliable: true);
+        var originalSocket = new GatedReceiveWebSocket(
+            new WebSocketReceiveResult(1, WebSocketMessageType.Text, endOfMessage: true));
+        var processor = new RecordingProcessPayloadProcessor();
+        using var original = connection.TryAttach(originalSocket, processor);
+        Assert.NotNull(original);
+        var handlerTask = handler.RunAsync(
+            connection.ConnectionId,
+            connection,
+            original,
+            processor,
+            CancellationToken.None);
+        await originalSocket.ReceiveStarted.Task.WaitAsync(TestTimeout);
+
+        var reconnect = connection.TryReconnectAsync(
+            new TestWebSocket(),
+            processor,
+            CancellationToken.None).AsTask();
+
+        Assert.False(reconnect.IsCompleted);
+        originalSocket.Release.TrySetResult();
+        await processor.Processed.Task.WaitAsync(TestTimeout);
+        using var recovered = await reconnect.WaitAsync(TestTimeout);
+        Assert.NotNull(recovered);
+        await handlerTask.WaitAsync(TestTimeout);
+    }
+
+    [Fact]
+    public async Task NormalCloseReceivedBeforeReconnectRemainsTerminal()
+    {
+        using var application = EmulatorApplication.Build();
+        var manager = application.Services.GetRequiredService<ConnectionManager>();
+        var handler = application.Services.GetRequiredService<ClientConnectionHandler>();
+        var connection = CreateConnection(manager, "connection", reliable: true);
+        var originalSocket = new GatedReceiveWebSocket(new WebSocketReceiveResult(
+            0,
+            WebSocketMessageType.Close,
+            endOfMessage: true,
+            WebSocketCloseStatus.NormalClosure,
+            "done"));
+        using var original = connection.TryAttach(
+            originalSocket,
+            TestClientPayloadProcessor.Instance);
+        Assert.NotNull(original);
+        Assert.True(manager.TryActivate(connection));
+        var handlerTask = handler.RunAsync(
+            connection.ConnectionId,
+            connection,
+            original,
+            TestClientPayloadProcessor.Instance,
+            CancellationToken.None);
+        await originalSocket.ReceiveStarted.Task.WaitAsync(TestTimeout);
+
+        var reconnect = connection.TryReconnectAsync(
+            new TestWebSocket(),
+            TestClientPayloadProcessor.Instance,
+            CancellationToken.None).AsTask();
+        originalSocket.Release.TrySetResult();
+
+        Assert.Null(await reconnect.WaitAsync(TestTimeout));
+        await handlerTask.WaitAsync(TestTimeout);
+        Assert.False(manager.TryGet(connection.Hub, connection.ConnectionId, out _));
+    }
+
+    [Fact]
+    public async Task CanceledReconnectCanBeRetried()
+    {
+        using var application = EmulatorApplication.Build();
+        var manager = application.Services.GetRequiredService<ConnectionManager>();
+        var connection = CreateConnection(manager, "connection", reliable: true);
+        using var original = connection.TryAttach(
+            new TestWebSocket(),
+            TestClientPayloadProcessor.Instance);
+        Assert.NotNull(original);
+        var processingStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseProcessing = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var processing = connection.ProcessIfCurrentAsync(
+            original,
+            async () =>
+            {
+                processingStarted.TrySetResult();
+                await releaseProcessing.Task;
+            },
+            CancellationToken.None).AsTask();
+        await processingStarted.Task.WaitAsync(TestTimeout);
+        using var cancellation = new CancellationTokenSource();
+        var canceledReconnect = connection.TryReconnectAsync(
+            new TestWebSocket(),
+            TestClientPayloadProcessor.Instance,
+            cancellation.Token).AsTask();
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => canceledReconnect);
+        releaseProcessing.TrySetResult();
+        Assert.True(await processing.WaitAsync(TestTimeout));
+        using var recovered = await connection.TryReconnectAsync(
+            new TestWebSocket(),
+            TestClientPayloadProcessor.Instance,
+            CancellationToken.None);
+
+        Assert.NotNull(recovered);
+    }
+
+    [Fact]
+    public async Task ProcessingCloseRemovesConnectionWhenTransportAlreadyEnded()
+    {
+        using var application = EmulatorApplication.Build();
+        var manager = application.Services.GetRequiredService<ConnectionManager>();
+        var connection = CreateConnection(manager, "connection", reliable: true);
+        using var original = connection.TryAttach(
+            new TestWebSocket(),
+            TestClientPayloadProcessor.Instance);
+        Assert.NotNull(original);
+        Assert.True(manager.TryActivate(connection));
+        original.Abort();
+
+        var result = await connection.ProcessMessageIfCurrentAsync(
+            original,
+            () => ValueTask.FromResult(PayloadProcessingResult.Close(
+                WebSocketCloseStatus.PolicyViolation,
+                "invalid")),
+            CancellationToken.None);
+        using var recovered = await connection.TryReconnectAsync(
+            new TestWebSocket(),
+            TestClientPayloadProcessor.Instance,
+            CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.False(manager.TryGet(connection.Hub, connection.ConnectionId, out _));
+        Assert.Null(recovered);
+    }
+
+    [Fact]
+    public async Task ReconnectTimeoutKeepsConnectionRecoverable()
+    {
+        using var application = EmulatorApplication.Build(
+            EmulatorApplication.CreateBuilder(
+                runtimeOptions: new EmulatorRuntimeOptions
+                {
+                    ReconnectTimeout = TimeSpan.FromMilliseconds(50),
+                }));
+        var manager = application.Services.GetRequiredService<ConnectionManager>();
+        var connection = CreateConnection(manager, "connection", reliable: true);
+        using var original = connection.TryAttach(
+            new TestWebSocket(),
+            TestClientPayloadProcessor.Instance);
+        Assert.NotNull(original);
+        Assert.True(manager.TryActivate(connection));
+        var processingStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseProcessing = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var processing = connection.ProcessIfCurrentAsync(
+            original,
+            async () =>
+            {
+                processingStarted.TrySetResult();
+                await releaseProcessing.Task;
+            },
+            CancellationToken.None).AsTask();
+        await processingStarted.Task.WaitAsync(TestTimeout);
+
+        await Assert.ThrowsAsync<TimeoutException>(() => connection.TryReconnectAsync(
+            new TestWebSocket(),
+            TestClientPayloadProcessor.Instance,
+            CancellationToken.None).AsTask());
+        Assert.True(manager.TryGet(connection.Hub, connection.ConnectionId, out _));
+        releaseProcessing.TrySetResult();
+        Assert.True(await processing.WaitAsync(TestTimeout));
+        using var recovered = await connection.TryReconnectAsync(
+            new TestWebSocket(),
+            TestClientPayloadProcessor.Instance,
+            CancellationToken.None);
+
+        Assert.NotNull(recovered);
+    }
+
     private static LogicalConnection CreateConnection(
         ConnectionManager manager,
         string connectionId,
@@ -524,6 +811,36 @@ public class LogicalConnectionTests
         }
     }
 
+    private sealed class RecordingProcessPayloadProcessor : IClientPayloadProcessor
+    {
+        public TaskCompletionSource Processed { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void OnConnected(LogicalConnection connection)
+        {
+        }
+
+        public ValueTask<PayloadProcessingResult> ProcessAsync(
+            LogicalConnection connection,
+            WebSocketMessageType messageType,
+            byte[] payload,
+            CancellationToken cancellationToken)
+        {
+            Processed.TrySetResult();
+            return ValueTask.FromResult(PayloadProcessingResult.Continue);
+        }
+
+        public WebSocketPayload EncodeGroupData(
+            LogicalConnection connection,
+            string group,
+            string? fromUserId,
+            MessageData data,
+            ulong? sequenceId)
+        {
+            return new WebSocketPayload(data.Bytes, WebSocketMessageType.Text);
+        }
+    }
+
     private class TestWebSocket : WebSocket
     {
         private WebSocketState _state = WebSocketState.Open;
@@ -594,6 +911,62 @@ public class LogicalConnectionTests
         {
             SendStarted.TrySetResult();
             await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+        }
+    }
+
+    private sealed class GatedSendWebSocket : TestWebSocket
+    {
+        public TaskCompletionSource SendStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource Release { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public override async Task SendAsync(
+            ArraySegment<byte> buffer,
+            WebSocketMessageType messageType,
+            bool endOfMessage,
+            CancellationToken cancellationToken)
+        {
+            SendStarted.TrySetResult();
+            await Release.Task;
+        }
+    }
+
+    private sealed class GatedReceiveWebSocket : TestWebSocket
+    {
+        private readonly WebSocketReceiveResult _result;
+
+        public GatedReceiveWebSocket(WebSocketReceiveResult result)
+        {
+            _result = result;
+        }
+
+        public override WebSocketCloseStatus? CloseStatus => _result.CloseStatus;
+
+        public override string? CloseStatusDescription => _result.CloseStatusDescription;
+
+        public override WebSocketState State => _result.MessageType == WebSocketMessageType.Close
+            ? WebSocketState.CloseReceived
+            : base.State;
+
+        public TaskCompletionSource ReceiveStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource Release { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public override async Task<WebSocketReceiveResult> ReceiveAsync(
+            ArraySegment<byte> buffer,
+            CancellationToken cancellationToken)
+        {
+            ReceiveStarted.TrySetResult();
+            await Release.Task;
+            if (_result.Count > 0)
+            {
+                buffer[0] = (byte)'x';
+            }
+            return _result;
         }
     }
 


### PR DESCRIPTION
## Summary

- serialize receive and message processing with reliable recovery
- quiesce the previous attached or detached writer before replay
- keep canceled and timed-out recovery attempts retryable
- prevent stale transports from processing messages or committing closes

## Tests

- `dotnet test tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/Microsoft.Azure.WebPubSub.Emulator.Tests.csproj --configuration Release --no-restore` (74 passed)