### PR TITLE
fix(graphql-sample): unbreak the build and document prerequisites

### DIFF
--- a/experimental/sdk/webpubsub-graphql-subscribe/README.md
+++ b/experimental/sdk/webpubsub-graphql-subscribe/README.md
@@ -13,6 +13,17 @@ Secondly, this package provides a replacement for `PubSub` using Azure Web PubSu
 
 Let's show how to apply the package into [the subscription sample provided by Apollo GraphQL](https://github.com/apollographql/docs-examples/tree/50808f11c5cfeaf029422dee3a3b324a6e93783e/apollo-server/v3/subscriptions).
 
+## Prerequisites
+
+- **Node.js.** Verified on Node 22; use a current LTS release. Runtimes older than Node 12
+  fail on startup with `ReferenceError: globalThis is not defined`.
+- **[Yarn](https://classic.yarnpkg.com/en/docs/install) 1.x.** The upstream Apollo sample
+  uses yarn, and this guide follows it for consistency.
+- **[Git](https://git-scm.com/downloads)**, to clone the Apollo sample.
+- **An Azure subscription**, and the
+  **[Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli)** for the
+  `az webpubsub` commands below.
+
 ## Get the subscription sample
 
 > [!NOTE]
@@ -90,17 +101,24 @@ Copy the fetched ConnectionString and it will be used later in this article as t
 
 Run the below command with `<connection_string>` replaced by the value fetched in the above step:
 
-Linux:
+Linux or macOS:
 
 ```bash
 export WebPubSubConnectionString="<connection_string>"
 yarn start
 ```
 
-Windows:
+Windows (Command Prompt):
 
 ```cmd
 SET WebPubSubConnectionString=<connection_string>
+yarn start
+```
+
+Windows (PowerShell):
+
+```powershell
+$env:WebPubSubConnectionString = "<connection_string>"
 yarn start
 ```
 
@@ -116,9 +134,19 @@ The console log shows that the exposed endpoint for Azure Web PubSub event handl
 
 ### Use `awps-tunnel` to tunnel traffic from Web PubSub service to your localhost
 
+Linux or macOS:
+
 ```bash
 npm install -g @azure/web-pubsub-tunnel-tool
 export WebPubSubConnectionString="<connection_string>"
+awps-tunnel run --hub graphql_subscription --upstream http://localhost:4000
+```
+
+Windows (PowerShell):
+
+```powershell
+npm install -g @azure/web-pubsub-tunnel-tool
+$env:WebPubSubConnectionString = "<connection_string>"
 awps-tunnel run --hub graphql_subscription --upstream http://localhost:4000
 ```
 

--- a/experimental/sdk/webpubsub-graphql-subscribe/package.json
+++ b/experimental/sdk/webpubsub-graphql-subscribe/package.json
@@ -35,7 +35,7 @@
     "compile": "tsc",
     "demo:client": "tsc && mocha --reporter spec --full-trace ./dist/demos/client-websockets/demo-awps.js",
     "posttest": "npm run lint",
-    "test": "echo TODO",
+    "test": "tsc --noEmit",
     "lint": "tslint --project ./tsconfig.json ./src/**/*.ts"
   },
   "dependencies": {
@@ -64,6 +64,6 @@
     "mocha": "^9.2.1",
     "simple-mock": "^0.8.0",
     "tslint": "^5.16.0",
-    "typescript": "^3.4.5"
+    "typescript": "^5.9.0"
   }
 }


### PR DESCRIPTION
Closes four Bug Bash issues from 2021 that are **all still reproducible today**, and fixes a compile break found while confirming them.

## The build was broken

`yarn compile` / `npm run compile` fails on `main`:

```
node_modules/@typespec/ts-http-runtime/dist/commonjs/index.d.ts(8,121): error TS1005: ',' expected.
... 
```

`typescript` was pinned at `^3.4.5`, which resolves to **3.9.10**. That compiler is too old to parse the `.d.ts` files now shipped through `@azure/web-pubsub@1.2.0` -> `@azure/logger` -> `@typespec/ts-http-runtime@0.3.8`. Bumping to `^5.9.0` compiles clean.

### Why CI stayed green

The `javascript` job does pick this directory up - `experimental/**` is in its path filter - and it runs `npm install && npm run test` for every `package.json` it finds. But the script was:

```json
"test": "echo TODO"
```

so it always succeeded. `posttest` then runs `tslint`, which reports `found no valid, enabled rules for this file type and file path` for both source files, i.e. it lints nothing either. The whole check was hollow.

`test` now runs `tsc --noEmit`. Verified both ways, through the exact commands CI uses:

| typescript | `npm run test` |
| --- | --- |
| 3.9.10 (before) | exits **1**, reports the `TS1005` errors |
| 5.9.3 (after) | exits **0** |

## The four issues

| issue | still valid? | fix |
| --- | --- | --- |
| #238 Prerequisites lacking | yes - the README had no Prerequisites section at all | adds one |
| #270 GraphQL sample not working | yes - `globalThis is not defined` on old Node. The issue's own follow-up concluded "probably add a prerequisite to this sample can fix this" | same Prerequisites section, calling out the failure |
| #237 command only available in CMD | yes - Windows instructions were `cmd`-only | adds PowerShell |
| #260 `Set` command not applicable to Windows powershell | yes - same root cause as #237 | adds PowerShell |

The Node requirement is stated as verified rather than guessed: `yarn install` and `tsc` were run on **Node 22**, and the `globalThis` failure mode from #270 is attributed to runtimes older than Node 12 rather than a version I did not test.

## Note on the dependencies

Install succeeds but warns that `apollo-server-express@3.1.2` and `subscriptions-transport-ws` are end-of-life. That is a larger question about whether this experimental sample should be modernised or retired, and is deliberately left out of this change.