### PR TITLE
Activate reliable JSON recovery in emulator

### DIFF
--- a/tools/emulator/CHANGELOG.md
+++ b/tools/emulator/CHANGELOG.md
@@ -11,3 +11,4 @@
 - Add build, test, package, installation, and health-check validation in CI.
 - Add endpoint-derived local connection strings with a configurable `WebPubSub:AccessKey`.
 - Add opt-in unvalidated Entra token compatibility for trusted local server SDK testing.
+- Add reliable JSON connections with scoped recovery tokens, sequence acknowledgements, and bounded message replay.

--- a/tools/emulator/README.md
+++ b/tools/emulator/README.md
@@ -47,6 +47,18 @@ in its token's `webpubsub.group` claims. To publish raw text or binary frames to
 `webpubsub_mode=sendToGroup&group={group}` and use a token with the corresponding
 `webpubsub.sendToGroup` role.
 
+JSON clients can request `json.webpubsub.azure.v1` or
+`json.reliable.webpubsub.azure.v1`. The reliable protocol includes a `reconnectionToken` in the
+connected message. After an unexpected disconnect, recover the logical connection with:
+
+```text
+ws://localhost:8080/client/hubs/{hub}?awps_connection_id={connectionId}&awps_reconnection_token={reconnectionToken}
+```
+
+Reliable connections retain groups and unacknowledged messages for 30 seconds within the running
+emulator process. The replay buffer is limited to 1,000 messages and 16 MiB per connection. Send
+`sequenceAck` messages to cumulatively acknowledge delivered sequence IDs.
+
 Set the ASP.NET Core `Urls` configuration value to use another address. The generated connection
 string automatically uses the address and port that the emulator actually binds. For example:
 

--- a/tools/emulator/SUPPORTED_FEATURES.md
+++ b/tools/emulator/SUPPORTED_FEATURES.md
@@ -1,6 +1,6 @@
 # Supported Features and Gaps
 
-The current implementation provides raw WebSocket and non-reliable JSON client endpoints for
+The current implementation provides raw WebSocket, JSON, and reliable JSON client endpoints for
 local Azure Web PubSub development.
 
 ## Current support
@@ -13,7 +13,8 @@ local Azure Web PubSub development.
 | Client token authentication | Implemented | Validates access-key JWTs supplied by query string or bearer header. |
 | Raw WebSocket | Implemented | Receives group messages and publishes text or binary frames with raw `sendToGroup` mode. |
 | JSON WebSocket | Implemented | Supports `json.webpubsub.azure.v1` negotiation, connection messages, group operations, acknowledgements, ping, metadata, and message TTL validation. |
-| Connection state | Implemented | Tracks active connections and removes their state when the WebSocket disconnects. |
+| Reliable JSON WebSocket | Implemented | Supports `json.reliable.webpubsub.azure.v1`, scoped reconnection tokens, 30-second local recovery, ordered replay, and `sequenceAck`. |
+| Connection state | Implemented | Tracks active connections and temporarily retains reliable logical connections after unexpected disconnects. |
 | Groups and roles | Implemented | Supports connection-scoped token groups and authorized join, leave, and group send, including wildcard roles. |
 | Outbound delivery | Implemented | Uses a bounded, single-writer queue for each WebSocket connection. |
 
@@ -25,8 +26,6 @@ The following areas are planned for follow-up changes:
 - HTTP upstream event handlers
 - Tunnel connections (`tunnel://` upstream URLs)
 - Event Hubs listeners
-- Reliable JSON subprotocol
-- Reliable reconnect and message replay
 - Protobuf subprotocols
 - Client message streaming
 - Production Microsoft Entra ID validation

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientConnectionHandler.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientConnectionHandler.cs
@@ -20,18 +20,24 @@ internal sealed class ClientConnectionHandler
         LogicalConnection connection,
         SocketTransport transport,
         IClientPayloadProcessor processor,
-        CancellationToken requestAborted)
+        CancellationToken requestAborted,
+        bool isInitialConnection = true)
     {
         using var linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(
             requestAborted,
             transport.Aborted);
+        using var detachOnCancellation = linkedCancellation.Token.Register(
+            () => connection.Detach(transport));
         try
         {
             if (!await connection.ProcessIfCurrentAsync(
                 transport,
                 () =>
                 {
-                    processor.OnConnected(connection);
+                    if (isInitialConnection)
+                    {
+                        processor.OnConnected(connection);
+                    }
                     return ValueTask.CompletedTask;
                 },
                 linkedCancellation.Token))
@@ -105,20 +111,6 @@ internal sealed class ClientConnectionHandler
                             return;
                         }
 
-                        var result = await processor.ProcessAsync(
-                            connection,
-                            message.MessageType,
-                            message.Payload,
-                            linkedCancellation.Token);
-                        if (result.CloseStatus is { } closeStatus)
-                        {
-                            terminalCloseStatus = closeStatus;
-                            terminalCloseDescription = result.CloseDescription ?? string.Empty;
-                            connection.CloseIfCurrent(
-                                transport,
-                                terminalCloseStatus.Value,
-                                terminalCloseDescription);
-                        }
                     },
                     linkedCancellation.Token);
                 if (!current)
