### PR TITLE
deps: patch fast-uri and postcss-selector-parser advisories across all lockfiles

### DIFF
--- a/experimental/sdk/y-azure-webpubsub-client/package-lock.json
+++ b/experimental/sdk/y-azure-webpubsub-client/package-lock.json
@@ -1428,9 +1428,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://packagefeedproxy.microsoft.io/npm/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "dev": true,
       "funding": [
         {
@@ -4053,9 +4053,9 @@
       "dev": true
     },
     "fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://packagefeedproxy.microsoft.io/npm/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "dev": true
     },
     "fastest-levenshtein": {

--- a/experimental/sdk/y-azure-webpubsub/package-lock.json
+++ b/experimental/sdk/y-azure-webpubsub/package-lock.json
@@ -2310,9 +2310,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://packagefeedproxy.microsoft.io/npm/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "dev": true,
       "funding": [
         {
@@ -6416,9 +6416,9 @@
       "dev": true
     },
     "fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://packagefeedproxy.microsoft.io/npm/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "dev": true
     },
     "fb-watchman": {

--- a/samples/csharp/logstream/sdk/logstream/package-lock.json
+++ b/samples/csharp/logstream/sdk/logstream/package-lock.json
@@ -1088,9 +1088,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "dev": true,
       "funding": [
         {

--- a/samples/javascript/scoreboard/yarn.lock
+++ b/samples/javascript/scoreboard/yarn.lock
@@ -2621,9 +2621,9 @@ fast-levenshtein@^2.0.6:
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
 fast-uri@^3.0.1:
-  version "3.1.5"
-  resolved "https://packagefeedproxy.microsoft.io/npm/fast-uri/-/fast-uri-3.1.5.tgz"
-  integrity sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==
+  version "3.1.6"
+  resolved "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz"
+  integrity sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==
 
 fastest-levenshtein@^1.0.12:
   version "1.0.12"

--- a/sdk/webpubsub-chat-client/yarn.lock
+++ b/sdk/webpubsub-chat-client/yarn.lock
@@ -684,9 +684,9 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 fast-uri@^3.0.1:
-  version "3.1.5"
-  resolved "https://packagefeedproxy.microsoft.io/npm/fast-uri/-/fast-uri-3.1.5.tgz"
-  integrity sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==
+  version "3.1.6"
+  resolved "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz"
+  integrity sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==
 
 fs-extra@~11.3.0:
   version "11.3.6"

--- a/sdk/webpubsub-socketio-extension/yarn.lock
+++ b/sdk/webpubsub-socketio-extension/yarn.lock
@@ -2629,9 +2629,9 @@ fast-safe-stringify@^2.1.1:
   integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
 
 fast-uri@^3.0.1:
-  version "3.1.5"
-  resolved "https://packagefeedproxy.microsoft.io/npm/fast-uri/-/fast-uri-3.1.5.tgz"
-  integrity sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==
+  version "3.1.6"
+  resolved "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz"
+  integrity sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==
 
 fastq@^1.6.0:
   version "1.20.1"

--- a/tools/vscode-azurewebpubsub/package-lock.json
+++ b/tools/vscode-azurewebpubsub/package-lock.json
@@ -4950,9 +4950,9 @@
             "dev": true
         },
         "node_modules/fast-uri": {
-            "version": "3.1.5",
-            "resolved": "https://packagefeedproxy.microsoft.io/npm/fast-uri/-/fast-uri-3.1.5.tgz",
-            "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+            "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
             "dev": true,
             "funding": [
                 {

--- a/website/src/plugins/docusaurus-plugin-content-docs-extend/yarn.lock
+++ b/website/src/plugins/docusaurus-plugin-content-docs-extend/yarn.lock
@@ -3995,9 +3995,9 @@ fast-json-stable-stringify@^2.0.0:
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
 fast-uri@^3.0.1:
-  version "3.1.5"
-  resolved "https://packagefeedproxy.microsoft.io/npm/fast-uri/-/fast-uri-3.1.5.tgz"
-  integrity sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==
+  version "3.1.6"
+  resolved "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz"
+  integrity sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==
 
 fastq@^1.6.0:
   version "1.20.1"

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -4767,9 +4767,9 @@ fast-json-stable-stringify@^2.0.0:
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
 fast-uri@^3.0.1:
-  version "3.1.5"
-  resolved "https://packagefeedproxy.microsoft.io/npm/fast-uri/-/fast-uri-3.1.5.tgz"
-  integrity sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==
+  version "3.1.6"
+  resolved "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz"
+  integrity sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==
 
 fastq@^1.6.0:
   version "1.19.1"
@@ -7747,17 +7747,17 @@ postcss-selector-not@^8.0.1:
     postcss-selector-parser "^7.0.0"
 
 postcss-selector-parser@^6.0.11, postcss-selector-parser@^6.0.16, postcss-selector-parser@^6.1.1, postcss-selector-parser@^6.1.2:
-  version "6.1.2"
-  resolved "https://packagefeedproxy.microsoft.io/npm/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz"
-  integrity sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==
+  version "6.1.3"
+  resolved "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.3.tgz"
+  integrity sha512-cDoO18VWCIWRsSaws3C23b0HXRxlUknttfdNcbXnf3IGHAPRNLlXPHc6dYiatOkxW0W4uZh524Plaaw5a7WEtQ==
   dependencies:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
 
 postcss-selector-parser@^7.0.0:
-  version "7.1.0"
-  resolved "https://packagefeedproxy.microsoft.io/npm/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz"
-  integrity sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==
+  version "7.1.3"
+  resolved "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.3.tgz"
+  integrity sha512-ajnd7iZnqjJDkyHNfznl/ZVO0lWqvBmQXfKKENx9/p/bEiF/L3eHwdydNUg9RXZx6xfZWOCmXmBa5oeB+YrAPQ==
   dependencies:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5668,9 +5668,9 @@ fast-levenshtein@^2.0.6:
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
 fast-uri@^3.0.1:
-  version "3.1.5"
-  resolved "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-uri/-/fast-uri-3.1.5.tgz#610f37419a030270430cecd68d74e3d4d96725d0"
-  integrity sha1-YQ83QZoDAnBDDOzWjXTj1NlnJdA=
+  version "3.1.6"
+  resolved "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz"
+  integrity sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==
 
 fastq@^1.6.0:
   version "1.17.1"


### PR DESCRIPTION
Dependabot opened **54 alerts** on 2026-09-03, all from three transitive packages. This sweeps the two the approved package feed can currently serve, across every affected lockfile in one pass instead of waiting for one Dependabot PR per manifest.

## What changed

| Package | Severity | Alerts | Bump | Lockfiles |
|---|---|---|---|---|
| `fast-uri` | high | 40 | 3.1.5 → **3.1.6** | 10 |
| `postcss-selector-parser` | low | 2 | 6.1.2 → **6.1.3**, 7.1.0 → **7.1.3** | 1 |

Advisories: GHSA-f65p-4m7j-42xc, GHSA-fph4-wmhf-6fwf, GHSA-jqff-g426-hqxp, GHSA-5jgf-p345-68v8 (fast-uri); GHSA-w9m9-85wc-3x92 (postcss-selector-parser).

Both are the first patched releases on their respective lines. Every lockfile pins `fast-uri@^3.0.1`, so 3.1.6 satisfies all of them; `fast-uri` has no dependencies and `postcss-selector-parser` declares the same two (`cssesc`, `util-deprecate`) before and after, so no resolution graph changes. Diff is exactly 42 insertions / 42 deletions.

## Not included: `qs`

`qs` 6.15.3 → 6.16.0 (medium, 12 alerts, 6 lockfiles) is **deliberately left out**. The approved package feed does not yet mirror `qs@6.16.0` — it currently tops out at 6.15.3 — so the fix cannot be resolved or verified. This needs a follow-up once the feed syncs.

For the same reason this targets `fast-uri` **3.1.6** rather than the 3.1.7 that #1085 / #1086 propose: 3.1.7 is not in the approved feed either. 3.1.6 is the advisory's first patched version, so it closes the alerts.

## `resolved` URL normalization

The touched entries had `resolved` URLs pointing at internal feed hostnames (`packagefeedproxy.microsoft.io`, `ms-feed-*.pkgs.visualstudio.com`) that had leaked into these lockfiles. They are normalized to `registry.npmjs.org`, matching the dominant convention already in the repo.

Integrity hashes were computed from the actual tarballs rather than copied from anywhere. Mirror payloads are byte-identical — confirmed by recomputing an existing lockfile's hash (`fastq@1.17.1`, whose entry resolves to registry.npmjs.org) from a different mirror and getting an exact match.

## Verification

Everything below was actually run, not assumed:

- `yarn install --frozen-lockfile` on the patched `sdk/webpubsub-chat-client` lockfile → installs `fast-uri@3.1.6`, integrity check passes
- `npm ci` on the patched `experimental/sdk/y-azure-webpubsub` lockfile → 361 packages, `fast-uri@3.1.6`, `found 0 vulnerabilities`
- `yarn install --frozen-lockfile` + **`yarn build`** on `website/` → docusaurus build succeeds in 172s; all 9 nested `postcss-selector-parser` copies resolve to 6.1.3 / 7.1.3. This matters because PR CI does **not** cover `website/` — only `deploy-demo-website.yml` touches it, so a broken bump there would surface at deploy time.
- Repo-wide rescan of all 22 lockfiles → zero remaining vulnerable `fast-uri` or `postcss-selector-parser` versions.

## Supersedes

- #1086 (root `yarn.lock`, fast-uri → 3.1.7)
- #1085 (`sdk/webpubsub-chat-client`, fast-uri → 3.1.7)

Both cover 2 of the 10 affected lockfiles and target a version the approved feed does not carry.
