### PR TITLE
Emulator: support single-connection group membership REST APIs

### DIFF
--- a/tools/emulator/CHANGELOG.md
+++ b/tools/emulator/CHANGELOG.md
@@ -14,3 +14,4 @@
 - Add reliable JSON connections with scoped recovery tokens, sequence acknowledgements, and bounded message replay.
 - Add authenticated REST operations and official .NET server SDK compatibility for checking connection presence and sending directly to a connection.
 - Add authenticated REST and official .NET server SDK support for closing a connection.
+- Add authenticated REST and official .NET server SDK support for adding and removing a connection from a group.

--- a/tools/emulator/README.md
+++ b/tools/emulator/README.md
@@ -77,6 +77,8 @@ await serviceClient.SendToConnectionAsync(
   connectionId,
   BinaryData.FromString("Hello"),
   ContentType.TextPlain);
+await serviceClient.AddConnectionToGroupAsync("room", connectionId);
+await serviceClient.RemoveConnectionFromGroupAsync("room", connectionId);
 await serviceClient.CloseConnectionAsync(connectionId, "Done");
 ```
 

--- a/tools/emulator/SUPPORTED_FEATURES.md
+++ b/tools/emulator/SUPPORTED_FEATURES.md
@@ -17,9 +17,9 @@ local Azure Web PubSub development.
 | Connection state | Tracks active connections and temporarily retains reliable logical connections after unexpected disconnects. | ✅ |
 | Groups and roles | Supports connection-scoped token groups and authorized join, leave, and group send, including wildcard roles. | ✅ |
 | Outbound delivery | Uses a bounded, single-writer queue for each WebSocket connection. | ✅ |
-| REST connection operations | Authenticated connection presence, direct text, JSON, and binary sends, and close for GA API versions from `2021-10-01` through `2024-12-01`. | ✅ |
+| REST connection operations | Authenticated connection presence, direct text, JSON, and binary sends, close, and single-connection group membership changes for GA API versions from `2021-10-01` through `2024-12-01`. | ✅ |
 | REST direct-send TTL | Accepts valid `messageTtlSeconds` values; delivery is immediate and expiration is not modeled. | ⚠️ |
-| Other REST APIs | Group, user, permission, and broadcast operations. | ❌ |
+| Other REST APIs | Group fan-out, user, permission, and broadcast operations. | ❌ |
 
 ## Not yet implemented
 

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ConnectionManager.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ConnectionManager.cs
@@ -71,6 +71,20 @@ internal sealed class ConnectionManager
         }
     }
 
+    public bool AddConnectionToGroup(string hub, string group, string connectionId)
+    {
+        return _connections.TryGetValue((hub, connectionId), out var connection) &&
+            connection.TryAddToGroup(group);
+    }
+
+    public void RemoveConnectionFromGroup(string hub, string group, string connectionId)
+    {
+        if (_connections.TryGetValue((hub, connectionId), out var connection))
+        {
+            connection.RemoveFromGroup(group);
+        }
+    }
+
     public void CloseConnection(
         string hub,
         string connectionId,

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/LogicalConnection.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/LogicalConnection.cs
@@ -241,6 +241,31 @@ internal sealed class LogicalConnection
         return _joinLeaveGroupPermissions.Check(group);
     }
 
+    public bool TryAddToGroup(string group)
+    {
+        lock (_stateLock)
+        {
+            if (_closed)
+            {
+                return false;
+            }
+
+            Groups.TryAdd(group, 0);
+            return true;
+        }
+    }
+
+    public void RemoveFromGroup(string group)
+    {
+        lock (_stateLock)
+        {
+            if (!_closed)
+            {
+                Groups.TryRemove(group, out _);
+            }
+        }
+    }
+
     public void SendGroupData(
         string group,
         string? fromUserId,

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubEmulatorController.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubEmulatorController.cs
@@ -145,6 +145,81 @@ internal sealed class WebPubSubEmulatorController : WebPubSubApiControllerDefini
         return Accepted();
     }
 
+    [HttpPut(
+        "/api/hubs/{hub}/groups/{group}/connections/{connectionId}",
+        Name = "WebPubSub_AddConnectionToGroup")]
+    public IActionResult AddConnectionToGroup(
+        [RegularExpression(
+            WebPubSubNameValidator.HubNamePattern,
+            ErrorMessage = "Invalid hub name.")]
+        string hub,
+        [StringLength(
+            WebPubSubNameValidator.MaximumGroupNameLength,
+            MinimumLength = 1,
+            ErrorMessage = "Invalid group name.")]
+        [RegularExpression(
+            WebPubSubNameValidator.NotWhitespacePattern,
+            ErrorMessage = "Invalid group name.")]
+        string group,
+        [MinLength(1, ErrorMessage = "Invalid connection ID.")]
+        string connectionId,
+        CancellationToken cancellationToken = default)
+    {
+        if (!Authorize())
+        {
+            return Unauthorized();
+        }
+
+        if (_connections.AddConnectionToGroup(
+            hub.ToLowerInvariant(),
+            group,
+            connectionId))
+        {
+            return Ok();
+        }
+
+        const string errorCode = "Error.Connection.NotExisted";
+        Response.Headers["x-ms-error-code"] = errorCode;
+        return NotFound(new
+        {
+            code = errorCode,
+            message = $"Connection `{connectionId}` is not found.",
+            target = "Connection",
+        });
+    }
+
+    [HttpDelete(
+        "/api/hubs/{hub}/groups/{group}/connections/{connectionId}",
+        Name = "WebPubSub_RemoveConnectionFromGroup")]
+    public IActionResult RemoveConnectionFromGroup(
+        [RegularExpression(
+            WebPubSubNameValidator.HubNamePattern,
+            ErrorMessage = "Invalid hub name.")]
+        string hub,
+        [StringLength(
+            WebPubSubNameValidator.MaximumGroupNameLength,
+            MinimumLength = 1,
+            ErrorMessage = "Invalid group name.")]
+        [RegularExpression(
+            WebPubSubNameValidator.NotWhitespacePattern,
+            ErrorMessage = "Invalid group name.")]
+        string group,
+        [MinLength(1, ErrorMessage = "Invalid connection ID.")]
+        string connectionId,
+        CancellationToken cancellationToken = default)
+    {
+        if (!Authorize())
+        {
+            return Unauthorized();
+        }
+
+        _connections.RemoveConnectionFromGroup(
+            hub.ToLowerInvariant(),
+            group,
+            connectionId);
+        return NoContent();
+    }
+
     private bool Authorize()
     {
         var authorization = Request.Headers.Authorization.ToString();

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubNameValidator.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubNameValidator.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.WebPubSub.Emulator;
 internal static partial class WebPubSubNameValidator
 {
     public const string HubNamePattern = "^[A-Za-z][A-Za-z0-9_`,.\\[\\]]{0,127}$";