@@ -136,6 +128,35 @@ internal sealed class ClientConnectionHandler
 
                 if (message?.IsClose == true)
                 {
+                    break;
+                }
+
+                if (message is null)
+                {
+                    continue;
+                }
+
+                var processing = await connection.ProcessReceivedMessageAsync(
+                    () => processor.ProcessAsync(
+                        connection,
+                        message.MessageType,
+                        message.Payload,
+                        linkedCancellation.Token),
+                    linkedCancellation.Token);
+                if (processing is null)
+                {
+                    break;
+                }
+
+                var (result, closingTransport) = processing.Value;
+                if (result.CloseStatus is { } processingCloseStatus)
+                {
+                    if (closingTransport is not null)
+                    {
+                        await closingTransport.CloseAsync(
+                            processingCloseStatus,
+                            result.CloseDescription ?? string.Empty);
+                    }
                     break;
                 }
             }

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientPayloadProcessor.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientPayloadProcessor.cs
@@ -56,10 +56,7 @@ internal sealed class ClientPayloadProcessorFactory
 
     public IClientPayloadProcessor Get(string? subprotocol)
     {
-        return string.Equals(
-            subprotocol,
-            WebPubSubJsonV1PayloadProcessor.SubprotocolName,
-            StringComparison.OrdinalIgnoreCase)
+        return WebPubSubJsonV1PayloadProcessor.IsSupportedSubprotocol(subprotocol)
             ? _jsonV1Processor
             : _defaultProcessor;
     }

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientWebSocketEndpoint.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientWebSocketEndpoint.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Azure.WebPubSub.Emulator;
 internal sealed class ClientWebSocketEndpoint
 {
     private const string AccessTokenQueryName = "access_token";
+    private const string ConnectionIdQueryName = "awps_connection_id";
+    private const string ReconnectionTokenQueryName = "awps_reconnection_token";
 
     private readonly ConnectionManager _connections;
     private readonly ClientPayloadProcessorFactory _payloadProcessorFactory;
@@ -41,10 +43,23 @@ internal sealed class ClientWebSocketEndpoint
             return;
         }
 
-        var hub = context.Request.RouteValues["hub"]?.ToString();
-        if (string.IsNullOrWhiteSpace(hub))
+        var rawHub = context.Request.RouteValues["hub"]?.ToString();
+        if (string.IsNullOrWhiteSpace(rawHub))
         {
             context.Response.StatusCode = StatusCodes.Status400BadRequest;
+            return;
+        }
+
+        var selectedSubprotocol = SelectSubprotocol(context);
+        var reconnectConnectionId = context.Request.Query[ConnectionIdQueryName].ToString();
+        if (!string.IsNullOrEmpty(reconnectConnectionId))
+        {
+            await HandleReconnectAsync(
+                context,
+                rawHub.ToLowerInvariant(),
+                selectedSubprotocol,
+                reconnectConnectionId,
+                context.Request.Query[ReconnectionTokenQueryName].ToString());
             return;
         }
 
@@ -59,7 +74,7 @@ internal sealed class ClientWebSocketEndpoint
         try
         {
             var endpoint = new Uri($"{context.Request.Scheme}://{context.Request.Host}");
-            user = _tokenService.ValidateClientToken(endpoint, hub, accessToken);
+            user = _tokenService.ValidateClientToken(endpoint, rawHub, accessToken);
         }
         catch (Exception exception) when (
             exception is SecurityTokenException or ArgumentException)
@@ -76,7 +91,6 @@ internal sealed class ClientWebSocketEndpoint
             return;
         }
 
-        var selectedSubprotocol = SelectSubprotocol(context);
         string? rawSendToGroup = null;
         if (selectedSubprotocol is null &&
             !TryGetRawSendToGroup(context, out rawSendToGroup, out var error))
@@ -86,11 +100,14 @@ internal sealed class ClientWebSocketEndpoint
             return;
         }
 
+        var hub = rawHub.ToLowerInvariant();
         var connection = _connections.Create(
             Guid.NewGuid().ToString("N"),
             hub,
             user,
-            rawSendToGroup);
+            rawSendToGroup,
+            WebPubSubJsonV1PayloadProcessor.IsReliableSubprotocol(selectedSubprotocol),
+            selectedSubprotocol);
         var processor = _payloadProcessorFactory.Get(selectedSubprotocol);
 
         using var webSocket = await context.WebSockets.AcceptWebSocketAsync(selectedSubprotocol);
@@ -108,11 +125,74 @@ internal sealed class ClientWebSocketEndpoint
                 connection,
                 transport,
                 processor,
-                context.RequestAborted);
+                context.RequestAborted,
+                isInitialConnection: true);
         }
         finally
         {
             connection.Detach(transport);
+        }
+    }
+
+    private async Task HandleReconnectAsync(
+        HttpContext context,
+        string hub,
+        string? selectedSubprotocol,
+        string connectionId,
+        string reconnectionToken)
+    {
+        if (!_tokenService.ValidateReconnectionToken(connectionId, reconnectionToken) ||
+            !_connections.TryGet(hub, connectionId, out var connection) ||
+            !connection.IsReliable)
+        {
+            using var rejectedSocket = await context.WebSockets.AcceptWebSocketAsync(
+                selectedSubprotocol);
+            await CloseAsync(rejectedSocket, "The connection could not be recovered.");
+            return;
+        }
+
+        var processor = _payloadProcessorFactory.Get(connection.Subprotocol);
+        using var webSocket = await context.WebSockets.AcceptWebSocketAsync(connection.Subprotocol);
+        SocketTransport? transport;
+        try
+        {
+            transport = await connection.TryReconnectAsync(
+                webSocket,
+                processor,
+                context.RequestAborted);
+        }
+        catch (TimeoutException exception)
+        {
+            _logger.LogDebug(
+                exception,
+                "Recovering connection {ConnectionId} timed out.",
+                connectionId);
+            webSocket.Abort();
+            return;
+        }
+
+        using (transport)
+        {
+            if (transport is null)
+            {
+                await CloseAsync(webSocket, "The connection could not be recovered.");
+                return;
+            }
+
+            try
+            {
+                await _connectionHandler.RunAsync(
+                    connection.ConnectionId,
+                    connection,
+                    transport,
+                    processor,
+                    context.RequestAborted,
+                    isInitialConnection: false);
+            }
+            finally
+            {
+                connection.Detach(transport);
+            }
         }
     }
 
@@ -182,9 +262,6 @@ internal sealed class ClientWebSocketEndpoint
     private static string? SelectSubprotocol(HttpContext context)
     {
         return context.WebSockets.WebSocketRequestedProtocols.FirstOrDefault(
-            protocol => string.Equals(
-                protocol,
-                WebPubSubJsonV1PayloadProcessor.SubprotocolName,
-                StringComparison.OrdinalIgnoreCase));
+            WebPubSubJsonV1PayloadProcessor.IsSupportedSubprotocol);
     }
 }

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ConnectionManager.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ConnectionManager.cs
@@ -27,7 +27,8 @@ internal sealed class ConnectionManager
         string hub,
         ClaimsPrincipal user,
         string? rawSendToGroup = null,
