### PR TITLE
ci: run chat client job on Node 22

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,16 +120,16 @@ jobs:
       shell: bash
 
   chat-client:
-    name: Build and Test Chat Client (20.x)
+    name: Build and Test Chat Client (22.x)
     needs: changes
     if: needs.changes.outputs.chat_client == 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-    - name: Use Node.js 20.x
+    - name: Use Node.js 22.x
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
-        node-version: 20.x
+        node-version: 22.x
     - name: Install Yarn
       run: npm install --global yarn@1.22.22 --registry https://packagefeedproxy.microsoft.io/npm/
     - name: Build and test chat client


### PR DESCRIPTION
## Problem

`Build and Test Chat Client` has been failing since **2026-08-28** and nobody noticed.

#919 bumped `@azure/web-pubsub-client` from 1.0.4 to 1.1.0. The two versions declare different engine requirements:

| version | `engines.node` |
| --- | --- |
| 1.0.4 | `>=18.0.0` |
| **1.1.0** | **`>=22.0.0`** |

The `chat-client` job pins Node **20.x**, so `yarn install` aborts after ~23s:

```
error @azure/web-pubsub-client@1.1.0: The engine "node" is incompatible
with this module. Expected version ">=22.0.0". Got "20.20.2"
```

This stayed latent because the job is path-gated on `sdk/webpubsub-chat-client/**`, and nothing touched that path for six days. It resurfaced on #1088 (a lockfile change under that path) and fails identically on Dependabot's #1085, confirming it is pre-existing and unrelated to either PR.

## Fix

Point the job at Node 22.x — three lines. Node 20 is EOL, and the `javascript` job in the same file already runs a `[22.20.0]` matrix, so this also brings the two into line. `chat-client` is the only job still on 20.

## Verification

Ran the job's complete step sequence locally on Node 22.20.0 / yarn 1.22.22:

| step | result |
| --- | --- |
| `yarn install --frozen-lockfile` | ✅ (the step that fails on Node 20) |
| `yarn build` | ✅ |
| `yarn build:bundle` | ✅ |
| `yarn extract-api` | ✅ |
| `git diff --exit-code -- review/` | ✅ no change to `web-pubsub-chat-client.api.md` |
| `yarn test:unit` | ✅ 8/8 passing |

`sdk/webpubsub-chat-client/package.json` keeps `engines.node: >=20.0.0`, which Node 22 satisfies. Narrowing the *published* package's supported range to match its dependency is a separate decision and is deliberately not made here.