### PR TITLE
Emulator: add direct connection REST APIs

### DIFF
--- a/tools/emulator/CHANGELOG.md
+++ b/tools/emulator/CHANGELOG.md
@@ -12,3 +12,4 @@
 - Add endpoint-derived local connection strings with a configurable `WebPubSub:AccessKey`.
 - Add opt-in unvalidated Entra token compatibility for trusted local server SDK testing.
 - Add reliable JSON connections with scoped recovery tokens, sequence acknowledgements, and bounded message replay.
+- Add authenticated REST operations and official .NET server SDK compatibility for checking connection presence and sending directly to a connection.

--- a/tools/emulator/Directory.Packages.props
+++ b/tools/emulator/Directory.Packages.props
@@ -4,6 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageVersion Include="Azure.Messaging.WebPubSub" Version="1.6.0" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.11" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />

--- a/tools/emulator/README.md
+++ b/tools/emulator/README.md
@@ -80,8 +80,8 @@ await serviceClient.SendToConnectionAsync(
 ```
 
 Direct sends return success when the connection does not exist, matching the service's
-fire-and-forget behavior. Nonzero `messageTtlSeconds` values are not implemented and return
-`501 Not Implemented` rather than silently ignoring message expiry.
+fire-and-forget behavior. Valid `messageTtlSeconds` values are accepted, but the emulator does not
+model message expiration.
 
 Set the ASP.NET Core `Urls` configuration value to use another address. The generated connection
 string automatically uses the address and port that the emulator actually binds. For example:

--- a/tools/emulator/README.md
+++ b/tools/emulator/README.md
@@ -59,6 +59,30 @@ Reliable connections retain groups and unacknowledged messages for 30 seconds wi
 emulator process. The replay buffer is limited to 1,000 messages and 16 MiB per connection. Send
 `sequenceAck` messages to cumulatively acknowledge delivered sequence IDs.
 
+## Use a server SDK
+
+The emulator supports checking whether a connection exists and sending text, JSON, or binary data
+to a connection through the Azure Web PubSub REST API. For example, use the generated connection
+string with the Azure Web PubSub .NET server SDK:
+
+```csharp
+using Azure.Messaging.WebPubSub;
+
+var serviceClient = new WebPubSubServiceClient(
+  "Endpoint=http://localhost:8080;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGH;Version=1.0;",
+  "chat");
+
+bool exists = await serviceClient.ConnectionExistsAsync(connectionId);
+await serviceClient.SendToConnectionAsync(
+  connectionId,
+  BinaryData.FromString("Hello"),
+  ContentType.TextPlain);
+```
+
+Direct sends return success when the connection does not exist, matching the service's
+fire-and-forget behavior. Nonzero `messageTtlSeconds` values are not implemented and return
+`501 Not Implemented` rather than silently ignoring message expiry.
+
 Set the ASP.NET Core `Urls` configuration value to use another address. The generated connection
 string automatically uses the address and port that the emulator actually binds. For example:
 

--- a/tools/emulator/SUPPORTED_FEATURES.md
+++ b/tools/emulator/SUPPORTED_FEATURES.md
@@ -18,7 +18,7 @@ local Azure Web PubSub development.
 | Groups and roles | Supports connection-scoped token groups and authorized join, leave, and group send, including wildcard roles. | ✅ |
 | Outbound delivery | Uses a bounded, single-writer queue for each WebSocket connection. | ✅ |
 | REST connection operations | Authenticated connection presence and direct text, JSON, and binary sends for GA API versions from `2021-10-01` through `2024-12-01`. | ✅ |
-| REST direct-send TTL | Validates `messageTtlSeconds`, but returns `501 Not Implemented` for nonzero values. | ❌ |
+| REST direct-send TTL | Accepts valid `messageTtlSeconds` values; delivery is immediate and expiration is not modeled. | ⚠️ |
 | Other REST APIs | Group, user, permission, close-connection, and broadcast operations. | ❌ |
 
 ## Not yet implemented

--- a/tools/emulator/SUPPORTED_FEATURES.md
+++ b/tools/emulator/SUPPORTED_FEATURES.md
@@ -5,24 +5,26 @@ local Azure Web PubSub development.
 
 ## Current support
 
-| Area | Status | Notes |
+| Area | Features | Support |
 | --- | --- | --- |
-| .NET tool | Implemented | Builds and installs as `Microsoft.Azure.WebPubSub.Emulator`; runs as `awps-emulator`. |
-| Local connection settings | Implemented | Derives the endpoint from the bound ASP.NET Core `Urls` address and supports a separate `WebPubSub:AccessKey` setting. |
-| Service health | Implemented | `HEAD /api/health` returns `200 OK`. |
-| Client token authentication | Implemented | Validates access-key JWTs supplied by query string or bearer header. |
-| Raw WebSocket | Implemented | Receives group messages and publishes text or binary frames with raw `sendToGroup` mode. |
-| JSON WebSocket | Implemented | Supports `json.webpubsub.azure.v1` negotiation, connection messages, group operations, acknowledgements, ping, metadata, and message TTL validation. |
-| Reliable JSON WebSocket | Implemented | Supports `json.reliable.webpubsub.azure.v1`, scoped reconnection tokens, 30-second local recovery, ordered replay, and `sequenceAck`. |
-| Connection state | Implemented | Tracks active connections and temporarily retains reliable logical connections after unexpected disconnects. |
-| Groups and roles | Implemented | Supports connection-scoped token groups and authorized join, leave, and group send, including wildcard roles. |
-| Outbound delivery | Implemented | Uses a bounded, single-writer queue for each WebSocket connection. |
+| .NET tool | Builds and installs as `Microsoft.Azure.WebPubSub.Emulator`; runs as `awps-emulator`. | ✅ |
+| Local connection settings | Derives the endpoint from the bound ASP.NET Core `Urls` address and supports a separate `WebPubSub:AccessKey` setting. | ✅ |
+| Service health | `HEAD /api/health` returns `200 OK`. | ✅ |
+| Client token authentication | Validates access-key JWTs supplied by query string or bearer header. | ✅ |
+| Raw WebSocket | Receives group messages and publishes text or binary frames with raw `sendToGroup` mode. | ✅ |
+| JSON WebSocket | Supports `json.webpubsub.azure.v1` negotiation, connection messages, group operations, acknowledgements, ping, metadata, and message TTL validation. | ✅ |
+| Reliable JSON WebSocket | Supports `json.reliable.webpubsub.azure.v1`, scoped reconnection tokens, 30-second local recovery, ordered replay, and `sequenceAck`. | ✅ |
+| Connection state | Tracks active connections and temporarily retains reliable logical connections after unexpected disconnects. | ✅ |
+| Groups and roles | Supports connection-scoped token groups and authorized join, leave, and group send, including wildcard roles. | ✅ |
+| Outbound delivery | Uses a bounded, single-writer queue for each WebSocket connection. | ✅ |
+| REST connection operations | Authenticated connection presence and direct text, JSON, and binary sends for GA API versions from `2021-10-01` through `2024-12-01`. | ✅ |
+| REST direct-send TTL | Validates `messageTtlSeconds`, but returns `501 Not Implemented` for nonzero values. | ❌ |
+| Other REST APIs | Group, user, permission, close-connection, and broadcast operations. | ❌ |
 
 ## Not yet implemented
 
 The following areas are planned for follow-up changes:
 
-- REST APIs and server SDK compatibility
 - HTTP upstream event handlers
 - Tunnel connections (`tunnel://` upstream URLs)
 - Event Hubs listeners

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientPayloadProcessor.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientPayloadProcessor.cs
@@ -21,6 +21,11 @@ internal interface IClientPayloadProcessor
         string? fromUserId,
         MessageData data,
         ulong? sequenceId);
+
+    WebSocketPayload EncodeServerData(
+        LogicalConnection connection,
+        MessageData data,
+        ulong? sequenceId);
 }
 
 internal readonly record struct WebSocketPayload(

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ConnectionManager.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ConnectionManager.cs
@@ -57,6 +57,19 @@ internal sealed class ConnectionManager
         return _connections.TryGetValue((hub, connectionId), out connection);
     }
 
+    public bool ConnectionExists(string hub, string connectionId)
+    {
+        return _connections.ContainsKey((hub, connectionId));
+    }
+
+    public void SendToConnection(string hub, string connectionId, MessageData data)
+    {
+        if (_connections.TryGetValue((hub, connectionId), out var connection))
+        {
+            connection.SendServerData(data);
+        }
+    }
+
     public void Remove(LogicalConnection connection)
     {
         _connections.TryRemove((connection.Hub, connection.ConnectionId), out _);

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorApplication.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorApplication.cs
@@ -3,6 +3,7 @@
 
 using System.Reflection;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -45,6 +46,23 @@ internal static class EmulatorApplication
             {
                 manager.FeatureProviders.Add(new EmulatorControllerFeatureProvider());
             });
