### PR TITLE
deps: bump the four remaining nuget packages

### DIFF
--- a/sdk/clients/protobuf-client/csharp/samples/WebPubSubProtobufSample/WebPubSubProtobufSample.csproj
+++ b/sdk/clients/protobuf-client/csharp/samples/WebPubSubProtobufSample/WebPubSubProtobufSample.csproj
@@ -17,7 +17,7 @@
 	  <PackageReference Include="Azure.Messaging.WebPubSub.Client" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.11" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/clients/protobuf-client/csharp/src/Azure.Messaging.WebPubSub.Client.Protobuf.csproj
+++ b/sdk/clients/protobuf-client/csharp/src/Azure.Messaging.WebPubSub.Client.Protobuf.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="System.Threading.Channels" Version="10.0.11" />
     <PackageReference Include="Azure.Messaging.WebPubSub.Client" Version="1.0.0"/>
-    <PackageReference Include="Google.Protobuf" Version="3.35.1" />
+    <PackageReference Include="Google.Protobuf" Version="3.36.0" />
     <PackageReference Include="Grpc.Tools" Version="2.83.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tools/emulator/Directory.Packages.props
+++ b/tools/emulator/Directory.Packages.props
@@ -8,8 +8,8 @@
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.11" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
-    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.19.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.22.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>


### PR DESCRIPTION
Picks up what is left of #1083 now that #1093 has landed the `Microsoft.CodeAnalysis.Analyzers` and `Microsoft.CodeAnalysis.CSharp` bumps it was blocked on.

| package | from | to |
| --- | --- | --- |
| `Google.Protobuf` | 3.35.1 | 3.36.0 |
| `Microsoft.Extensions.Configuration.Json` | 10.0.10 | 10.0.11 |
| `Microsoft.NET.Test.Sdk` | 18.8.1 | 18.9.0 |
| `System.IdentityModel.Tokens.Jwt` | 8.19.2 | 8.22.0 |

Dependabot was asked to rebase #1083 but did not respond, and its branch had gone into conflict against the `Directory.Packages.props` lines #1093 rewrote, so the remainder is applied directly here. #1083 is closed in favour of this, and #1069 was closed earlier as a duplicate of it.

## Verification

Both touched areas have their own workflow - `emulator-tests.yml` for `tools/emulator/**` and `protobuf-client-tests.yml` for `sdk/clients/protobuf-client/csharp/**` - so CI covers this change. Both were also run locally:

```
tools/emulator                          127/127 passed
protobuf-client (src, tests, samples)   build succeeded, 13/13 passed
```

The one `CS8604` warning in `WebPubSubProtobufProtocolHelperTests.cs` is pre-existing - a baseline build of the unmodified tree reports the same single warning - and is unrelated to these versions.

Resolved versions were read back out of `project.assets.json` to confirm the restore actually moved, rather than trusting the edited `.csproj`:

```
Google.Protobuf                          = 3.36.0
Microsoft.Extensions.Configuration.Json  = 10.0.11
```