-        bool reliable = false)
+        bool reliable = false,
+        string? subprotocol = null)
     {
         return new LogicalConnection(
             connectionId,
@@ -37,6 +38,7 @@ internal sealed class ConnectionManager
             this,
             _runtimeOptions,
             reliable,
+            subprotocol,
             _logger);
     }
 

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorOptions.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorOptions.cs
@@ -38,6 +38,8 @@ internal sealed class EmulatorRuntimeOptions
 
     public TimeSpan ReconnectTimeout { get; init; } = TimeSpan.FromSeconds(30);
 
+    public TimeSpan ReconnectionTokenLifetime { get; init; } = TimeSpan.FromDays(7);
+
     public int ReliableMessageBufferCapacity { get; init; } = 1000;
 
     public long MaxReliableMessageBufferBytes { get; init; } = 16 * 1024 * 1024;

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/LogicalConnection.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/LogicalConnection.cs
@@ -16,6 +16,7 @@ internal sealed class LogicalConnection
     private const string ReliableBufferFullReason = "The reliable message buffer is full.";
 
     private readonly SemaphoreSlim _processingGate = new(1, 1);
+    private readonly SemaphoreSlim _messageProcessingGate = new(1, 1);
     private readonly object _stateLock = new();
     private readonly Queue<(ulong SequenceId, WebSocketPayload Payload)> _unacknowledgedMessages = [];
     private readonly ConnectionManager _manager;
@@ -45,12 +46,14 @@ internal sealed class LogicalConnection
         ConnectionManager manager,
         EmulatorRuntimeOptions runtimeOptions,
         bool reliable = false,
+        string? subprotocol = null,
         ILogger? logger = null)
     {
         ConnectionId = connectionId;
         Hub = hub;
         RawSendToGroup = rawSendToGroup;
         IsReliable = reliable;
+        Subprotocol = subprotocol;
         _manager = manager;
         _logger = logger;
         _runtimeOptions = runtimeOptions;
@@ -93,6 +96,8 @@ internal sealed class LogicalConnection
     public string? UserId { get; }
 
     public bool IsReliable { get; }
+
+    public string? Subprotocol { get; }
 
     public AckCache AckIdCache { get; } = new();
 
@@ -426,6 +431,35 @@ internal sealed class LogicalConnection
         }
     }
 