+        builder.Services.Configure<ApiBehaviorOptions>(options =>
+        {
+            options.InvalidModelStateResponseFactory = context =>
+            {
+                var error = context.ModelState.Values
+                    .SelectMany(value => value.Errors)
+                    .Select(value => value.ErrorMessage)
+                    .FirstOrDefault(message => !string.IsNullOrEmpty(message)) ??
+                    "The request parameters are invalid.";
+                return new BadRequestObjectResult(new
+                {
+                    code = "Error.BadRequest",
+                    message = error,
+                    target = "Request",
+                });
+            };
+        });
         return builder;
     }
 

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/LogicalConnection.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/LogicalConnection.cs
@@ -254,6 +254,14 @@ internal sealed class LogicalConnection
             sequenceId));
     }
 
+    public void SendServerData(MessageData data)
+    {
+        SendData(sequenceId => _activePayloadProcessor!.EncodeServerData(
+            this,
+            data,
+            sequenceId));
+    }
+
     public void Send(WebSocketPayload payload)
     {
         IClientPayloadProcessor? payloadProcessor;

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/SimpleWebSocketPayloadProcessor.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/SimpleWebSocketPayloadProcessor.cs
@@ -55,4 +55,15 @@ internal sealed class SimpleWebSocketPayloadProcessor : IClientPayloadProcessor
             : WebSocketMessageType.Text;
         return new WebSocketPayload(data.Bytes, messageType);
     }
+
+    public WebSocketPayload EncodeServerData(
+        LogicalConnection connection,
+        MessageData data,
+        ulong? sequenceId)
+    {
+        var messageType = data.Type == MessageDataType.Binary
+            ? WebSocketMessageType.Binary
+            : WebSocketMessageType.Text;
+        return new WebSocketPayload(data.Bytes, messageType);
+    }
 }

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubApiControllerDefinition.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubApiControllerDefinition.cs
@@ -9,14 +9,6 @@ namespace Microsoft.Azure.WebPubSub.Emulator;
 
 [WebPubSubApi("2024-12-01")]
 [WebPubSubApiOperation("HEAD", "/api/health", "HealthApi_GetServiceStatus")]
