### PR TITLE
Emulator: support closing a connection through REST and server SDK

### DIFF
--- a/tools/emulator/CHANGELOG.md
+++ b/tools/emulator/CHANGELOG.md
@@ -13,3 +13,4 @@
 - Add opt-in unvalidated Entra token compatibility for trusted local server SDK testing.
 - Add reliable JSON connections with scoped recovery tokens, sequence acknowledgements, and bounded message replay.
 - Add authenticated REST operations and official .NET server SDK compatibility for checking connection presence and sending directly to a connection.
+- Add authenticated REST and official .NET server SDK support for closing a connection.

--- a/tools/emulator/README.md
+++ b/tools/emulator/README.md
@@ -61,9 +61,9 @@ emulator process. The replay buffer is limited to 1,000 messages and 16 MiB per 
 
 ## Use a server SDK
 
-The emulator supports checking whether a connection exists and sending text, JSON, or binary data
-to a connection through the Azure Web PubSub REST API. For example, use the generated connection
-string with the Azure Web PubSub .NET server SDK:
+The emulator supports checking whether a connection exists, sending text, JSON, or binary data,
+and closing a connection through the Azure Web PubSub REST API. For example, use the generated
+connection string with the Azure Web PubSub .NET server SDK:
 
 ```csharp
 using Azure.Messaging.WebPubSub;
@@ -77,6 +77,7 @@ await serviceClient.SendToConnectionAsync(
   connectionId,
   BinaryData.FromString("Hello"),
   ContentType.TextPlain);
+await serviceClient.CloseConnectionAsync(connectionId, "Done");
 ```
 
 Direct sends return success when the connection does not exist, matching the service's