+    public async ValueTask<(
+        PayloadProcessingResult Result,
+        SocketTransport? ClosingTransport)?> ProcessReceivedMessageAsync(
+        Func<ValueTask<PayloadProcessingResult>> process,
+        CancellationToken cancellationToken)
+    {
+        await _messageProcessingGate.WaitAsync(cancellationToken);
+        try
+        {
+            lock (_stateLock)
+            {
+                if (_closed)
+                {
+                    return null;
+                }
+            }
+
+            var result = await process();
+            var closingTransport = result.CloseStatus is { } closeStatus
+                ? Close(closeStatus, result.CloseDescription ?? string.Empty)
+                : null;
+            return (result, closingTransport);
+        }
+        finally
+        {
+            _messageProcessingGate.Release();
+        }
+    }
+
     public bool CloseIfCurrent(
         SocketTransport transport,
         WebSocketCloseStatus closeStatus,
@@ -433,19 +467,48 @@ internal sealed class LogicalConnection
     {
         lock (_stateLock)
         {
-            if (_closed || !ReferenceEquals(_activeTransport, transport))
+            if (_closed ||
+                (!ReferenceEquals(_activeTransport, transport) &&
+                    !ReferenceEquals(_detachedTransport, transport)))
             {
                 return false;
             }
 
             transport.TryCloseOutput(closeStatus, closeDescription);
             _closed = true;
+            _activeTransport = null;
+            _detachedTransport = null;
             _activePayloadProcessor = null;
             ClearReliableBufferLocked();
         }
 
         _manager.Remove(this);
         return true;
+    }
+
+    public SocketTransport? Close(
+        WebSocketCloseStatus closeStatus,
+        string closeDescription)
+    {
+        SocketTransport? transport;
+        lock (_stateLock)
+        {
+            if (_closed)
+            {
+                return null;
+            }
+
+            transport = _activeTransport ?? _detachedTransport;
+            transport?.TryCloseOutput(closeStatus, closeDescription);
+            _closed = true;
+            _activeTransport = null;
+            _detachedTransport = null;
+            _activePayloadProcessor = null;
+            ClearReliableBufferLocked();
+        }
+
+        _manager.Remove(this);
+        return transport;
     }
 
     public void Detach(SocketTransport transport)

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubJsonV1PayloadProcessor.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubJsonV1PayloadProcessor.cs
@@ -9,27 +9,34 @@ namespace Microsoft.Azure.WebPubSub.Emulator;
 internal sealed class WebPubSubJsonV1PayloadProcessor : IClientPayloadProcessor
 {
     public const string SubprotocolName = "json.webpubsub.azure.v1";
+    public const string ReliableSubprotocolName = "json.reliable.webpubsub.azure.v1";
 
     private readonly ConnectionManager _connections;
     private readonly IWebPubSubConnectionLifetimeHandler _lifetimeHandler;
     private readonly ILogger<WebPubSubJsonV1PayloadProcessor> _logger;
     private readonly WebPubSubJsonV1Protocol _protocol;
+    private readonly WebPubSubTokenService _tokenService;
 
     public WebPubSubJsonV1PayloadProcessor(
         ConnectionManager connections,
         IWebPubSubConnectionLifetimeHandler lifetimeHandler,
         WebPubSubJsonV1Protocol protocol,
+        WebPubSubTokenService tokenService,
         ILogger<WebPubSubJsonV1PayloadProcessor> logger)
     {
         _connections = connections;
         _lifetimeHandler = lifetimeHandler;
         _protocol = protocol;
+        _tokenService = tokenService;
         _logger = logger;
     }
 
     public void OnConnected(LogicalConnection connection)
     {
-        connection.Send(_protocol.WriteConnected(connection));
+        var reconnectionToken = connection.IsReliable
+            ? _tokenService.IssueReconnectionToken(connection.ConnectionId)
+            : null;
+        connection.Send(_protocol.WriteConnected(connection, reconnectionToken));
     }
 
     public async ValueTask<PayloadProcessingResult> ProcessAsync(
@@ -135,6 +142,20 @@ internal sealed class WebPubSubJsonV1PayloadProcessor : IClientPayloadProcessor
         return _protocol.WriteGroupData(group, fromUserId, data, sequenceId);
     }
 
+    public static bool IsSupportedSubprotocol(string? subprotocol)
+    {
+        return string.Equals(subprotocol, SubprotocolName, StringComparison.OrdinalIgnoreCase) ||
+            IsReliableSubprotocol(subprotocol);
+    }
+
+    public static bool IsReliableSubprotocol(string? subprotocol)
+    {
+        return string.Equals(
+            subprotocol,
+            ReliableSubprotocolName,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
     private void DispatchClientRequest(
         LogicalConnection connection,
         WebPubSubClientRequest request)
@@ -189,6 +210,10 @@ internal sealed class WebPubSubJsonV1PayloadProcessor : IClientPayloadProcessor
                 connection.AckIdCache.Add(ackId);
                 connection.Send(_protocol.WriteAck(ackId));
             }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception exception)
         {

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubJsonV1Protocol.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubJsonV1Protocol.cs
@@ -123,7 +123,9 @@ internal sealed partial class WebPubSubJsonV1Protocol
         }
     }
 
-    public WebSocketPayload WriteConnected(LogicalConnection connection)
+    public WebSocketPayload WriteConnected(
+        LogicalConnection connection,
+        string? reconnectionToken = null)
     {
         return WriteJson(writer =>
         {
@@ -132,6 +134,10 @@ internal sealed partial class WebPubSubJsonV1Protocol
             writer.WriteString("event", "connected");
             writer.WriteString("userId", connection.UserId);
             writer.WriteString("connectionId", connection.ConnectionId);
+            if (reconnectionToken is not null)
+            {
+                writer.WriteString("reconnectionToken", reconnectionToken);
+            }
             writer.WriteEndObject();
         });
     }

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubTokenService.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubTokenService.cs
@@ -18,16 +18,19 @@ internal sealed class WebPubSubTokenService
     private readonly JwtSecurityTokenHandler _handler = new();
     private readonly SymmetricSecurityKey _signingKey;
     private readonly bool _allowUnvalidatedEntraTokens;
+    private readonly TimeSpan _reconnectionTokenLifetime;
     private readonly ILogger<WebPubSubTokenService> _logger;
 
     public WebPubSubTokenService(
         IOptions<EmulatorOptions> options,
+        EmulatorRuntimeOptions runtimeOptions,
         ILogger<WebPubSubTokenService> logger)
     {
         var emulatorOptions = options.Value;
         _signingKey = new SymmetricSecurityKey(
             Encoding.UTF8.GetBytes(emulatorOptions.AccessKey));
         _allowUnvalidatedEntraTokens = emulatorOptions.AllowUnvalidatedEntraTokens;
+        _reconnectionTokenLifetime = runtimeOptions.ReconnectionTokenLifetime;
         _logger = logger;
 
         if (_allowUnvalidatedEntraTokens)
@@ -101,6 +104,43 @@ internal sealed class WebPubSubTokenService
                 exception,
                 "REST access token validation failed for {Path}.",
                 requestUri.AbsolutePath);
+            return false;
+        }
+    }
+
+    public string IssueReconnectionToken(string connectionId)
+    {
+        var now = DateTime.UtcNow;
+        var token = new JwtSecurityToken(
+            issuer: WebPubSubAudience,
+            audience: connectionId,
+            claims: [new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString("N"))],
+            notBefore: now,
+            expires: now.Add(_reconnectionTokenLifetime),
+            signingCredentials: new SigningCredentials(
+                _signingKey,
+                SecurityAlgorithms.HmacSha256));
+        return _handler.WriteToken(token);
+    }
+
+    public bool ValidateReconnectionToken(string connectionId, string token)
+    {
+        try
+        {
+            var parameters = CreateValidationParameters(connectionId);
+            parameters.ValidateIssuer = true;
+            parameters.ValidIssuer = WebPubSubAudience;
+            parameters.ClockSkew = TimeSpan.Zero;
+            _handler.ValidateToken(token, parameters, out _);
+            return true;
+        }
+        catch (Exception exception) when (
+            exception is SecurityTokenException or ArgumentException)
+        {
+            _logger.LogDebug(
+                exception,
+                "Reconnection token validation failed for connection {ConnectionId}.",
+                connectionId);
             return false;
         }
     }

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/ClientWebSocketEndpointTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/ClientWebSocketEndpointTests.cs
@@ -110,7 +110,6 @@ public class ClientWebSocketEndpointTests
 
     [Theory]
     [InlineData("custom.protocol")]