-[WebPubSubApiOperation(
-    "HEAD",
-    "/api/hubs/{hub}/connections/{connectionId}",
-    "WebPubSub_ConnectionExists")]
-[WebPubSubApiOperation(
-    "POST",
-    "/api/hubs/{hub}/connections/{connectionId}/:send",
-    "WebPubSub_SendToConnection")]
 internal abstract partial class WebPubSubApiControllerDefinition
 {
     private const string SupportedApiVersionsHeader =

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubApiControllerDefinition.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubApiControllerDefinition.cs
@@ -9,18 +9,53 @@ namespace Microsoft.Azure.WebPubSub.Emulator;
 
 [WebPubSubApi("2024-12-01")]
 [WebPubSubApiOperation("HEAD", "/api/health", "HealthApi_GetServiceStatus")]
+[WebPubSubApiOperation(
+    "HEAD",
+    "/api/hubs/{hub}/connections/{connectionId}",
+    "WebPubSub_ConnectionExists")]
+[WebPubSubApiOperation(
+    "POST",
+    "/api/hubs/{hub}/connections/{connectionId}/:send",
+    "WebPubSub_SendToConnection")]
 internal abstract partial class WebPubSubApiControllerDefinition
 {
-    private const string SupportedApiVersions =
+    private const string SupportedApiVersionsHeader =
         "2021-10-01, 2022-11-01, 2023-07-01, 2024-01-01, 2024-12-01";
+    private static readonly HashSet<string> SupportedApiVersions = new(StringComparer.Ordinal)
+    {
+        "2021-10-01",
+        "2022-11-01",
+        "2023-07-01",
+        "2024-01-01",
+        "2024-12-01",
+    };
 
     [NonAction]
     public async Task OnActionExecutionAsync(
         ActionExecutingContext context,
         ActionExecutionDelegate next)
     {
-        Response.Headers["api-supported-versions"] = SupportedApiVersions;
+        Response.Headers["api-supported-versions"] = SupportedApiVersionsHeader;
+        if (Request.Query.TryGetValue("api-version", out var versions) &&
+            (versions.Count != 1 || !SupportedApiVersions.Contains(versions[0]!)))
+        {
+            context.Result = CreateBadRequest(
+                "The specified API version is not supported.",
+                "api-version");
+            return;
+        }
+
         await next();
+    }
+
+    protected IActionResult CreateBadRequest(string message, string target = "Request")
+    {
+        return BadRequest(new
+        {
+            code = "Error.BadRequest",
+            message,
+            target,
+        });
     }
 
     protected Task<IActionResult> NotImplementedAsync(string operationId)

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubEmulatorController.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubEmulatorController.cs
@@ -80,16 +80,6 @@ internal sealed class WebPubSubEmulatorController : WebPubSubApiControllerDefini
         {
             return Unauthorized();
         }
-        if (messageTtlSeconds.GetValueOrDefault() != 0)
-        {
-            return StatusCode(
-                StatusCodes.Status501NotImplemented,
-                new
-                {
-                    code = "NotImplemented",
-                    message = "Non-zero messageTtlSeconds is not implemented by the emulator.",
-                });
-        }
         if (Request.ContentLength is not { } contentLength ||
             contentLength < 0 ||
             contentLength > _runtimeOptions.MaxMessageSizeBytes)

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubEmulatorController.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubEmulatorController.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Globalization;
+using System.ComponentModel.DataAnnotations;
 using System.Text;
 using System.Text.Json;
 using Microsoft.AspNetCore.Http;
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.WebPubSub.Emulator;
 [ApiController]
 internal sealed class WebPubSubEmulatorController : WebPubSubApiControllerDefinition
 {
+    private const int MaximumMessageTtlSeconds = 300;
     private const string MetadataHeaderPrefix = "X-WebPubSub-Metadata-";
     private readonly ConnectionManager _connections;
     private readonly EmulatorRuntimeOptions _runtimeOptions;
@@ -33,8 +34,15 @@ internal sealed class WebPubSubEmulatorController : WebPubSubApiControllerDefini
         return Task.FromResult<IActionResult>(Ok());
     }
 
-    public override Task<IActionResult> ConnectionExists(
+    [HttpHead(
+        "/api/hubs/{hub}/connections/{connectionId}",
+        Name = "WebPubSub_ConnectionExists")]
+    public Task<IActionResult> ConnectionExists(
+        [RegularExpression(
+            WebPubSubNameValidator.HubNamePattern,
+            ErrorMessage = "Invalid hub name.")]
         string hub,
+        [MinLength(1, ErrorMessage = "Invalid connection ID.")]
         string connectionId,
         CancellationToken cancellationToken = default)
     {
@@ -42,14 +50,6 @@ internal sealed class WebPubSubEmulatorController : WebPubSubApiControllerDefini
         if (!Authorize())
         {
             result = Unauthorized();
-        }
-        else if (!WebPubSubNameValidator.IsValidHubName(hub))
-        {
-            result = CreateBadRequest("Invalid hub name.");
-        }
-        else if (string.IsNullOrEmpty(connectionId))
-        {
-            result = CreateBadRequest("Invalid connection ID.");
         }
         else
         {
@@ -61,28 +61,26 @@ internal sealed class WebPubSubEmulatorController : WebPubSubApiControllerDefini
         return Task.FromResult(result);
     }
 
-    public override async Task<IActionResult> SendToConnection(
+    [HttpPost(
+        "/api/hubs/{hub}/connections/{connectionId}/:send",
+        Name = "WebPubSub_SendToConnection")]
+    public async Task<IActionResult> SendToConnection(
+        [RegularExpression(
+            WebPubSubNameValidator.HubNamePattern,
+            ErrorMessage = "Invalid hub name.")]
         string hub,
+        [MinLength(1, ErrorMessage = "Invalid connection ID.")]
         string connectionId,
+        [Range(0, MaximumMessageTtlSeconds, ErrorMessage = "Invalid messageTtlSeconds.")]
+        [FromQuery(Name = "messageTtlSeconds")]
+        uint? messageTtlSeconds,
         CancellationToken cancellationToken = default)
     {
         if (!Authorize())
         {
             return Unauthorized();
         }
-        if (!WebPubSubNameValidator.IsValidHubName(hub))
-        {
-            return CreateBadRequest("Invalid hub name.");
-        }
-        if (string.IsNullOrEmpty(connectionId))
-        {
-            return CreateBadRequest("Invalid connection ID.");
-        }
-        if (!TryGetMessageTtl(out var messageTtlSeconds))
-        {
-            return CreateBadRequest("Invalid messageTtlSeconds.");
-        }
-        if (messageTtlSeconds != 0)
+        if (messageTtlSeconds.GetValueOrDefault() != 0)
         {
             return StatusCode(
                 StatusCodes.Status501NotImplemented,
@@ -218,23 +216,6 @@ internal sealed class WebPubSubEmulatorController : WebPubSubApiControllerDefini
         {
             return false;
         }
-    }
-
-    private bool TryGetMessageTtl(out int messageTtlSeconds)
-    {
-        messageTtlSeconds = 0;
-        if (!Request.Query.TryGetValue("messageTtlSeconds", out var values))
-        {
-            return true;
-        }
-
-        return values.Count == 1 &&
-            int.TryParse(
-                values[0],
-                NumberStyles.None,
-                CultureInfo.InvariantCulture,
-                out messageTtlSeconds) &&
-            messageTtlSeconds is >= 0 and <= 300;
     }
 
     private async Task<byte[]?> ReadBodyAsync(

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubEmulatorController.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubEmulatorController.cs
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Microsoft.Azure.WebPubSub.Emulator;
@@ -8,9 +12,270 @@ namespace Microsoft.Azure.WebPubSub.Emulator;
 [ApiController]
 internal sealed class WebPubSubEmulatorController : WebPubSubApiControllerDefinition
 {
+    private const string MetadataHeaderPrefix = "X-WebPubSub-Metadata-";
+    private readonly ConnectionManager _connections;
+    private readonly EmulatorRuntimeOptions _runtimeOptions;
+    private readonly WebPubSubTokenService _tokenService;
+
+    public WebPubSubEmulatorController(
+        ConnectionManager connections,
+        EmulatorRuntimeOptions runtimeOptions,
+        WebPubSubTokenService tokenService)
+    {
+        _connections = connections;
+        _runtimeOptions = runtimeOptions;
+        _tokenService = tokenService;
+    }
+
     public override Task<IActionResult> GetServiceStatus(
         CancellationToken cancellationToken = default)
     {
         return Task.FromResult<IActionResult>(Ok());
+    }
+
+    public override Task<IActionResult> ConnectionExists(
+        string hub,
+        string connectionId,
+        CancellationToken cancellationToken = default)
+    {
+        IActionResult result;
+        if (!Authorize())
+        {
+            result = Unauthorized();
+        }
+        else if (!WebPubSubNameValidator.IsValidHubName(hub))
+        {
+            result = CreateBadRequest("Invalid hub name.");
+        }
+        else if (string.IsNullOrEmpty(connectionId))
+        {
+            result = CreateBadRequest("Invalid connection ID.");
+        }
+        else
+        {
+            result = _connections.ConnectionExists(hub.ToLowerInvariant(), connectionId)
+                ? Ok()
+                : NotFound();
+        }
+
+        return Task.FromResult(result);
+    }
+
+    public override async Task<IActionResult> SendToConnection(
+        string hub,
+        string connectionId,
+        CancellationToken cancellationToken = default)
+    {
+        if (!Authorize())
+        {
+            return Unauthorized();
+        }
+        if (!WebPubSubNameValidator.IsValidHubName(hub))
+        {
+            return CreateBadRequest("Invalid hub name.");
+        }
+        if (string.IsNullOrEmpty(connectionId))
+        {
+            return CreateBadRequest("Invalid connection ID.");
+        }
+        if (!TryGetMessageTtl(out var messageTtlSeconds))
+        {
+            return CreateBadRequest("Invalid messageTtlSeconds.");
+        }
+        if (messageTtlSeconds != 0)
+        {
+            return StatusCode(
+                StatusCodes.Status501NotImplemented,
+                new
+                {
+                    code = "NotImplemented",
+                    message = "Non-zero messageTtlSeconds is not implemented by the emulator.",
+                });
+        }
+        if (Request.ContentLength is not { } contentLength ||
+            contentLength < 0 ||
+            contentLength > _runtimeOptions.MaxMessageSizeBytes)
+        {
+            return CreateBadRequest("Invalid Content-Length header.");
+        }
+        if (!TryGetDataType(out var dataType, out var encoding))
+        {
+            return StatusCode(StatusCodes.Status415UnsupportedMediaType);
+        }
+
+        var bytes = await ReadBodyAsync(encoding, cancellationToken);
+        if (bytes is null)
+        {
+            return CreateBadRequest("Invalid Content-Length header.");
+        }
+        if (dataType == MessageDataType.Json && !IsValidJson(bytes))
+        {
+            return CreateBadRequest("The request body is not a valid JSON.");
+        }
+
+        IReadOnlyDictionary<string, string>? metadata;
+        try
+        {
+            metadata = GetMetadata();
+            WebPubSubMetadataValidator.Validate(metadata);
+        }
+        catch (InvalidDataException exception)
+        {
+            return CreateBadRequest(exception.Message);
+        }
+
+        _connections.SendToConnection(
+            hub.ToLowerInvariant(),
+            connectionId,
+            new MessageData(dataType, bytes, metadata));
+        return Accepted();
+    }
+
+    private bool Authorize()
+    {
+        var authorization = Request.Headers.Authorization.ToString();
+        const string bearerPrefix = "Bearer ";
+        if (!authorization.StartsWith(bearerPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var token = authorization[bearerPrefix.Length..].Trim();
+        var requestUri = new Uri(
+            $"{Request.Scheme}://{Request.Host}{Request.PathBase}" +
+            $"{Request.Path}{Request.QueryString}");
+        return _tokenService.ValidateRestToken(requestUri, token);
+    }
+
+    private IReadOnlyDictionary<string, string>? GetMetadata()
+    {
+        Dictionary<string, string>? metadata = null;
+        foreach (var header in Request.Headers)
+        {
+            if (!header.Key.StartsWith(MetadataHeaderPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var key = header.Key[MetadataHeaderPrefix.Length..].ToLowerInvariant();
+            var value = header.Value.Count == 0 ? string.Empty : header.Value[^1] ?? string.Empty;
+            var lastComma = value.LastIndexOf(',');
+            metadata ??= new(StringComparer.Ordinal);
+            metadata[key] = lastComma < 0 ? value.Trim() : value[(lastComma + 1)..].Trim();
+        }
+        return metadata;
+    }
+
+    private bool TryGetDataType(out MessageDataType dataType, out Encoding? encoding)
+    {
+        dataType = MessageDataType.Binary;
+        encoding = null;
+        if (string.IsNullOrEmpty(Request.ContentType))
+        {
+            return true;
+        }
+
+        Microsoft.Net.Http.Headers.MediaTypeHeaderValue? contentType;
+        try
+        {
+            contentType = Request.GetTypedHeaders().ContentType;
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+        if (contentType is null)
+        {
+            return false;
+        }
+
+        var mediaType = contentType.MediaType.Value;
+        if (string.Equals(mediaType, "application/octet-stream", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+        if (string.Equals(mediaType, "application/json", StringComparison.OrdinalIgnoreCase))
+        {
+            dataType = MessageDataType.Json;
+        }
+        else if (string.Equals(mediaType, "text/plain", StringComparison.OrdinalIgnoreCase))
+        {
+            dataType = MessageDataType.Text;
+        }
+        else
+        {
+            return false;
+        }
+
+        try
+        {
+            encoding = string.IsNullOrEmpty(contentType.Charset.Value)
+                ? Encoding.UTF8
+                : Encoding.GetEncoding(contentType.Charset.Value);
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+    }
+
+    private bool TryGetMessageTtl(out int messageTtlSeconds)
+    {
+        messageTtlSeconds = 0;
+        if (!Request.Query.TryGetValue("messageTtlSeconds", out var values))
+        {
+            return true;
+        }
+
+        return values.Count == 1 &&
+            int.TryParse(
+                values[0],
+                NumberStyles.None,
+                CultureInfo.InvariantCulture,
+                out messageTtlSeconds) &&
+            messageTtlSeconds is >= 0 and <= 300;
+    }
+
+    private async Task<byte[]?> ReadBodyAsync(
+        Encoding? encoding,
+        CancellationToken cancellationToken)
+    {
+        using var stream = new MemoryStream();
+        var buffer = new byte[81920];
+        while (true)
+        {
+            var count = await Request.Body.ReadAsync(buffer, cancellationToken);
+            if (count == 0)
+            {
+                break;
+            }
+            if (stream.Length + count > _runtimeOptions.MaxMessageSizeBytes)
+            {
+                return null;
+            }
+            await stream.WriteAsync(buffer.AsMemory(0, count), cancellationToken);
+        }
+
+        var bytes = stream.ToArray();
+        return encoding is null || encoding.CodePage == Encoding.UTF8.CodePage
+            ? bytes
+            : Encoding.Convert(encoding, Encoding.UTF8, bytes);
+    }
+
+    private static bool IsValidJson(byte[] payload)
+    {
+        var reader = new Utf8JsonReader(payload, isFinalBlock: true, state: default);
+        try
+        {
+            while (reader.Read())
+            {
+            }
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
     }
 }

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubJsonV1PayloadProcessor.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubJsonV1PayloadProcessor.cs
@@ -142,6 +142,14 @@ internal sealed class WebPubSubJsonV1PayloadProcessor : IClientPayloadProcessor
         return _protocol.WriteGroupData(group, fromUserId, data, sequenceId);
     }
 
+    public WebSocketPayload EncodeServerData(
+        LogicalConnection connection,
+        MessageData data,
+        ulong? sequenceId)
+    {
+        return _protocol.WriteServerData(data, sequenceId);
+    }
+
     public static bool IsSupportedSubprotocol(string? subprotocol)
     {
         return string.Equals(subprotocol, SubprotocolName, StringComparison.OrdinalIgnoreCase) ||

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubMetadataValidator.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubMetadataValidator.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.RegularExpressions;
+
+namespace Microsoft.Azure.WebPubSub.Emulator;
+
+internal static partial class WebPubSubMetadataValidator
+{
+    private const int MaximumTotalBytes = 8 * 1024;
+    private const int MaximumKeyBytes = 256;
+    private const int MaximumValueBytes = 1024;
+
+    public static void Validate(IReadOnlyDictionary<string, string>? metadata)
+    {
+        if (metadata is null)
+        {
+            return;
+        }
+
+        var totalBytes = 0;
+        foreach (var item in metadata)
+        {
+            if (!MetadataKeyRegex().IsMatch(item.Key))
+            {
+                throw new InvalidDataException(
+                    $"Metadata key '{item.Key}' contains invalid characters.");
+            }
+            if (!item.Value.All(character => character <= 0x7f))
+            {
+                throw new InvalidDataException(
+                    $"Metadata value for key '{item.Key}' must be ASCII.");
+            }
+            if (item.Key.Length > MaximumKeyBytes)
+            {
+                throw new InvalidDataException(
+                    $"Metadata key '{item.Key}' exceeds {MaximumKeyBytes} bytes.");
+            }
+            if (item.Value.Length > MaximumValueBytes)
+            {
+                throw new InvalidDataException(
+                    $"Metadata value for key '{item.Key}' exceeds {MaximumValueBytes} bytes.");
+            }
+
+            totalBytes += item.Key.Length + item.Value.Length;
+            if (totalBytes > MaximumTotalBytes)
+            {
+                throw new InvalidDataException($"Metadata exceeds {MaximumTotalBytes} bytes.");
+            }
+        }
+    }
+
+    [GeneratedRegex(
+        "^[!#$%&'*+\\-.^_`|~0-9a-z]+$",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex MetadataKeyRegex();
+}

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubNameValidator.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubNameValidator.cs
@@ -14,6 +14,11 @@ internal static partial class WebPubSubNameValidator
         return !string.IsNullOrWhiteSpace(group) && group.Length <= MaximumGroupNameLength;
     }
 
+    public static bool IsValidHubName(string? hub)
+    {
+        return !string.IsNullOrEmpty(hub) && HubNameRegex().IsMatch(hub);
+    }
+
     public static bool IsValidEventName(string? eventName)
     {
         return !string.IsNullOrEmpty(eventName) && EventNameRegex().IsMatch(eventName);
@@ -23,4 +28,9 @@ internal static partial class WebPubSubNameValidator
         "^[a-z][a-z0-9_.-]{0,127}$",
         RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
     private static partial Regex EventNameRegex();
+
+    [GeneratedRegex(
+        "^[A-Za-z][A-Za-z0-9_`,.\\[\\]]{0,127}$",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex HubNameRegex();
 }

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubNameValidator.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubNameValidator.cs
@@ -7,16 +7,12 @@ namespace Microsoft.Azure.WebPubSub.Emulator;
 
 internal static partial class WebPubSubNameValidator
 {
+    public const string HubNamePattern = "^[A-Za-z][A-Za-z0-9_`,.\\[\\]]{0,127}$";
     public const int MaximumGroupNameLength = 1024;
 
     public static bool IsValidGroupName(string? group)
     {
         return !string.IsNullOrWhiteSpace(group) && group.Length <= MaximumGroupNameLength;
-    }
-
-    public static bool IsValidHubName(string? hub)
-    {
-        return !string.IsNullOrEmpty(hub) && HubNameRegex().IsMatch(hub);
     }
 
     public static bool IsValidEventName(string? eventName)
@@ -28,9 +24,4 @@ internal static partial class WebPubSubNameValidator
         "^[a-z][a-z0-9_.-]{0,127}$",
         RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
     private static partial Regex EventNameRegex();
-
-    [GeneratedRegex(
-        "^[A-Za-z][A-Za-z0-9_`,.\\[\\]]{0,127}$",
-        RegexOptions.CultureInvariant)]
-    private static partial Regex HubNameRegex();
 }

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubTokenService.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubTokenService.cs
@@ -91,11 +91,23 @@ internal sealed class WebPubSubTokenService
 
         try
         {
-            _handler.ValidateToken(
-                token,
-                CreateValidationParameters(requestUri.AbsoluteUri),
-                out _);
-            return true;
+            foreach (var audience in GetRestAudiences(requestUri))
+            {
+                try
+                {
+                    var parameters = CreateValidationParameters(audience);
+                    parameters.AudienceValidator = (audiences, _, _) => audiences.Any(
+                        input => string.Equals(input, audience, StringComparison.OrdinalIgnoreCase));
+                    _handler.ValidateToken(
+                        token,
+                        parameters,
+                        out _);
+                    return true;
+                }
+                catch (SecurityTokenInvalidAudienceException)
+                {
+                }
+            }
         }
         catch (Exception exception) when (
             exception is SecurityTokenException or ArgumentException)
@@ -106,6 +118,8 @@ internal sealed class WebPubSubTokenService
                 requestUri.AbsolutePath);
             return false;
         }
+
+        return false;
     }
 
     public string IssueReconnectionToken(string connectionId)
@@ -165,5 +179,14 @@ internal sealed class WebPubSubTokenService
         return new Uri(
             endpoint,
             $"{ClientPathPrefix.TrimStart('/')}{Uri.EscapeDataString(hub)}").AbsoluteUri;
+    }
+
+    private static IEnumerable<string> GetRestAudiences(Uri requestUri)
+    {
+        yield return requestUri.AbsoluteUri;
+        if (!string.IsNullOrEmpty(requestUri.Query))
+        {
+            yield return requestUri.GetLeftPart(UriPartial.Path);
+        }
     }
 }

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/EmulatorApplicationTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/EmulatorApplicationTests.cs
@@ -124,7 +124,7 @@ public class EmulatorApplicationTests
 
         using var request = new HttpRequestMessage(
             HttpMethod.Head,
-            "/api/hubs/chat/connections/connection?api-version=2024-12-01");
+            "/api/hubs/chat/groups/group?api-version=2024-12-01");
         using var response = await application.GetTestClient().SendAsync(request).WaitAsync(TestTimeout);
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/LogicalConnectionTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/LogicalConnectionTests.cs
@@ -124,6 +124,28 @@ public class LogicalConnectionTests
     }
 
     [Fact]
+    public async Task RawDirectServerDataPreservesBinaryFrame()
+    {
+        using var application = EmulatorApplication.Build();
+        var manager = application.Services.GetRequiredService<ConnectionManager>();
+        var connection = CreateConnection(manager, "connection");
+        var webSocket = new RecordingSendWebSocket();
+        var processor = new SimpleWebSocketPayloadProcessor(manager);
+        using var transport = connection.TryAttach(webSocket, processor);
+        Assert.NotNull(transport);
+        Assert.True(manager.TryActivate(connection));
+
+        manager.SendToConnection(
+            connection.Hub,
+            connection.ConnectionId,
+            new MessageData(MessageDataType.Binary, new byte[] { 0, 1, 2 }));
+        var sent = await webSocket.Sent.Task.WaitAsync(TestTimeout);
+
+        Assert.Equal(new byte[] { 0, 1, 2 }, sent.Payload);
+        Assert.Equal(WebSocketMessageType.Binary, sent.MessageType);
+    }
+
+    [Fact]
     public void SequenceAckReleasesReliableBufferCapacity()
     {
         using var application = EmulatorApplication.Build(
@@ -283,6 +305,38 @@ public class LogicalConnectionTests
         Assert.True(connection.Groups.ContainsKey("room"));
         Assert.Equal("second"u8.ToArray(), await recoveredSocket.ReadAsync());
         Assert.Equal("third"u8.ToArray(), await recoveredSocket.ReadAsync());
+    }
+
+    [Fact]
+    public async Task ReliableDetachBuffersAndReplaysDirectServerDataInOrder()
+    {
+        using var application = EmulatorApplication.Build();
+        var manager = application.Services.GetRequiredService<ConnectionManager>();
+        var connection = CreateConnection(manager, "connection", reliable: true);
+        var processor = new RecordingSequencePayloadProcessor();
+        using var original = connection.TryAttach(new TestWebSocket(), processor);
+        Assert.NotNull(original);
+        Assert.True(manager.TryActivate(connection));
+        connection.Detach(original);
+
+        manager.SendToConnection(
+            connection.Hub,
+            connection.ConnectionId,
+            new MessageData(MessageDataType.Text, "first"u8.ToArray()));
+        manager.SendToConnection(
+            connection.Hub,
+            connection.ConnectionId,
+            new MessageData(MessageDataType.Text, "second"u8.ToArray()));
+        var recoveredSocket = new QueueingSendWebSocket();
+        using var recovered = await connection.TryReconnectAsync(
+            recoveredSocket,
+            processor,
+            CancellationToken.None);
+
+        Assert.NotNull(recovered);
+        Assert.Equal(new ulong?[] { 1, 2 }, processor.SequenceIds);
+        Assert.Equal("first"u8.ToArray(), await recoveredSocket.ReadAsync());
+        Assert.Equal("second"u8.ToArray(), await recoveredSocket.ReadAsync());
     }
 
     [Fact]
@@ -937,6 +991,14 @@ public class LogicalConnectionTests
                         : WebSocketMessageType.Text)
                 : _webSocketPayload;
         }
+
+        public WebSocketPayload EncodeServerData(
+            LogicalConnection connection,
+            MessageData data,
+            ulong? sequenceId)
+        {
+            return EncodeGroupData(connection, string.Empty, null, data, sequenceId);
+        }
     }
 
     private sealed class RecordingSequencePayloadProcessor : IClientPayloadProcessor
@@ -965,6 +1027,14 @@ public class LogicalConnectionTests
         {
             SequenceIds.Add(sequenceId);
             return new WebSocketPayload(data.Bytes, WebSocketMessageType.Text);
+        }
+
+        public WebSocketPayload EncodeServerData(
+            LogicalConnection connection,
+            MessageData data,
+            ulong? sequenceId)
+        {
+            return EncodeGroupData(connection, string.Empty, null, data, sequenceId);
         }
     }
 
@@ -995,6 +1065,14 @@ public class LogicalConnectionTests
             ulong? sequenceId)
         {
             return new WebSocketPayload(data.Bytes, WebSocketMessageType.Text);
+        }
+
+        public WebSocketPayload EncodeServerData(
+            LogicalConnection connection,
+            MessageData data,
+            ulong? sequenceId)
+        {
+            return EncodeGroupData(connection, string.Empty, null, data, sequenceId);
         }
     }
 
@@ -1029,6 +1107,14 @@ public class LogicalConnectionTests
             ulong? sequenceId)
         {
             return new WebSocketPayload(data.Bytes, WebSocketMessageType.Text);
+        }
+
+        public WebSocketPayload EncodeServerData(
+            LogicalConnection connection,
+            MessageData data,
+            ulong? sequenceId)
+        {
+            return EncodeGroupData(connection, string.Empty, null, data, sequenceId);
         }
     }
 
@@ -1065,6 +1151,14 @@ public class LogicalConnectionTests
             ulong? sequenceId)
         {
             return new WebSocketPayload(data.Bytes, WebSocketMessageType.Text);
+        }
+
+        public WebSocketPayload EncodeServerData(
+            LogicalConnection connection,
+            MessageData data,
+            ulong? sequenceId)
+        {
+            return EncodeGroupData(connection, string.Empty, null, data, sequenceId);
         }
     }
 

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/Microsoft.Azure.WebPubSub.Emulator.Tests.csproj
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/Microsoft.Azure.WebPubSub.Emulator.Tests.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Messaging.WebPubSub" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/RestApiTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/RestApiTests.cs
@@ -1,0 +1,609 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure;
+using Azure.Core;
+using Azure.Messaging.WebPubSub;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Microsoft.Azure.WebPubSub.Emulator.Tests;
+
+public class RestApiTests
+{
+    private const string Hub = "chat";
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(10);
+
+    [Fact]
+    public async Task OfficialServerSdkCanCheckAndSendToConnection()
+    {
+        await using var application = EmulatorApplication.Build(
+            ["--urls=http://127.0.0.1:0"]);
+        await application.StartAsync().WaitAsync(TestTimeout);
+        var server = application.Services.GetRequiredService<IServer>();
+        var endpoint = Assert.Single(
+            server.Features.Get<IServerAddressesFeature>()!.Addresses);
+        var connectionString =
+            $"Endpoint={endpoint};AccessKey={EmulatorOptions.DefaultAccessKey};Version=1.0;";
+        var serviceClient = new WebPubSubServiceClient(connectionString, Hub);
+        using var webSocket = new ClientWebSocket();
+        webSocket.Options.AddSubProtocol(WebPubSubJsonV1PayloadProcessor.SubprotocolName);
+        await webSocket.ConnectAsync(
+            serviceClient.GetClientAccessUri(),
+            CancellationToken.None).WaitAsync(TestTimeout);
+        using var connected = await ReceiveJsonAsync(webSocket);
+        var connectionId = connected.RootElement.GetProperty("connectionId").GetString()!;
+
+        Assert.True((await serviceClient.ConnectionExistsAsync(connectionId)
+            .WaitAsync(TestTimeout)).Value);
+
+        await serviceClient.SendToConnectionAsync(
+            connectionId,
+            BinaryData.FromString("from-sdk"),
+            ContentType.TextPlain).WaitAsync(TestTimeout);
+        using var textMessage = await ReceiveJsonAsync(webSocket);
+        Assert.Equal("server", textMessage.RootElement.GetProperty("from").GetString());
+        Assert.Equal("from-sdk", textMessage.RootElement.GetProperty("data").GetString());
+
+        await serviceClient.SendToConnectionAsync(
+            connectionId,
+            RequestContent.Create(BinaryData.FromString("""{"value":42}""")),
+            ContentType.ApplicationJson).WaitAsync(TestTimeout);
+        using var jsonMessage = await ReceiveJsonAsync(webSocket);
+        Assert.Equal("json", jsonMessage.RootElement.GetProperty("dataType").GetString());
+        Assert.Equal(42, jsonMessage.RootElement
+            .GetProperty("data")
+            .GetProperty("value")
+            .GetInt32());
+
+        Assert.False((await serviceClient.ConnectionExistsAsync("missing")
+            .WaitAsync(TestTimeout)).Value);
+        await serviceClient.SendToConnectionAsync(
+            "missing",
+            BinaryData.FromString("ignored"),
+            ContentType.TextPlain).WaitAsync(TestTimeout);
+
+        await webSocket.CloseAsync(
+            WebSocketCloseStatus.NormalClosure,
+            "done",
+            CancellationToken.None).WaitAsync(TestTimeout);
+    }
+
+    [Fact]
+    public async Task ConnectionExistsAndSendToConnectionUseLiveConnection()
+    {
+        await using var application = await StartApplicationAsync();
+        using var webSocket = await ConnectAsync(application);
+        using var connected = await ReceiveJsonAsync(webSocket);
+        var connectionId = connected.RootElement.GetProperty("connectionId").GetString()!;
+        var connectionPath = $"/api/hubs/{Hub}/connections/{connectionId}?api-version=2024-12-01";
+
+        using var existsRequest = CreateAuthorizedRequest(HttpMethod.Head, connectionPath);
+        using var existsResponse = await application.GetTestClient()
+            .SendAsync(existsRequest)
+            .WaitAsync(TestTimeout);
+
+        Assert.Equal(HttpStatusCode.OK, existsResponse.StatusCode);
+
+        var sendPath = $"/api/hubs/{Hub}/connections/{connectionId}/:send?api-version=2024-12-01";
+        using var sendRequest = CreateAuthorizedRequest(HttpMethod.Post, sendPath);
+        sendRequest.Content = new StringContent("hello", Encoding.UTF8, "text/plain");
+        sendRequest.Headers.Add("X-WebPubSub-Metadata-Trace", "first, final");
+        using var sendResponse = await application.GetTestClient()
+            .SendAsync(sendRequest)
+            .WaitAsync(TestTimeout);
+        using var message = await ReceiveJsonAsync(webSocket);
+
+        Assert.Equal(HttpStatusCode.Accepted, sendResponse.StatusCode);
+        Assert.Equal("message", message.RootElement.GetProperty("type").GetString());
+        Assert.Equal("server", message.RootElement.GetProperty("from").GetString());
+        Assert.Equal("text", message.RootElement.GetProperty("dataType").GetString());
+        Assert.Equal("hello", message.RootElement.GetProperty("data").GetString());
+        Assert.Equal(
+            "final",
+            message.RootElement.GetProperty("metadata").GetProperty("trace").GetString());
+
+        using var binaryRequest = CreateAuthorizedRequest(HttpMethod.Post, sendPath);
+        binaryRequest.Content = new ByteArrayContent([0, 1, 2]);
+        binaryRequest.Content.Headers.ContentType =
+            new MediaTypeHeaderValue("application/octet-stream");
+        using var binaryResponse = await application.GetTestClient()
+            .SendAsync(binaryRequest)
+            .WaitAsync(TestTimeout);
+        using var binaryMessage = await ReceiveJsonAsync(webSocket);
+
+        Assert.Equal(HttpStatusCode.Accepted, binaryResponse.StatusCode);
+        Assert.Equal("binary", binaryMessage.RootElement.GetProperty("dataType").GetString());
+        Assert.Equal([0, 1, 2], binaryMessage.RootElement.GetProperty("data").GetBytesFromBase64());
+    }
+
+    [Fact]
+    public async Task DirectSendToDetachedReliableConnectionReplaysInOrder()
+    {
+        await using var application = await StartApplicationAsync();
+        var initial = await ConnectReliableAsync(application);
+        using var initialSocket = initial.WebSocket;
+        initialSocket.Abort();
+
+        var sendPath =
+            $"/api/hubs/{Hub}/connections/{initial.ConnectionId}/:send?api-version=2024-12-01";
+        using var firstRequest = CreateAuthorizedRequest(HttpMethod.Post, sendPath);
+        firstRequest.Content = new StringContent("first", Encoding.UTF8, "text/plain");
+        firstRequest.Headers.Add("X-WebPubSub-Metadata-Trace", "rest");
+        using var firstResponse = await application.GetTestClient()
+            .SendAsync(firstRequest)
+            .WaitAsync(TestTimeout);
+        using var secondRequest = CreateAuthorizedRequest(HttpMethod.Post, sendPath);
+        secondRequest.Content = new StringContent("second", Encoding.UTF8, "text/plain");
+        using var secondResponse = await application.GetTestClient()
+            .SendAsync(secondRequest)
+            .WaitAsync(TestTimeout);
+
+        Assert.Equal(HttpStatusCode.Accepted, firstResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.Accepted, secondResponse.StatusCode);
+
+        using var recovered = await ConnectRecoveryAsync(
+            application,
+            initial.ConnectionId,
+            initial.ReconnectionToken);
+        using var first = await ReceiveJsonAsync(recovered);
+        using var second = await ReceiveJsonAsync(recovered);
+
+        Assert.Equal("server", first.RootElement.GetProperty("from").GetString());
+        Assert.Equal("first", first.RootElement.GetProperty("data").GetString());
+        Assert.Equal(1UL, first.RootElement.GetProperty("sequenceId").GetUInt64());
+        Assert.Equal(
+            "rest",
+            first.RootElement.GetProperty("metadata").GetProperty("trace").GetString());
+        Assert.Equal("second", second.RootElement.GetProperty("data").GetString());
+        Assert.Equal(2UL, second.RootElement.GetProperty("sequenceId").GetUInt64());
+    }
+
+    [Fact]
+    public async Task MissingConnectionHasServiceCompatibleStatuses()
+    {
+        await using var application = await StartApplicationAsync();
+        const string connectionPath =
+            "/api/hubs/chat/connections/missing?api-version=2024-12-01";
+        using var existsRequest = CreateAuthorizedRequest(HttpMethod.Head, connectionPath);
+        using var existsResponse = await application.GetTestClient()
+            .SendAsync(existsRequest)
+            .WaitAsync(TestTimeout);
+
+        const string sendPath =
+            "/api/hubs/chat/connections/missing/:send?api-version=2024-12-01";
+        using var sendRequest = CreateAuthorizedRequest(HttpMethod.Post, sendPath);
+        sendRequest.Content = new ByteArrayContent("ignored"u8.ToArray());
+        sendRequest.Content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        using var sendResponse = await application.GetTestClient()
+            .SendAsync(sendRequest)
+            .WaitAsync(TestTimeout);
+
+        Assert.Equal(HttpStatusCode.NotFound, existsResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.Accepted, sendResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task RestOperationsRequireRequestScopedBearerToken()
+    {
+        await using var application = await StartApplicationAsync();
+        const string path = "/api/hubs/chat/connections/missing?api-version=2024-12-01";
+        using var unauthorized = await application.GetTestClient()
+            .SendAsync(new HttpRequestMessage(HttpMethod.Head, path))
+            .WaitAsync(TestTimeout);
+        using var wrongAudienceRequest = new HttpRequestMessage(HttpMethod.Head, path);
+        wrongAudienceRequest.Headers.Authorization = new AuthenticationHeaderValue(
+            "Bearer",
+            CreateToken("http://localhost/api/hubs/other/connections/missing"));
+        using var wrongAudience = await application.GetTestClient()
+            .SendAsync(wrongAudienceRequest)
+            .WaitAsync(TestTimeout);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, unauthorized.StatusCode);
+        Assert.Equal(HttpStatusCode.Unauthorized, wrongAudience.StatusCode);
+    }
+
+    [Fact]
+    public async Task RestTokenAudienceCanOmitQueryString()
+    {
+        await using var application = await StartApplicationAsync();
+        const string path = "/api/hubs/chat/connections/missing?api-version=2024-12-01";
+        using var request = new HttpRequestMessage(HttpMethod.Head, path);
+        request.Headers.Authorization = new AuthenticationHeaderValue(
+            "Bearer",
+            CreateToken("http://localhost/api/hubs/chat/connections/missing"));
+
+        using var response = await application.GetTestClient()
+            .SendAsync(request)
+            .WaitAsync(TestTimeout);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("2021-10-01")]
+    [InlineData("2022-11-01")]
+    [InlineData("2023-07-01")]
+    [InlineData("2024-01-01")]
+    [InlineData("2024-12-01")]
+    public async Task AdvertisedApiVersionIsAccepted(string? apiVersion)
+    {
+        await using var application = await StartApplicationAsync();
+        var path = "/api/hubs/chat/connections/missing" +
+            (apiVersion is null ? string.Empty : $"?api-version={apiVersion}");
+        using var request = CreateAuthorizedRequest(HttpMethod.Head, path);
+
+        using var response = await application.GetTestClient()
+            .SendAsync(request)
+            .WaitAsync(TestTimeout);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.Equal(
+            "2021-10-01, 2022-11-01, 2023-07-01, 2024-01-01, 2024-12-01",
+            response.Headers.GetValues("api-supported-versions").Single());
+    }
+
+    [Theory]
+    [InlineData("unsupported")]
+    [InlineData("2024-12-01,2023-07-01")]
+    public async Task UnsupportedApiVersionIsRejected(string apiVersion)
+    {
+        await using var application = await StartApplicationAsync();
+        var path =
+            $"/api/hubs/chat/connections/missing/:send?api-version={Uri.EscapeDataString(apiVersion)}";
+        using var request = CreateAuthorizedRequest(HttpMethod.Post, path);
+        request.Content = new StringContent("hello", Encoding.UTF8, "text/plain");
+
+        using var response = await application.GetTestClient()
+            .SendAsync(request)
+            .WaitAsync(TestTimeout);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DuplicateApiVersionIsRejected()
+    {
+        await using var application = await StartApplicationAsync();
+        const string path =
+            "/api/hubs/chat/connections/missing?api-version=2024-12-01&api-version=2023-07-01";
+        using var request = CreateAuthorizedRequest(HttpMethod.Head, path);
+
+        using var response = await application.GetTestClient()
+            .SendAsync(request)
+            .WaitAsync(TestTimeout);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task InvalidApiVersionDoesNotDeliverMessage()
+    {
+        await using var application = await StartApplicationAsync();
+        using var webSocket = await ConnectAsync(application);
+        using var connected = await ReceiveJsonAsync(webSocket);
+        var connectionId = connected.RootElement.GetProperty("connectionId").GetString()!;
+        var invalidPath =
+            $"/api/hubs/{Hub}/connections/{connectionId}/:send?api-version=unsupported";
+        using var invalidRequest = CreateAuthorizedRequest(HttpMethod.Post, invalidPath);
+        invalidRequest.Content = new StringContent("invalid", Encoding.UTF8, "text/plain");
+
+        using var invalidResponse = await application.GetTestClient()
+            .SendAsync(invalidRequest)
+            .WaitAsync(TestTimeout);
+
+        Assert.Equal(HttpStatusCode.BadRequest, invalidResponse.StatusCode);
+
+        var validPath =
+            $"/api/hubs/{Hub}/connections/{connectionId}/:send?api-version=2024-12-01";
+        using var validRequest = CreateAuthorizedRequest(HttpMethod.Post, validPath);
+        validRequest.Content = new StringContent("valid", Encoding.UTF8, "text/plain");
+        using var validResponse = await application.GetTestClient()
+            .SendAsync(validRequest)
+            .WaitAsync(TestTimeout);
+        using var delivered = await ReceiveJsonAsync(webSocket);
+
+        Assert.Equal(HttpStatusCode.Accepted, validResponse.StatusCode);
+        Assert.Equal("valid", delivered.RootElement.GetProperty("data").GetString());
+    }
+
+    [Fact]
+    public async Task UnknownLengthBodyIsRejected()
+    {
+        await using var application = await StartApplicationAsync();
+        using var webSocket = await ConnectAsync(application);
+        using var connected = await ReceiveJsonAsync(webSocket);
+        var connectionId = connected.RootElement.GetProperty("connectionId").GetString()!;
+        var path =
+            $"/api/hubs/chat/connections/{connectionId}/:send?api-version=2024-12-01";
+        using var request = CreateAuthorizedRequest(HttpMethod.Post, path);
+        request.Content = new UnknownLengthContent("hello"u8.ToArray());
+        request.Content.Headers.ContentType = new MediaTypeHeaderValue("text/plain");
+
+        using var response = await application.GetTestClient()
+            .SendAsync(request)
+            .WaitAsync(TestTimeout);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        using var validRequest = CreateAuthorizedRequest(HttpMethod.Post, path);
+        validRequest.Content = new StringContent("sentinel", Encoding.UTF8, "text/plain");
+        using var validResponse = await application.GetTestClient()
+            .SendAsync(validRequest)
+            .WaitAsync(TestTimeout);
+        using var delivered = await ReceiveJsonAsync(webSocket);
+
+        Assert.Equal(HttpStatusCode.Accepted, validResponse.StatusCode);
+        Assert.Equal("sentinel", delivered.RootElement.GetProperty("data").GetString());
+    }
+
+    [Theory]
+    [InlineData("application/xml", "<message />", HttpStatusCode.UnsupportedMediaType)]
+    [InlineData("application/json", "{", HttpStatusCode.BadRequest)]
+    public async Task SendToConnectionValidatesContent(
+        string contentType,
+        string body,
+        HttpStatusCode expectedStatus)
+    {
+        await using var application = await StartApplicationAsync();
+        const string path =
+            "/api/hubs/chat/connections/missing/:send?api-version=2024-12-01";
+        using var request = CreateAuthorizedRequest(HttpMethod.Post, path);
+        request.Content = new StringContent(body, Encoding.UTF8);
+        request.Content.Headers.ContentType = MediaTypeHeaderValue.Parse(contentType);
+
+        using var response = await application.GetTestClient()
+            .SendAsync(request)
+            .WaitAsync(TestTimeout);
+
+        Assert.Equal(expectedStatus, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task MalformedContentTypeDoesNotDeliverMessage()
+    {
+        await using var application = await StartApplicationAsync();
+        using var webSocket = await ConnectAsync(application);
+        using var connected = await ReceiveJsonAsync(webSocket);
+        var connectionId = connected.RootElement.GetProperty("connectionId").GetString()!;
+        var path =
+            $"/api/hubs/chat/connections/{connectionId}/:send?api-version=2024-12-01";
+        using var malformedRequest = CreateAuthorizedRequest(HttpMethod.Post, path);
+        malformedRequest.Content = new ByteArrayContent("invalid"u8.ToArray());
+        malformedRequest.Content.Headers.TryAddWithoutValidation(
+            "Content-Type",
+            "text/plain; charset=\"");
+
+        using var malformedResponse = await application.GetTestClient()
+            .SendAsync(malformedRequest)
+            .WaitAsync(TestTimeout);
+
+        Assert.Equal(HttpStatusCode.UnsupportedMediaType, malformedResponse.StatusCode);
+
+        using var validRequest = CreateAuthorizedRequest(HttpMethod.Post, path);
+        validRequest.Content = new StringContent("sentinel", Encoding.UTF8, "text/plain");
+        using var validResponse = await application.GetTestClient()
+            .SendAsync(validRequest)
+            .WaitAsync(TestTimeout);
+        using var delivered = await ReceiveJsonAsync(webSocket);
+
+        Assert.Equal(HttpStatusCode.Accepted, validResponse.StatusCode);
+        Assert.Equal("sentinel", delivered.RootElement.GetProperty("data").GetString());
+    }
+
+    [Fact]
+    public async Task ValidationErrorsUseStructuredResponse()
+    {
+        await using var application = await StartApplicationAsync();
+        const string path =
+            "/api/hubs/chat/connections/missing/:send?api-version=2024-12-01";
+        using var request = CreateAuthorizedRequest(HttpMethod.Post, path);
+        request.Content = new StringContent("{", Encoding.UTF8, "application/json");
+
+        using var response = await application.GetTestClient()
+            .SendAsync(request)
+            .WaitAsync(TestTimeout);
+        using var error = JsonDocument.Parse(
+            await response.Content.ReadAsByteArrayAsync().WaitAsync(TestTimeout));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+        Assert.Equal("Error.BadRequest", error.RootElement.GetProperty("code").GetString());
+        Assert.Equal(
+            "The request body is not a valid JSON.",
+            error.RootElement.GetProperty("message").GetString());
+        Assert.Equal("Request", error.RootElement.GetProperty("target").GetString());
+    }
+
+    [Fact]
+    public async Task InvalidMetadataUsesStructuredResponse()
+    {
+        await using var application = await StartApplicationAsync();
+        const string path =
+            "/api/hubs/chat/connections/missing/:send?api-version=2024-12-01";
+        using var request = CreateAuthorizedRequest(HttpMethod.Post, path);
+        request.Content = new StringContent("hello", Encoding.UTF8, "text/plain");
+        request.Headers.TryAddWithoutValidation(
+            $"X-WebPubSub-Metadata-{new string('a', 257)}",
+            "value");
+
+        using var response = await application.GetTestClient()
+            .SendAsync(request)
+            .WaitAsync(TestTimeout);
+        using var error = JsonDocument.Parse(
+            await response.Content.ReadAsByteArrayAsync().WaitAsync(TestTimeout));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("Error.BadRequest", error.RootElement.GetProperty("code").GetString());
+        Assert.False(string.IsNullOrEmpty(error.RootElement.GetProperty("message").GetString()));
+        Assert.Equal("Request", error.RootElement.GetProperty("target").GetString());
+    }
+
+    [Theory]
+    [InlineData("-1", HttpStatusCode.BadRequest)]
+    [InlineData("301", HttpStatusCode.BadRequest)]
+    [InlineData("invalid", HttpStatusCode.BadRequest)]
+    [InlineData("1", HttpStatusCode.NotImplemented)]
+    public async Task SendToConnectionDoesNotPretendToSupportMessageTtl(
+        string ttl,
+        HttpStatusCode expectedStatus)
+    {
+        await using var application = await StartApplicationAsync();
+        var path =
+            $"/api/hubs/chat/connections/missing/:send?api-version=2024-12-01&messageTtlSeconds={ttl}";
+        using var request = CreateAuthorizedRequest(HttpMethod.Post, path);
+        request.Content = new StringContent("hello", Encoding.UTF8, "text/plain");
+
+        using var response = await application.GetTestClient()
+            .SendAsync(request)
+            .WaitAsync(TestTimeout);
+
+        Assert.Equal(expectedStatus, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnsupportedMessageTtlDoesNotDeliverMessage()
+    {
+        await using var application = await StartApplicationAsync();
+        using var webSocket = await ConnectAsync(application);
+        using var connected = await ReceiveJsonAsync(webSocket);
+        var connectionId = connected.RootElement.GetProperty("connectionId").GetString()!;
+        var ttlPath = $"/api/hubs/{Hub}/connections/{connectionId}/:send" +
+            "?api-version=2024-12-01&messageTtlSeconds=1";
+        using var ttlRequest = CreateAuthorizedRequest(HttpMethod.Post, ttlPath);
+        ttlRequest.Content = new StringContent("expired", Encoding.UTF8, "text/plain");
+
+        using var ttlResponse = await application.GetTestClient()
+            .SendAsync(ttlRequest)
+            .WaitAsync(TestTimeout);
+
+        Assert.Equal(HttpStatusCode.NotImplemented, ttlResponse.StatusCode);
+
+        var validPath = $"/api/hubs/{Hub}/connections/{connectionId}/:send" +
+            "?api-version=2024-12-01";
+        using var validRequest = CreateAuthorizedRequest(HttpMethod.Post, validPath);
+        validRequest.Content = new StringContent("delivered", Encoding.UTF8, "text/plain");
+        using var validResponse = await application.GetTestClient()
+            .SendAsync(validRequest)
+            .WaitAsync(TestTimeout);
+        using var delivered = await ReceiveJsonAsync(webSocket);
+
+        Assert.Equal(HttpStatusCode.Accepted, validResponse.StatusCode);
+        Assert.Equal("delivered", delivered.RootElement.GetProperty("data").GetString());
+    }
+
+    private static async Task<WebApplication> StartApplicationAsync()
+    {
+        var builder = EmulatorApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        var application = EmulatorApplication.Build(builder);
+        await application.StartAsync().WaitAsync(TestTimeout);
+        return application;
+    }
+
+    private static async Task<WebSocket> ConnectAsync(WebApplication application)
+    {
+        var client = application.GetTestServer().CreateWebSocketClient();
+        client.SubProtocols.Add(WebPubSubJsonV1PayloadProcessor.SubprotocolName);
+        var path = $"{WebPubSubTokenService.ClientPathPrefix}{Hub}";
+        var token = CreateToken($"http://localhost{path}");
+        return await client.ConnectAsync(
+            new Uri($"ws://localhost{path}?access_token={Uri.EscapeDataString(token)}"),
+            CancellationToken.None).WaitAsync(TestTimeout);
+    }
+
+    private static async Task<(WebSocket WebSocket, string ConnectionId, string ReconnectionToken)>
+        ConnectReliableAsync(WebApplication application)
+    {
+        var client = application.GetTestServer().CreateWebSocketClient();
+        client.SubProtocols.Add(WebPubSubJsonV1PayloadProcessor.ReliableSubprotocolName);
+        var path = $"{WebPubSubTokenService.ClientPathPrefix}{Hub}";
+        var token = CreateToken($"http://localhost{path}");
+        var webSocket = await client.ConnectAsync(
+            new Uri($"ws://localhost{path}?access_token={Uri.EscapeDataString(token)}"),
+            CancellationToken.None).WaitAsync(TestTimeout);
+        using var connected = await ReceiveJsonAsync(webSocket);
+        return (
+            webSocket,
+            connected.RootElement.GetProperty("connectionId").GetString()!,
+            connected.RootElement.GetProperty("reconnectionToken").GetString()!);
+    }
+
+    private static async Task<WebSocket> ConnectRecoveryAsync(
+        WebApplication application,
+        string connectionId,
+        string reconnectionToken)
+    {
+        var client = application.GetTestServer().CreateWebSocketClient();
+        var uri = $"ws://localhost{WebPubSubTokenService.ClientPathPrefix}{Hub}" +
+            $"?awps_connection_id={Uri.EscapeDataString(connectionId)}" +
+            $"&awps_reconnection_token={Uri.EscapeDataString(reconnectionToken)}";
+        return await client.ConnectAsync(new Uri(uri), CancellationToken.None)
+            .WaitAsync(TestTimeout);
+    }
+
+    private static HttpRequestMessage CreateAuthorizedRequest(HttpMethod method, string path)
+    {
+        var request = new HttpRequestMessage(method, path);
+        request.Headers.Authorization = new AuthenticationHeaderValue(
+            "Bearer",
+            CreateToken($"http://localhost{path}"));
+        return request;
+    }
+
+    private static string CreateToken(string audience)
+    {
+        var token = new JwtSecurityToken(
+            audience: audience,
+            expires: DateTime.UtcNow.AddHours(1),
+            signingCredentials: new SigningCredentials(
+                new SymmetricSecurityKey(Encoding.UTF8.GetBytes(EmulatorOptions.DefaultAccessKey)),
+                SecurityAlgorithms.HmacSha256));
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    private static async Task<JsonDocument> ReceiveJsonAsync(WebSocket webSocket)
+    {
+        var buffer = new byte[4096];
+        var result = await webSocket.ReceiveAsync(buffer, CancellationToken.None)
+            .WaitAsync(TestTimeout);
+        Assert.Equal(WebSocketMessageType.Text, result.MessageType);
+        Assert.True(result.EndOfMessage);
+        return JsonDocument.Parse(buffer.AsMemory(0, result.Count));
+    }
+
+    private sealed class UnknownLengthContent(byte[] content) : HttpContent
+    {
+        protected override Task SerializeToStreamAsync(
+            Stream stream,
+            TransportContext? context)
+        {
+            return stream.WriteAsync(content).AsTask();
+        }
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = 0;
+            return false;
+        }
+    }
+}

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/RestApiTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/RestApiTests.cs
@@ -462,8 +462,9 @@ public class RestApiTests
     [InlineData("-1", HttpStatusCode.BadRequest)]
     [InlineData("301", HttpStatusCode.BadRequest)]
     [InlineData("invalid", HttpStatusCode.BadRequest)]
-    [InlineData("1", HttpStatusCode.NotImplemented)]
-    public async Task SendToConnectionDoesNotPretendToSupportMessageTtl(
+    [InlineData("1", HttpStatusCode.Accepted)]
+    [InlineData("300", HttpStatusCode.Accepted)]
+    public async Task SendToConnectionValidatesMessageTtl(
         string ttl,
         HttpStatusCode expectedStatus)
     {
@@ -481,7 +482,7 @@ public class RestApiTests
     }
 
     [Fact]
-    public async Task UnsupportedMessageTtlDoesNotDeliverMessage()
+    public async Task MessageTtlIsAcceptedForImmediateDelivery()
     {
         await using var application = await StartApplicationAsync();
         using var webSocket = await ConnectAsync(application);
@@ -490,24 +491,14 @@ public class RestApiTests
         var ttlPath = $"/api/hubs/{Hub}/connections/{connectionId}/:send" +
             "?api-version=2024-12-01&messageTtlSeconds=1";
         using var ttlRequest = CreateAuthorizedRequest(HttpMethod.Post, ttlPath);
-        ttlRequest.Content = new StringContent("expired", Encoding.UTF8, "text/plain");
+        ttlRequest.Content = new StringContent("delivered", Encoding.UTF8, "text/plain");
 
         using var ttlResponse = await application.GetTestClient()
             .SendAsync(ttlRequest)
             .WaitAsync(TestTimeout);
-
-        Assert.Equal(HttpStatusCode.NotImplemented, ttlResponse.StatusCode);
-
-        var validPath = $"/api/hubs/{Hub}/connections/{connectionId}/:send" +
-            "?api-version=2024-12-01";
-        using var validRequest = CreateAuthorizedRequest(HttpMethod.Post, validPath);
-        validRequest.Content = new StringContent("delivered", Encoding.UTF8, "text/plain");
-        using var validResponse = await application.GetTestClient()
-            .SendAsync(validRequest)
-            .WaitAsync(TestTimeout);
         using var delivered = await ReceiveJsonAsync(webSocket);
 
-        Assert.Equal(HttpStatusCode.Accepted, validResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.Accepted, ttlResponse.StatusCode);
         Assert.Equal("delivered", delivered.RootElement.GetProperty("data").GetString());
     }
 


### PR DESCRIPTION
## Relationship

This is a focused slice extracted from the umbrella emulator PR #1048. It preserves that PR's emulator semantics, including accepting valid `messageTtlSeconds` values for immediate delivery without modeling expiration.

## Summary

- add authenticated connection presence and direct-send REST operations
- deliver text, JSON, and binary data through raw, JSON, and reliable client paths
- validate API versions, request-scoped access-key tokens, content, metadata, and TTL ranges
- verify compatibility with Azure.Messaging.WebPubSub 1.6.0

## Validation

- 116 emulator tests passed in Release
- official .NET server SDK integration test passed
- valid message TTL values are accepted and delivered immediately
- adversarial runtime comparison found no merge blockers
- git diff --check passed

## Deliberate gaps

- message expiration is not modeled; valid TTL values are accepted and otherwise ignored
- preview API versions and other REST operations remain unsupported