@@ -100,10 +101,23 @@ dotnet run --project tools\emulator\src\Microsoft.Azure.WebPubSub.Emulator
 ```
 
 `WebPubSub:AllowUnvalidatedEntraTokens` is disabled by default. Enable it only for trusted local
-server SDK `TokenCredential` testing. This compatibility mode checks the Azure Web PubSub audience
-and token lifetime, but does not validate the signature, algorithm, issuer, tenant, identity, or
-Azure RBAC assignments. It does not change client WebSocket token validation. Server SDKs require
-an HTTPS endpoint when sending bearer tokens.
+server SDK `TokenCredential` testing. With an HTTPS emulator endpoint, the SDK can use
+`DefaultAzureCredential`:
+
+```csharp
+using Azure.Identity;
+using Azure.Messaging.WebPubSub;
+
+var serviceClient = new WebPubSubServiceClient(
+  new Uri("https://localhost:8080"),
+  "chat",
+  new DefaultAzureCredential());
+```
+
+`DefaultAzureCredential` obtains a real token, but this emulator mode does **not** validate Azure
+RBAC. It checks only the Azure Web PubSub audience and token lifetime; it does not validate the
+signature, algorithm, issuer, tenant, identity, or role assignments. It does not change client
+WebSocket token validation. Server SDKs require an HTTPS endpoint when sending bearer tokens.
 
 When multiple listener addresses are configured, the first address in ordinal order is the
 effective endpoint.

--- a/tools/emulator/SUPPORTED_FEATURES.md
+++ b/tools/emulator/SUPPORTED_FEATURES.md
@@ -17,9 +17,9 @@ local Azure Web PubSub development.
 | Connection state | Tracks active connections and temporarily retains reliable logical connections after unexpected disconnects. | ✅ |
 | Groups and roles | Supports connection-scoped token groups and authorized join, leave, and group send, including wildcard roles. | ✅ |
 | Outbound delivery | Uses a bounded, single-writer queue for each WebSocket connection. | ✅ |
-| REST connection operations | Authenticated connection presence and direct text, JSON, and binary sends for GA API versions from `2021-10-01` through `2024-12-01`. | ✅ |
+| REST connection operations | Authenticated connection presence, direct text, JSON, and binary sends, and close for GA API versions from `2021-10-01` through `2024-12-01`. | ✅ |
 | REST direct-send TTL | Accepts valid `messageTtlSeconds` values; delivery is immediate and expiration is not modeled. | ⚠️ |
-| Other REST APIs | Group, user, permission, close-connection, and broadcast operations. | ❌ |
+| Other REST APIs | Group, user, permission, and broadcast operations. | ❌ |
 
 ## Not yet implemented
 

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientPayloadProcessor.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientPayloadProcessor.cs
@@ -26,6 +26,11 @@ internal interface IClientPayloadProcessor
         LogicalConnection connection,
         MessageData data,
         ulong? sequenceId);
+
+    WebSocketPayload? EncodeDisconnected(string message)
+    {
+        return null;
+    }
 }
 
 internal readonly record struct WebSocketPayload(

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ConnectionManager.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ConnectionManager.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
+using System.Net.WebSockets;
 using System.Security.Claims;
 using Microsoft.Extensions.Logging;
 
@@ -67,6 +68,23 @@ internal sealed class ConnectionManager
         if (_connections.TryGetValue((hub, connectionId), out var connection))
         {
             connection.SendServerData(data);
+        }
+    }
+
+    public void CloseConnection(
+        string hub,
+        string connectionId,
+        string? reason)
+    {
+        if (!_connections.TryGetValue((hub, connectionId), out var connection))
+        {
+            return;
+        }
+
+        var transport = connection.CloseByAppServer(reason);
+        if (transport is not null)
+        {
+            _ = transport.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty);
         }
     }
 

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/LogicalConnection.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/LogicalConnection.cs
@@ -498,6 +498,26 @@ internal sealed class LogicalConnection
         WebSocketCloseStatus closeStatus,
         string closeDescription)
     {
+        return Close(closeStatus, closeDescription, finalPayloadFactory: null);
+    }
+
+    public SocketTransport? CloseByAppServer(string? reason)
+    {
+        const string closedMessage = "Application server closed the connection.";
+        var message = string.IsNullOrEmpty(reason)
+            ? closedMessage
+            : $"{closedMessage} Reason: {reason}";
+        return Close(
+            WebSocketCloseStatus.NormalClosure,
+            string.Empty,
+            processor => processor.EncodeDisconnected(message));
+    }
+
+    private SocketTransport? Close(
+        WebSocketCloseStatus closeStatus,
+        string closeDescription,
+        Func<IClientPayloadProcessor, WebSocketPayload?>? finalPayloadFactory)
+    {
         SocketTransport? transport;
         lock (_stateLock)
         {
@@ -507,7 +527,10 @@ internal sealed class LogicalConnection
             }
 
             transport = _activeTransport ?? _detachedTransport;
-            transport?.TryCloseOutput(closeStatus, closeDescription);
+            var finalPayload = _activePayloadProcessor is not null
+                ? finalPayloadFactory?.Invoke(_activePayloadProcessor)
+                : null;
+            transport?.TryCloseOutput(closeStatus, closeDescription, finalPayload);
             _closed = true;
             _activeTransport = null;
             _detachedTransport = null;

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/SimpleWebSocketPayloadProcessor.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/SimpleWebSocketPayloadProcessor.cs
@@ -66,4 +66,9 @@ internal sealed class SimpleWebSocketPayloadProcessor : IClientPayloadProcessor
             : WebSocketMessageType.Text;
         return new WebSocketPayload(data.Bytes, messageType);
     }
+
+    public WebSocketPayload? EncodeDisconnected(string message)
+    {
+        return null;
+    }
 }

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/SocketTransport.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/SocketTransport.cs
@@ -139,9 +139,17 @@ internal sealed class SocketTransport : IDisposable
 
     public bool TryCloseOutput(WebSocketCloseStatus status, string description)
     {
+        return TryCloseOutput(status, description, finalPayload: null);
+    }
+
+    public bool TryCloseOutput(
+        WebSocketCloseStatus status,
+        string description,
+        WebSocketPayload? finalPayload)
+    {
         return QueueClose(new OutboundMessage(
-            default,
-            WebSocketMessageType.Close,
+            finalPayload?.Bytes ?? default,
+            finalPayload?.MessageType ?? WebSocketMessageType.Close,
             status,
             description));
     }

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubEmulatorController.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubEmulatorController.cs
@@ -61,6 +61,32 @@ internal sealed class WebPubSubEmulatorController : WebPubSubApiControllerDefini
         return Task.FromResult(result);
     }
 
+    [HttpDelete(
+        "/api/hubs/{hub}/connections/{connectionId}",
+        Name = "WebPubSub_CloseConnection")]
+    public IActionResult CloseConnection(
+        [RegularExpression(
+            WebPubSubNameValidator.HubNamePattern,
+            ErrorMessage = "Invalid hub name.")]
+        string hub,
+        [MinLength(1, ErrorMessage = "Invalid connection ID.")]
+        string connectionId,
+        [FromQuery(Name = "reason")]
+        string? reason,
+        CancellationToken cancellationToken = default)
+    {
+        if (!Authorize())
+        {
+            return Unauthorized();
+        }
+
+        _connections.CloseConnection(
+            hub.ToLowerInvariant(),
+            connectionId,
+            reason);
+        return NoContent();
+    }
+
     [HttpPost(
         "/api/hubs/{hub}/connections/{connectionId}/:send",
         Name = "WebPubSub_SendToConnection")]

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubJsonV1PayloadProcessor.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubJsonV1PayloadProcessor.cs
@@ -150,6 +150,11 @@ internal sealed class WebPubSubJsonV1PayloadProcessor : IClientPayloadProcessor
         return _protocol.WriteServerData(data, sequenceId);
     }
 
+    public WebSocketPayload? EncodeDisconnected(string message)
+    {
+        return _protocol.WriteDisconnected(message);
+    }
+
     public static bool IsSupportedSubprotocol(string? subprotocol)
     {
         return string.Equals(subprotocol, SubprotocolName, StringComparison.OrdinalIgnoreCase) ||

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubJsonV1Protocol.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubJsonV1Protocol.cs
@@ -142,6 +142,18 @@ internal sealed partial class WebPubSubJsonV1Protocol
         });
     }
 
+    public WebSocketPayload WriteDisconnected(string message)
+    {
+        return WriteJson(writer =>
+        {
+            writer.WriteStartObject();
+            writer.WriteString("type", "system");
+            writer.WriteString("event", "disconnected");
+            writer.WriteString("message", message);
+            writer.WriteEndObject();
+        });
+    }
+
     public WebSocketPayload WritePong()
     {
         return WriteJson(writer =>

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/RestApiTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/RestApiTests.cs
@@ -81,10 +81,23 @@ public class RestApiTests
             BinaryData.FromString("ignored"),
             ContentType.TextPlain).WaitAsync(TestTimeout);
 
-        await webSocket.CloseAsync(
-            WebSocketCloseStatus.NormalClosure,
-            "done",
-            CancellationToken.None).WaitAsync(TestTimeout);
+        await serviceClient.CloseConnectionAsync(connectionId, "server-close")
+            .WaitAsync(TestTimeout);
+        using var disconnected = await ReceiveJsonAsync(webSocket);
+        var close = await webSocket.ReceiveAsync(new byte[256], CancellationToken.None)
+            .WaitAsync(TestTimeout);
+
+        Assert.Equal("system", disconnected.RootElement.GetProperty("type").GetString());
+        Assert.Equal("disconnected", disconnected.RootElement.GetProperty("event").GetString());
+        Assert.Equal(
+            "Application server closed the connection. Reason: server-close",
+            disconnected.RootElement.GetProperty("message").GetString());
+        Assert.Equal(WebSocketMessageType.Close, close.MessageType);
+        Assert.Equal(WebSocketCloseStatus.NormalClosure, close.CloseStatus);
+        Assert.Equal(string.Empty, close.CloseStatusDescription);
+        Assert.False((await serviceClient.ConnectionExistsAsync(connectionId)
+            .WaitAsync(TestTimeout)).Value);
+        await serviceClient.CloseConnectionAsync("missing").WaitAsync(TestTimeout);
     }
 
     [Fact]
@@ -199,6 +212,124 @@ public class RestApiTests
 
         Assert.Equal(HttpStatusCode.NotFound, existsResponse.StatusCode);
         Assert.Equal(HttpStatusCode.Accepted, sendResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task CloseConnectionSendsDisconnectedMessageWithReason()
+    {
+        await using var application = await StartApplicationAsync();
+        using var webSocket = await ConnectAsync(application);
+        using var connected = await ReceiveJsonAsync(webSocket);
+        var connectionId = connected.RootElement.GetProperty("connectionId").GetString()!;
+        var reason = new string('x', 200);
+        var path = $"/api/hubs/{Hub}/connections/{connectionId}" +
+            $"?reason={reason}&api-version=2024-12-01";
+        using var request = CreateAuthorizedRequest(HttpMethod.Delete, path);
+
+        using var response = await application.GetTestClient()
+            .SendAsync(request)
+            .WaitAsync(TestTimeout);
+        using var disconnected = await ReceiveJsonAsync(webSocket);
+        var close = await webSocket.ReceiveAsync(new byte[256], CancellationToken.None)
+            .WaitAsync(TestTimeout);
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        Assert.Equal("system", disconnected.RootElement.GetProperty("type").GetString());
+        Assert.Equal("disconnected", disconnected.RootElement.GetProperty("event").GetString());
+        Assert.Equal(
+            $"Application server closed the connection. Reason: {reason}",
+            disconnected.RootElement.GetProperty("message").GetString());
+        Assert.Equal(WebSocketMessageType.Close, close.MessageType);
+        Assert.Equal(WebSocketCloseStatus.NormalClosure, close.CloseStatus);
+        Assert.Equal(string.Empty, close.CloseStatusDescription);
+    }
+
+    [Fact]
+    public async Task CloseMissingConnectionReturnsNoContent()
+    {
+        await using var application = await StartApplicationAsync();
+        const string path =
+            "/api/hubs/chat/connections/missing?api-version=2024-12-01";
+        using var request = CreateAuthorizedRequest(HttpMethod.Delete, path);
+
+        using var response = await application.GetTestClient()
+            .SendAsync(request)
+            .WaitAsync(TestTimeout);
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CloseDetachedReliableConnectionPreventsRecovery()
+    {
+        await using var application = await StartApplicationAsync();
+        var initial = await ConnectReliableAsync(application);
+        using var initialSocket = initial.WebSocket;
+        initialSocket.Abort();
+        var path = $"/api/hubs/{Hub}/connections/{initial.ConnectionId}" +
+            "?api-version=2024-12-01";
+        using var request = CreateAuthorizedRequest(HttpMethod.Delete, path);
+
+        using var response = await application.GetTestClient()
+            .SendAsync(request)
+            .WaitAsync(TestTimeout);
+        using var recovered = await ConnectRecoveryAsync(
+            application,
+            initial.ConnectionId,
+            initial.ReconnectionToken);
+        var close = await recovered.ReceiveAsync(new byte[256], CancellationToken.None)
+            .WaitAsync(TestTimeout);
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        Assert.Equal(WebSocketMessageType.Close, close.MessageType);
+        Assert.Equal(WebSocketCloseStatus.PolicyViolation, close.CloseStatus);
+    }
+
+    [Fact]
+    public async Task CloseConnectionRequiresAuthorization()
+    {
+        await using var application = await StartApplicationAsync();
+        using var webSocket = await ConnectAsync(application);
+        using var connected = await ReceiveJsonAsync(webSocket);
+        var connectionId = connected.RootElement.GetProperty("connectionId").GetString()!;
+        var path = $"/api/hubs/{Hub}/connections/{connectionId}" +
+            "?api-version=2024-12-01";
+
+        using var response = await application.GetTestClient()
+            .DeleteAsync(path)
+            .WaitAsync(TestTimeout);
+        using var existsRequest = CreateAuthorizedRequest(HttpMethod.Head, path);
+        using var existsResponse = await application.GetTestClient()
+            .SendAsync(existsRequest)
+            .WaitAsync(TestTimeout);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, existsResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task InvalidApiVersionDoesNotCloseConnection()
+    {
+        await using var application = await StartApplicationAsync();
+        using var webSocket = await ConnectAsync(application);
+        using var connected = await ReceiveJsonAsync(webSocket);
+        var connectionId = connected.RootElement.GetProperty("connectionId").GetString()!;
+        var invalidPath = $"/api/hubs/{Hub}/connections/{connectionId}" +
+            "?api-version=unsupported";
+        using var invalidRequest = CreateAuthorizedRequest(HttpMethod.Delete, invalidPath);
+
+        using var invalidResponse = await application.GetTestClient()
+            .SendAsync(invalidRequest)
+            .WaitAsync(TestTimeout);
+        var validPath = $"/api/hubs/{Hub}/connections/{connectionId}" +
+            "?api-version=2024-12-01";
+        using var existsRequest = CreateAuthorizedRequest(HttpMethod.Head, validPath);
+        using var existsResponse = await application.GetTestClient()
+            .SendAsync(existsRequest)
+            .WaitAsync(TestTimeout);
+
+        Assert.Equal(HttpStatusCode.BadRequest, invalidResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, existsResponse.StatusCode);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add authenticated `DELETE /api/hubs/{hub}/connections/{connectionId}` with service-compatible `204` behavior
- send JSON protocol clients the runtime-compatible `system/disconnected` message before normal closure and prevent reliable recovery
- cover official `Azure.Messaging.WebPubSub` `CloseConnectionAsync` plus active, missing, unauthorized, invalid-version, and detached reliable cases
- add a `DefaultAzureCredential` sample while explicitly noting that emulator compatibility mode does not validate Azure RBAC

## Validation
- `dotnet test tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/Microsoft.Azure.WebPubSub.Emulator.Tests.csproj --configuration Release --no-restore` (121 passed)
- `git diff --check`

Part of #1048.