-    [InlineData("json.reliable.webpubsub.azure.v1")]
     [InlineData("protobuf.webpubsub.azure.v1")]
     public async Task UnsupportedSubprotocolIsNotSelected(string subprotocol)
     {
@@ -140,6 +139,162 @@ public class ClientWebSocketEndpointTests
         Assert.Equal("connected", message.RootElement.GetProperty("event").GetString());
         Assert.False(string.IsNullOrEmpty(
             message.RootElement.GetProperty("connectionId").GetString()));
+    }
+
+    [Fact]
+    public async Task ReliableJsonSubprotocolReceivesReconnectionToken()
+    {
+        await using var application = await StartApplicationAsync();
+        using var webSocket = await ConnectAsync(
+            application,
+            subprotocol: WebPubSubJsonV1PayloadProcessor.ReliableSubprotocolName);
+
+        using var message = await ReceiveJsonAsync(webSocket);
+
+        Assert.Equal(
+            WebPubSubJsonV1PayloadProcessor.ReliableSubprotocolName,
+            webSocket.SubProtocol);
+        var reconnectionToken = message.RootElement
+            .GetProperty("reconnectionToken")
+            .GetString();
+        Assert.False(string.IsNullOrEmpty(reconnectionToken));
+        Assert.Equal(
+            "https://webpubsub.azure.com",
+            new JwtSecurityTokenHandler().ReadJwtToken(reconnectionToken).Issuer);
+    }
+
+    [Fact]
+    public async Task InvalidReconnectionTokenClosesWithPolicyViolation()
+    {
+        await using var application = await StartApplicationAsync();
+        var client = application.GetTestServer().CreateWebSocketClient();
+        client.SubProtocols.Add(WebPubSubJsonV1PayloadProcessor.ReliableSubprotocolName);
+
+        using var recovered = await client.ConnectAsync(
+            CreateReconnectUri("missing", "invalid-token"),
+            CancellationToken.None).WaitAsync(TestTimeout);
+        var result = await recovered.ReceiveAsync(new byte[256], CancellationToken.None)
+            .WaitAsync(TestTimeout);
+
+        Assert.Equal(WebSocketMessageType.Close, result.MessageType);
+        Assert.Equal(WebSocketCloseStatus.PolicyViolation, result.CloseStatus);
+    }
+
+    [Fact]
+    public async Task ReconnectionTokenIsScopedToConnectionId()
+    {
+        await using var application = await StartApplicationAsync();
+        using var initial = await ConnectAsync(
+            application,
+            subprotocol: WebPubSubJsonV1PayloadProcessor.ReliableSubprotocolName);
+        using var connected = await ReceiveJsonAsync(initial);
+        var reconnectionToken = connected.RootElement
+            .GetProperty("reconnectionToken")
+            .GetString()!;
+        var client = application.GetTestServer().CreateWebSocketClient();
+        client.SubProtocols.Add(WebPubSubJsonV1PayloadProcessor.ReliableSubprotocolName);
+
+        using var recovered = await client.ConnectAsync(
+            CreateReconnectUri("another-connection", reconnectionToken),
+            CancellationToken.None).WaitAsync(TestTimeout);
+        var result = await recovered.ReceiveAsync(new byte[256], CancellationToken.None)
+            .WaitAsync(TestTimeout);
+
+        Assert.Equal(WebSocketMessageType.Close, result.MessageType);
+        Assert.Equal(WebSocketCloseStatus.PolicyViolation, result.CloseStatus);
+    }
+
+    [Fact]
+    public async Task ReconnectWithoutTokenClosesWithPolicyViolation()
+    {
+        await using var application = await StartApplicationAsync();
+        var client = application.GetTestServer().CreateWebSocketClient();
+        client.SubProtocols.Add(WebPubSubJsonV1PayloadProcessor.ReliableSubprotocolName);
+        var uri = new Uri(
+            $"ws://localhost/client/hubs/{Hub}?awps_connection_id=connection");
+
+        using var webSocket = await client.ConnectAsync(uri, CancellationToken.None)
+            .WaitAsync(TestTimeout);
+        var result = await webSocket.ReceiveAsync(new byte[256], CancellationToken.None)
+            .WaitAsync(TestTimeout);
+
+        Assert.Equal(WebSocketMessageType.Close, result.MessageType);
+        Assert.Equal(WebSocketCloseStatus.PolicyViolation, result.CloseStatus);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(WebPubSubJsonV1PayloadProcessor.SubprotocolName)]
+    public async Task ReconnectUsesOriginalReliableSubprotocol(string? requestedSubprotocol)
+    {
+        await using var application = await StartApplicationAsync();
+        using var initial = await ConnectAsync(
+            application,
+            subprotocol: WebPubSubJsonV1PayloadProcessor.ReliableSubprotocolName);
+        using var connected = await ReceiveJsonAsync(initial);
+        var connectionId = connected.RootElement.GetProperty("connectionId").GetString()!;
+        var reconnectionToken = connected.RootElement
+            .GetProperty("reconnectionToken")
+            .GetString()!;
+        var client = application.GetTestServer().CreateWebSocketClient();
+        if (requestedSubprotocol is not null)
+        {
+            client.SubProtocols.Add(requestedSubprotocol);
+        }
+
+        using var recovered = await client.ConnectAsync(
+            CreateReconnectUri(connectionId, reconnectionToken),
+            CancellationToken.None).WaitAsync(TestTimeout);
+        await recovered.SendAsync(
+            "{\"type\":\"ping\"}"u8.ToArray(),
+            WebSocketMessageType.Text,
+            endOfMessage: true,
+            CancellationToken.None).WaitAsync(TestTimeout);
+        using var pong = await ReceiveJsonAsync(recovered);
+
+        Assert.Equal(
+            WebPubSubJsonV1PayloadProcessor.ReliableSubprotocolName,
+            recovered.SubProtocol,
+            ignoreCase: true);
+        Assert.Equal("pong", pong.RootElement.GetProperty("type").GetString());
+    }
+
+    [Fact]
+    public async Task ReconnectionTokenWithoutConnectionIdStartsNewConnection()
+    {
+        await using var application = await StartApplicationAsync();
+        using var webSocket = await ConnectAsync(
+            application,
+            query: "awps_reconnection_token=stray",
+            subprotocol: WebPubSubJsonV1PayloadProcessor.SubprotocolName);
+
+        using var connected = await ReceiveJsonAsync(webSocket);
+
+        Assert.Equal("connected", connected.RootElement.GetProperty("event").GetString());
+    }
+
+    [Fact]
+    public async Task ReconnectCanonicalizesHubName()
+    {
+        await using var application = await StartApplicationAsync();
+        using var initial = await ConnectAsync(
+            application,
+            subprotocol: WebPubSubJsonV1PayloadProcessor.ReliableSubprotocolName);
+        using var connected = await ReceiveJsonAsync(initial);
+        var connectionId = connected.RootElement.GetProperty("connectionId").GetString()!;
+        var reconnectionToken = connected.RootElement
+            .GetProperty("reconnectionToken")
+            .GetString()!;
+        var client = application.GetTestServer().CreateWebSocketClient();
+
+        using var recovered = await client.ConnectAsync(
+            CreateReconnectUri(connectionId, reconnectionToken, hub: "CHAT"),
+            CancellationToken.None).WaitAsync(TestTimeout);
+
+        Assert.Equal(
+            WebPubSubJsonV1PayloadProcessor.ReliableSubprotocolName,
+            recovered.SubProtocol,
+            ignoreCase: true);
     }
 
     [Fact]