+    public const string NotWhitespacePattern = "^(?!\\s+$).+$";
     public const int MaximumGroupNameLength = 1024;
 
     public static bool IsValidGroupName(string? group)

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/RestApiTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/RestApiTests.cs
@@ -101,6 +101,113 @@ public class RestApiTests
     }
 
     [Fact]
+    public async Task OfficialServerSdkCanManageConnectionGroupMembership()
+    {
+        await using var application = EmulatorApplication.Build(
+            ["--urls=http://127.0.0.1:0"]);
+        await application.StartAsync().WaitAsync(TestTimeout);
+        var server = application.Services.GetRequiredService<IServer>();
+        var endpoint = Assert.Single(
+            server.Features.Get<IServerAddressesFeature>()!.Addresses);
+        var connectionString =
+            $"Endpoint={endpoint};AccessKey={EmulatorOptions.DefaultAccessKey};Version=1.0;";
+        var serviceClient = new WebPubSubServiceClient(connectionString, Hub);
+        using var webSocket = new ClientWebSocket();
+        webSocket.Options.AddSubProtocol(WebPubSubJsonV1PayloadProcessor.SubprotocolName);
+        await webSocket.ConnectAsync(
+            serviceClient.GetClientAccessUri(),
+            CancellationToken.None).WaitAsync(TestTimeout);
+        using var connected = await ReceiveJsonAsync(webSocket);
+        var connectionId = connected.RootElement.GetProperty("connectionId").GetString()!;
+        var manager = application.Services.GetRequiredService<ConnectionManager>();
+        Assert.True(manager.TryGet(Hub, connectionId, out var connection));
+
+        var addResponse = await serviceClient.AddConnectionToGroupAsync(
+            "room",
+            connection.ConnectionId).WaitAsync(TestTimeout);
+
+        Assert.Equal((int)HttpStatusCode.OK, addResponse.Status);
+        Assert.True(connection.Groups.ContainsKey("room"));
+
+        var removeResponse = await serviceClient.RemoveConnectionFromGroupAsync(
+            "room",
+            connection.ConnectionId).WaitAsync(TestTimeout);
+
+        Assert.Equal((int)HttpStatusCode.NoContent, removeResponse.Status);
+        Assert.False(connection.Groups.ContainsKey("room"));
+
+        var exception = await Assert.ThrowsAsync<RequestFailedException>(() =>
+            serviceClient.AddConnectionToGroupAsync("room", "missing"));
+        Assert.Equal((int)HttpStatusCode.NotFound, exception.Status);
+        Assert.Equal("Error.Connection.NotExisted", exception.ErrorCode);
+        var rawResponse = Assert.IsAssignableFrom<Response>(exception.GetRawResponse());
+        Assert.True(rawResponse.Headers.TryGetValue("x-ms-error-code", out var errorCode));
+        Assert.Equal(
+            "Error.Connection.NotExisted",
+            errorCode);
+        using var error = JsonDocument.Parse(rawResponse.Content);
+        Assert.Equal(
+            "Connection `missing` is not found.",
+            error.RootElement.GetProperty("message").GetString());
+        Assert.Equal("Connection", error.RootElement.GetProperty("target").GetString());
+        var missingRemoveResponse = await serviceClient.RemoveConnectionFromGroupAsync(
+            "room",
+            "missing").WaitAsync(TestTimeout);
+        Assert.Equal((int)HttpStatusCode.NoContent, missingRemoveResponse.Status);
+    }
+
+    [Fact]
+    public async Task DetachedReliableMembershipChangesAffectGroupDeliveryAfterRecovery()
+    {
+        await using var application = await StartApplicationAsync();
+        var initial = await ConnectReliableAsync(application);
+        using var initialSocket = initial.WebSocket;
+        initialSocket.Abort();
+        var manager = application.Services.GetRequiredService<ConnectionManager>();
+        Assert.True(manager.TryGet(Hub, initial.ConnectionId, out var connection));
+        var upperGroupPath = $"/api/hubs/CHAT/groups/Room/connections/{initial.ConnectionId}" +
+            "?api-version=2024-12-01";
+        using var addRequest = CreateAuthorizedRequest(HttpMethod.Put, upperGroupPath);
+
+        using var addResponse = await application.GetTestClient()
+            .SendAsync(addRequest)
+            .WaitAsync(TestTimeout);
+        manager.SendToGroup(
+            Hub,
+            "room",
+            new MessageData(MessageDataType.Text, "wrong-case"u8.ToArray()),
+            sender: null,
+            noEcho: false);
+        manager.SendToGroup(
+            Hub,
+            "Room",
+            new MessageData(MessageDataType.Text, "delivered"u8.ToArray()),
+            sender: null,
+            noEcho: false);
+        using var recovered = await ConnectRecoveryAsync(
+            application,
+            initial.ConnectionId,
+            initial.ReconnectionToken);
+        using var delivered = await ReceiveJsonAsync(recovered);
+
+        Assert.Equal(HttpStatusCode.OK, addResponse.StatusCode);
+        Assert.True(connection.Groups.ContainsKey("Room"));
+        Assert.False(connection.Groups.ContainsKey("room"));
+        Assert.Equal("Room", delivered.RootElement.GetProperty("group").GetString());
+        Assert.Equal("delivered", delivered.RootElement.GetProperty("data").GetString());
+
+        var removePath = $"/api/hubs/chat/groups/Room/connections/{initial.ConnectionId}" +
+            "?api-version=2024-12-01";
+        using var removeRequest = CreateAuthorizedRequest(HttpMethod.Delete, removePath);
+        using var removeResponse = await application.GetTestClient()
+            .SendAsync(removeRequest)
+            .WaitAsync(TestTimeout);
+
+        Assert.Equal(HttpStatusCode.NoContent, removeResponse.StatusCode);
+        Assert.False(connection.Groups.ContainsKey("Room"));
+    }
+
+    [Fact]
     public async Task ConnectionExistsAndSendToConnectionUseLiveConnection()
     {
         await using var application = await StartApplicationAsync();
@@ -330,6 +437,72 @@ public class RestApiTests
 
         Assert.Equal(HttpStatusCode.BadRequest, invalidResponse.StatusCode);
         Assert.Equal(HttpStatusCode.OK, existsResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task RejectedGroupMembershipRequestsDoNotMutateConnection()
+    {
+        await using var application = await StartApplicationAsync();
+        using var webSocket = await ConnectAsync(application);
+        using var connected = await ReceiveJsonAsync(webSocket);
+        var connectionId = connected.RootElement.GetProperty("connectionId").GetString()!;
+        var manager = application.Services.GetRequiredService<ConnectionManager>();
+        Assert.True(manager.TryGet(Hub, connectionId, out var connection));
+        var validPath = $"/api/hubs/{Hub}/groups/room/connections/{connectionId}" +
+            "?api-version=2024-12-01";
+
+        using var unauthorizedResponse = await application.GetTestClient()
+            .PutAsync(validPath, content: null)
+            .WaitAsync(TestTimeout);
+        var invalidVersionPath = $"/api/hubs/{Hub}/groups/room/connections/{connectionId}" +
+            "?api-version=unsupported";
+        using var invalidVersionRequest = CreateAuthorizedRequest(
+            HttpMethod.Put,
+            invalidVersionPath);
+        using var invalidVersionResponse = await application.GetTestClient()
+            .SendAsync(invalidVersionRequest)
+            .WaitAsync(TestTimeout);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, unauthorizedResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.BadRequest, invalidVersionResponse.StatusCode);
+        Assert.False(connection.Groups.ContainsKey("room"));
+    }
+
+    [Theory]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    public async Task GroupMembershipRejectsWhitespaceGroupName(string group)
+    {
+        await using var application = await StartApplicationAsync();
+        var path = $"/api/hubs/{Hub}/groups/{Uri.EscapeDataString(group)}" +
+            "/connections/missing?api-version=2024-12-01";
+        using var request = CreateAuthorizedRequest(HttpMethod.Put, path);
+
+        using var response = await application.GetTestClient()
+            .SendAsync(request)
+            .WaitAsync(TestTimeout);
+        using var error = JsonDocument.Parse(
+            await response.Content.ReadAsByteArrayAsync().WaitAsync(TestTimeout));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("Error.BadRequest", error.RootElement.GetProperty("code").GetString());
+        Assert.False(string.IsNullOrEmpty(error.RootElement.GetProperty("message").GetString()));
+    }
+
+    [Fact]
+    public async Task GroupMembershipRejectsGroupNameOverMaximumLength()
+    {
+        await using var application = await StartApplicationAsync();
+        var group = new string('g', WebPubSubNameValidator.MaximumGroupNameLength + 1);
+        var path = $"/api/hubs/{Hub}/groups/{group}" +
+            "/connections/missing?api-version=2024-12-01";
+        using var request = CreateAuthorizedRequest(HttpMethod.Delete, path);
+
+        using var response = await application.GetTestClient()
+            .SendAsync(request)
+            .WaitAsync(TestTimeout);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add authenticated `AddConnectionToGroupAsync` and `RemoveConnectionFromGroupAsync` compatibility
- match service status and error contracts, including structured missing-connection errors for add and idempotent remove
- preserve reliable connection membership across detachment and recovery with case-sensitive group names
- document the new server SDK operations and remaining REST gaps

## Validation
- `dotnet test tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/Microsoft.Azure.WebPubSub.Emulator.Tests.csproj --configuration Release --no-restore` (127 passed)
- `git diff --check`

Part of #1048.