@@ -258,6 +413,16 @@ public class ClientWebSocketEndpointTests
             uri += $"&{query}";
         }
         return new Uri(uri);
+    }
+
+    private static Uri CreateReconnectUri(
+        string connectionId,
+        string reconnectionToken,
+        string hub = Hub)
+    {
+        return new Uri(
+            $"ws://localhost/client/hubs/{hub}?awps_connection_id={Uri.EscapeDataString(connectionId)}" +
+            $"&awps_reconnection_token={Uri.EscapeDataString(reconnectionToken)}");
     }
 
     private static string CreateToken(

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/LogicalConnectionTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/LogicalConnectionTests.cs
@@ -375,7 +375,8 @@ public class LogicalConnectionTests
             connection,
             original,
             TestClientPayloadProcessor.Instance,
-            CancellationToken.None);
+            CancellationToken.None,
+            isInitialConnection: true);
         connection.Detach(original);
         using var recovered = await connection.TryReconnectAsync(
             new TestWebSocket(),
@@ -540,7 +541,7 @@ public class LogicalConnectionTests
     }
 
     [Fact]
-    public async Task ReconnectWaitsForReceivedMessageProcessing()
+    public async Task ReconnectDoesNotWaitForBlockedMessageProcessing()
     {
         using var application = EmulatorApplication.Build();
         var manager = application.Services.GetRequiredService<ConnectionManager>();
@@ -548,9 +549,44 @@ public class LogicalConnectionTests
         var connection = CreateConnection(manager, "connection", reliable: true);
         var originalSocket = new GatedReceiveWebSocket(
             new WebSocketReceiveResult(1, WebSocketMessageType.Text, endOfMessage: true));
-        var processor = new RecordingProcessPayloadProcessor();
+        var processor = new GatedProcessPayloadProcessor();
         using var original = connection.TryAttach(originalSocket, processor);
         Assert.NotNull(original);
+        using var requestAborted = new CancellationTokenSource();
+        var handlerTask = handler.RunAsync(
+            connection.ConnectionId,
+            connection,
+            original,
+            processor,
+            requestAborted.Token);
+        await originalSocket.ReceiveStarted.Task.WaitAsync(TestTimeout);
+
+        originalSocket.Release.TrySetResult();
+        await processor.Started.Task.WaitAsync(TestTimeout);
+        requestAborted.Cancel();
+
+        using var recovered = await connection.TryReconnectAsync(
+            new TestWebSocket(),
+            processor,
+            CancellationToken.None).AsTask().WaitAsync(TestTimeout);
+        Assert.NotNull(recovered);
+        processor.Release.TrySetResult();
+        await handlerTask.WaitAsync(TestTimeout);
+    }
+
+    [Fact]
+    public async Task TerminalMessageResultClosesTransportAttachedDuringProcessing()
+    {
+        using var application = EmulatorApplication.Build();
+        var manager = application.Services.GetRequiredService<ConnectionManager>();
+        var handler = application.Services.GetRequiredService<ClientConnectionHandler>();
+        var connection = CreateConnection(manager, "connection", reliable: true);
+        var originalSocket = new GatedReceiveWebSocket(
+            new WebSocketReceiveResult(1, WebSocketMessageType.Text, endOfMessage: true));
+        var processor = new GatedClosingPayloadProcessor();
+        using var original = connection.TryAttach(originalSocket, processor);
+        Assert.NotNull(original);
+        Assert.True(manager.TryActivate(connection));
         var handlerTask = handler.RunAsync(
             connection.ConnectionId,
             connection,
@@ -558,18 +594,62 @@ public class LogicalConnectionTests
             processor,
             CancellationToken.None);
         await originalSocket.ReceiveStarted.Task.WaitAsync(TestTimeout);
+        originalSocket.Release.TrySetResult();
+        await processor.Started.Task.WaitAsync(TestTimeout);
 
-        var reconnect = connection.TryReconnectAsync(
-            new TestWebSocket(),
+        var recoveredSocket = new TestWebSocket();
+        using var recovered = await connection.TryReconnectAsync(
+            recoveredSocket,
             processor,
+            CancellationToken.None).AsTask().WaitAsync(TestTimeout);
+        Assert.NotNull(recovered);
+        processor.Release.TrySetResult();
+        await handlerTask.WaitAsync(TestTimeout);
+
+        Assert.Equal(WebSocketState.CloseSent, recoveredSocket.State);
+        Assert.False(manager.TryGet(connection.Hub, connection.ConnectionId, out _));
+    }
+
+    [Fact]
+    public async Task TerminalMessageResultPreventsQueuedMessageProcessing()
+    {
+        using var application = EmulatorApplication.Build();
+        var manager = application.Services.GetRequiredService<ConnectionManager>();
+        var connection = CreateConnection(manager, "connection", reliable: true);
+        using var transport = connection.TryAttach(
+            new TestWebSocket(),
+            TestClientPayloadProcessor.Instance);
+        Assert.NotNull(transport);
+        Assert.True(manager.TryActivate(connection));
+        var processingStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseProcessing = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var terminalProcessing = connection.ProcessReceivedMessageAsync(
+            async () =>
+            {
+                processingStarted.TrySetResult();
+                await releaseProcessing.Task;
+                return PayloadProcessingResult.Close(
+                    WebSocketCloseStatus.InvalidPayloadData,
+                    "invalid");
+            },
+            CancellationToken.None).AsTask();
+        await processingStarted.Task.WaitAsync(TestTimeout);
+        var queuedMessageProcessed = false;
+        var queuedProcessing = connection.ProcessReceivedMessageAsync(
+            () =>
+            {
+                queuedMessageProcessed = true;
+                return ValueTask.FromResult(PayloadProcessingResult.Continue);
+            },
             CancellationToken.None).AsTask();
 
-        Assert.False(reconnect.IsCompleted);
-        originalSocket.Release.TrySetResult();
-        await processor.Processed.Task.WaitAsync(TestTimeout);
-        using var recovered = await reconnect.WaitAsync(TestTimeout);
-        Assert.NotNull(recovered);
-        await handlerTask.WaitAsync(TestTimeout);
+        releaseProcessing.TrySetResult();
+
+        Assert.NotNull(await terminalProcessing.WaitAsync(TestTimeout));
+        Assert.Null(await queuedProcessing.WaitAsync(TestTimeout));
+        Assert.False(queuedMessageProcessed);
     }
 
     [Fact]
@@ -677,6 +757,83 @@ public class LogicalConnectionTests
         Assert.NotNull(result);
         Assert.False(manager.TryGet(connection.Hub, connection.ConnectionId, out _));
         Assert.Null(recovered);
+    }
+
+    [Fact]
+    public async Task DetachedTransportCanCommitTerminalCloseBeforeReconnect()
+    {
+        using var application = EmulatorApplication.Build();
+        var manager = application.Services.GetRequiredService<ConnectionManager>();
+        var connection = CreateConnection(manager, "connection", reliable: true);
+        using var original = connection.TryAttach(
+            new TestWebSocket(),
+            TestClientPayloadProcessor.Instance);
+        Assert.NotNull(original);
+        Assert.True(manager.TryActivate(connection));
+        var processingStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseProcessing = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var processing = connection.ProcessIfCurrentAsync(
+            original,
+            async () =>
+            {
+                processingStarted.TrySetResult();
+                await releaseProcessing.Task;
+                connection.Detach(original);
+                Assert.True(connection.CloseIfCurrent(
+                    original,
+                    WebSocketCloseStatus.NormalClosure,
+                    "done"));
+            },
+            CancellationToken.None).AsTask();
+        await processingStarted.Task.WaitAsync(TestTimeout);
+
+        var reconnect = connection.TryReconnectAsync(
+            new TestWebSocket(),
+            TestClientPayloadProcessor.Instance,
+            CancellationToken.None).AsTask();
+        releaseProcessing.TrySetResult();
+
+        Assert.True(await processing.WaitAsync(TestTimeout));
+        Assert.Null(await reconnect.WaitAsync(TestTimeout));
+        Assert.False(manager.TryGet(connection.Hub, connection.ConnectionId, out _));
+    }
+
+    [Fact]
+    public async Task TransportAbortExpiresWhileMessageProcessingIsBlocked()
+    {
+        using var application = EmulatorApplication.Build(
+            EmulatorApplication.CreateBuilder(
+                runtimeOptions: new EmulatorRuntimeOptions
+                {
+                    ReconnectTimeout = TimeSpan.FromMilliseconds(50),
+                }));
+        var manager = application.Services.GetRequiredService<ConnectionManager>();
+        var handler = application.Services.GetRequiredService<ClientConnectionHandler>();
+        var connection = CreateConnection(manager, "connection", reliable: true);
+        var socket = new GatedReceiveWebSocket(
+            new WebSocketReceiveResult(1, WebSocketMessageType.Text, endOfMessage: true));
+        var processor = new GatedProcessPayloadProcessor();
+        using var transport = connection.TryAttach(socket, processor);
+        Assert.NotNull(transport);
+        Assert.True(manager.TryActivate(connection));
+        var handlerTask = handler.RunAsync(
+            connection.ConnectionId,
+            connection,
+            transport,
+            processor,
+            CancellationToken.None);
+        await socket.ReceiveStarted.Task.WaitAsync(TestTimeout);
+        socket.Release.TrySetResult();
+        await processor.Started.Task.WaitAsync(TestTimeout);
+
+        transport.Abort();
+        await Task.Delay(TimeSpan.FromMilliseconds(250));
+
+        Assert.False(manager.TryGet(connection.Hub, connection.ConnectionId, out _));
+        processor.Release.TrySetResult();
+        await handlerTask.WaitAsync(TestTimeout);
     }
 
     [Fact]
@@ -828,6 +985,76 @@ public class LogicalConnectionTests
         {
             Processed.TrySetResult();
             return ValueTask.FromResult(PayloadProcessingResult.Continue);
+        }
+
+        public WebSocketPayload EncodeGroupData(
+            LogicalConnection connection,
+            string group,
+            string? fromUserId,
+            MessageData data,
+            ulong? sequenceId)
+        {
+            return new WebSocketPayload(data.Bytes, WebSocketMessageType.Text);
+        }
+    }
+
+    private sealed class GatedProcessPayloadProcessor : IClientPayloadProcessor
+    {
+        public TaskCompletionSource Started { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource Release { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void OnConnected(LogicalConnection connection)
+        {
+        }
+
+        public async ValueTask<PayloadProcessingResult> ProcessAsync(
+            LogicalConnection connection,
+            WebSocketMessageType messageType,
+            byte[] payload,
+            CancellationToken cancellationToken)
+        {
+            Started.TrySetResult();
+            await Release.Task;
+            return PayloadProcessingResult.Continue;
+        }
+
+        public WebSocketPayload EncodeGroupData(
+            LogicalConnection connection,
+            string group,
+            string? fromUserId,
+            MessageData data,
+            ulong? sequenceId)
+        {
+            return new WebSocketPayload(data.Bytes, WebSocketMessageType.Text);
+        }
+    }
+
+    private sealed class GatedClosingPayloadProcessor : IClientPayloadProcessor
+    {
+        public TaskCompletionSource Started { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource Release { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void OnConnected(LogicalConnection connection)
+        {
+        }
+
+        public async ValueTask<PayloadProcessingResult> ProcessAsync(
+            LogicalConnection connection,
+            WebSocketMessageType messageType,
+            byte[] payload,
+            CancellationToken cancellationToken)
+        {
+            Started.TrySetResult();
+            await Release.Task;
+            return PayloadProcessingResult.Close(
+                WebSocketCloseStatus.InvalidPayloadData,
+                "invalid");
         }
 
         public WebSocketPayload EncodeGroupData(

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/WebPubSubJsonV1IntegrationTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/WebPubSubJsonV1IntegrationTests.cs
@@ -278,6 +278,73 @@ public class WebPubSubJsonV1IntegrationTests
     }
 
     [Fact]
+    public async Task ReliableReconnectReplaysUnacknowledgedMessagesAndPreservesGroups()
+    {
+        await using var application = await StartApplicationAsync();
+        var initial = await ConnectReliableAsync(
+            application,
+            roles: ["webpubsub.joinLeaveGroup.room"]);
+        using var initialSocket = initial.WebSocket;
+        await SendJsonAsync(initialSocket, new
+        {
+            type = "joinGroup",
+            group = "room",
+            ackId = 1,
+        });
+        using (var joinAck = await ReceiveJsonAsync(initialSocket))
+        {
+            AssertSuccessAck(joinAck.RootElement, 1);
+        }
+        using var sender = await ConnectJsonAsync(
+            application,
+            roles: ["webpubsub.sendToGroup.room"]);
+        await SendJsonAsync(sender, new
+        {
+            type = "sendToGroup",
+            group = "room",
+            dataType = "text",
+            data = "first",
+        });
+        using (var delivered = await ReceiveJsonAsync(initialSocket))
+        {
+            Assert.Equal(1UL, delivered.RootElement.GetProperty("sequenceId").GetUInt64());
+            Assert.Equal("first", delivered.RootElement.GetProperty("data").GetString());
+        }
+
+        initialSocket.Abort();
+        using var firstRecovery = await ReconnectReliableAsync(
+            application,
+            initial.ConnectionId,
+            initial.ReconnectionToken);
+        using (var replayed = await ReceiveJsonAsync(firstRecovery))
+        {
+            Assert.Equal(1UL, replayed.RootElement.GetProperty("sequenceId").GetUInt64());
+            Assert.Equal("first", replayed.RootElement.GetProperty("data").GetString());
+        }
+        await SendJsonAsync(firstRecovery, new { type = "sequenceAck", sequenceId = 1 });
+
+        firstRecovery.Abort();
+        using var secondRecovery = await ReconnectReliableAsync(
+            application,
+            initial.ConnectionId,
+            initial.ReconnectionToken);
+        await SendJsonAsync(sender, new
+        {
+            type = "sendToGroup",
+            group = "room",
+            dataType = "text",
+            data = "second",
+        });
+        using var deliveredAfterRecovery = await ReceiveJsonAsync(secondRecovery);
+        Assert.Equal(
+            2UL,
+            deliveredAfterRecovery.RootElement.GetProperty("sequenceId").GetUInt64());
+        Assert.Equal(
+            "second",
+            deliveredAfterRecovery.RootElement.GetProperty("data").GetString());
+    }
+
+    [Fact]
     public async Task JsonAckReportsForbiddenAndDuplicateRequests()
     {
         await using var application = await StartApplicationAsync();
@@ -484,6 +551,42 @@ public class WebPubSubJsonV1IntegrationTests
         using var connected = await ReceiveJsonAsync(webSocket);
         Assert.Equal("connected", connected.RootElement.GetProperty("event").GetString());
         return webSocket;
+    }
+
+    private static async Task<(
+        WebSocket WebSocket,
+        string ConnectionId,
+        string ReconnectionToken)> ConnectReliableAsync(
+        WebApplication application,
+        IEnumerable<string>? roles = null)
+    {
+        var client = application.GetTestServer().CreateWebSocketClient();
+        client.SubProtocols.Add(WebPubSubJsonV1PayloadProcessor.ReliableSubprotocolName);
+        var token = CreateToken(roles ?? [], [], userId: null);
+        var uri = new Uri(
+            $"ws://localhost{WebPubSubTokenService.ClientPathPrefix}{Hub}?access_token={Uri.EscapeDataString(token)}");
+        var webSocket = await client.ConnectAsync(uri, CancellationToken.None)
+            .WaitAsync(TestTimeout);
+        using var connected = await ReceiveJsonAsync(webSocket);
+        return (
+            webSocket,
+            connected.RootElement.GetProperty("connectionId").GetString()!,
+            connected.RootElement.GetProperty("reconnectionToken").GetString()!);
+    }
+
+    private static async Task<WebSocket> ReconnectReliableAsync(
+        WebApplication application,
+        string connectionId,
+        string reconnectionToken)
+    {
+        var client = application.GetTestServer().CreateWebSocketClient();
+        client.SubProtocols.Add(WebPubSubJsonV1PayloadProcessor.ReliableSubprotocolName);
+        var uri = new Uri(
+            $"ws://localhost{WebPubSubTokenService.ClientPathPrefix}{Hub}" +
+            $"?awps_connection_id={Uri.EscapeDataString(connectionId)}" +
+            $"&awps_reconnection_token={Uri.EscapeDataString(reconnectionToken)}");
+        return await client.ConnectAsync(uri, CancellationToken.None)
+            .WaitAsync(TestTimeout);
     }
 
     private static Task SendJsonAsync(WebSocket webSocket, object message)


### PR DESCRIPTION
## Summary

- activate `json.reliable.webpubsub.azure.v1` and issue connection-scoped recovery tokens
- recognize service recovery query parameters and restore the retained logical connection with its original negotiated protocol
- keep message processing, terminal results, transport handoff, and expiration correctly ordered during recovery
- preserve groups and replay unacknowledged messages after reconnect

## Runtime alignment

- recovery is selected only by a non-empty `awps_connection_id`
- missing or invalid recovery tokens are rejected with WebSocket policy violation
- hub identity is canonicalized for recovery lookup
- blocked payload processing cannot prevent transport recovery or detached-connection expiration

## Tests

- `dotnet test tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/Microsoft.Azure.WebPubSub.Emulator.Tests.csproj --configuration Release --no-restore` (86 passed)

## Follow-ups

- access-token `webpubsub.rtoken.ttl` support and periodic recovery-token refresh remain separate parity work