### PR TITLE
Emulator: support group existence and filtered sends

### DIFF
--- a/tools/emulator/CHANGELOG.md
+++ b/tools/emulator/CHANGELOG.md
@@ -15,3 +15,4 @@
 - Add authenticated REST operations and official .NET server SDK compatibility for checking connection presence and sending directly to a connection.
 - Add authenticated REST and official .NET server SDK support for closing a connection.
 - Add authenticated REST and official .NET server SDK support for adding and removing a connection from a group.
+- Add authenticated REST and official .NET server SDK support for checking group presence and sending to a group with excluded connection IDs and OData filters.

--- a/tools/emulator/Directory.Packages.props
+++ b/tools/emulator/Directory.Packages.props
@@ -9,6 +9,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageVersion Include="Microsoft.OData.Core" Version="8.4.4" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.22.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/tools/emulator/README.md
+++ b/tools/emulator/README.md
@@ -61,11 +61,13 @@ emulator process. The replay buffer is limited to 1,000 messages and 16 MiB per 
 
 ## Use a server SDK
 
-The emulator supports checking whether a connection exists, sending text, JSON, or binary data,
-and closing a connection through the Azure Web PubSub REST API. For example, use the generated
-connection string with the Azure Web PubSub .NET server SDK:
+The emulator supports checking whether connections and groups exist, sending text, JSON, or binary
+data to connections and groups, changing connection group membership, and closing a connection
+through the Azure Web PubSub REST API. For example, use the generated connection string with the
+Azure Web PubSub .NET server SDK:
 
 ```csharp
+using Azure.Core;
 using Azure.Messaging.WebPubSub;
 
 var serviceClient = new WebPubSubServiceClient(
@@ -78,13 +80,21 @@ await serviceClient.SendToConnectionAsync(
   BinaryData.FromString("Hello"),
   ContentType.TextPlain);
 await serviceClient.AddConnectionToGroupAsync("room", connectionId);
+bool groupExists = await serviceClient.GroupExistsAsync("room");
+await serviceClient.SendToGroupAsync(
+  "room",
+  BinaryData.FromString("Hello, room"),
+  ContentType.TextPlain,
+  excluded: new[] { connectionId });
 await serviceClient.RemoveConnectionFromGroupAsync("room", connectionId);
 await serviceClient.CloseConnectionAsync(connectionId, "Done");
 ```
 
-Direct sends return success when the connection does not exist, matching the service's
-fire-and-forget behavior. Valid `messageTtlSeconds` values are accepted, but the emulator does not
-model message expiration.
+Connection and group sends return success when the target does not exist, matching the service's
+fire-and-forget behavior. Group sends support repeated `excluded` connection IDs and OData `filter`
+expressions over `connectionId`, `userId`, `groups`, and `protocol`. Invalid filters return an
+`Error.BadRequest` response before the message body is processed. Valid `messageTtlSeconds` values
+are accepted, but the emulator does not model message expiration.
 
 Set the ASP.NET Core `Urls` configuration value to use another address. The generated connection
 string automatically uses the address and port that the emulator actually binds. For example:

--- a/tools/emulator/SUPPORTED_FEATURES.md
+++ b/tools/emulator/SUPPORTED_FEATURES.md
@@ -18,8 +18,9 @@ local Azure Web PubSub development.
 | Groups and roles | Supports connection-scoped token groups and authorized join, leave, and group send, including wildcard roles. | ✅ |
 | Outbound delivery | Uses a bounded, single-writer queue for each WebSocket connection. | ✅ |
 | REST connection operations | Authenticated connection presence, direct text, JSON, and binary sends, close, and single-connection group membership changes for GA API versions from `2021-10-01` through `2024-12-01`. | ✅ |
-| REST direct-send TTL | Accepts valid `messageTtlSeconds` values; delivery is immediate and expiration is not modeled. | ⚠️ |
-| Other REST APIs | Group fan-out, user, permission, and broadcast operations. | ❌ |
+| REST group operations | Authenticated group presence and text, JSON, or binary fan-out with excluded connection IDs and OData filters. | ✅ |
+| REST send TTL | Accepts valid `messageTtlSeconds` values; delivery is immediate and expiration is not modeled. | ⚠️ |
+| Other REST APIs | User, permission, and broadcast operations. | ❌ |
 
 ## Not yet implemented
 

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ConnectionManager.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ConnectionManager.cs
@@ -63,6 +63,11 @@ internal sealed class ConnectionManager
         return _connections.ContainsKey((hub, connectionId));
     }
 
+    public bool GroupExists(string hub, string group)
+    {
+        return GetHubConnections(hub).Any(connection => connection.Groups.ContainsKey(group));
+    }
+
     public void SendToConnection(string hub, string connectionId, MessageData data)
     {
         if (_connections.TryGetValue((hub, connectionId), out var connection))
@@ -117,16 +122,25 @@ internal sealed class ConnectionManager
         string group,
         MessageData data,
         LogicalConnection? sender,
-        bool noEcho)
+        bool noEcho,
+        IReadOnlySet<string>? excludedConnectionIds = null,
+        string? filter = null)
     {
-        foreach (var connection in _connections
-            .Where(item => string.Equals(item.Key.Hub, hub, StringComparison.Ordinal))
-            .Select(item => item.Value)
+        foreach (var connection in GetHubConnections(hub)
             .Where(connection => connection.Groups.ContainsKey(group))
-            .Where(connection => !noEcho || connection != sender))
+            .Where(connection => !noEcho || connection != sender)
+            .Where(connection => excludedConnectionIds?.Contains(connection.ConnectionId) != true)
+            .Where(connection => ODataFilterExecutor.Instance.Matches(filter, connection)))
         {
             connection.SendGroupData(group, sender?.UserId, data);
         }
+    }
+
+    private IEnumerable<LogicalConnection> GetHubConnections(string hub)
+    {
+        return _connections
+            .Where(item => string.Equals(item.Key.Hub, hub, StringComparison.Ordinal))
+            .Select(item => item.Value);
     }
 
     private async Task ExpireAsync(LogicalConnection connection, long generation)

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/LogicalConnection.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/LogicalConnection.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebPubSub.Emulator;
 
-internal sealed class LogicalConnection
+internal sealed class LogicalConnection : IODataFilterModel
 {
     private const long ReliableControlByteAllowance = 64 * 1024;
     private const int ReliableControlMessageAllowance = 32;
@@ -102,6 +102,10 @@ internal sealed class LogicalConnection
     public AckCache AckIdCache { get; } = new();
 
     public ConcurrentDictionary<string, byte> Groups { get; } = new(StringComparer.Ordinal);
+
+    string[] IODataFilterModel.Groups => Groups.Keys.ToArray();
+
+    string? IODataFilterModel.Protocol => Subprotocol;
 
     public SocketTransport? TryAttach(
         WebSocket webSocket,

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/Microsoft.Azure.WebPubSub.Emulator.csproj
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/Microsoft.Azure.WebPubSub.Emulator.csproj
@@ -26,6 +26,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.OData.Core" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
   </ItemGroup>
 

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ODataFilterExecutor.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ODataFilterExecutor.cs
@@ -1,0 +1,660 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.OData;
+using Microsoft.OData.UriParser;
+using Microsoft.OData.UriParser.Aggregation;
+
+namespace Microsoft.Azure.WebPubSub.Emulator;
+
+internal interface IODataFilterModel
+{
+    string ConnectionId { get; }
+
+    string? UserId { get; }
+
+    string[] Groups { get; }
+
+    string? Protocol { get; }
+}
+
+internal sealed class ODataFilterExecutor
+{
+    private const int MaxDepth = 100;
+    private readonly ConcurrentDictionary<string, QueryToken> _cache = [];
+
+    public static ODataFilterExecutor Instance { get; } = new();
+
+    public void Validate(string? filter)
+    {
+        if (string.IsNullOrEmpty(filter))
+        {
+            return;
+        }
+
+        try
+        {
+            FilterNodeVisitor.Validate(GetToken(filter));
+        }
+        catch (Exception exception) when (
+            exception is InvalidFilterTokenException or
+            FilterTokenNotSupportedException or
+            ODataException)
+        {
+            throw new InvalidFilterException(filter, exception);
+        }
+    }
+
+    public bool Matches(string? filter, IODataFilterModel model)
+    {
+        if (string.IsNullOrEmpty(filter))
+        {
+            return true;
+        }
+
+        try
+        {
+            return FilterNodeVisitor.Matches(GetToken(filter), model);
+        }
+        catch (Exception exception) when (
+            exception is InvalidFilterTokenException or
+            FilterTokenNotSupportedException or
+            ODataException)
+        {
+            throw new InvalidFilterException(filter, exception);
+        }
+    }
+
+    private QueryToken GetToken(string filter)
+    {
+        return _cache.GetOrAdd(
+            filter,
+            static value => new UriQueryExpressionParser(MaxDepth).ParseFilter(value));
+    }
+
+    private sealed class Node
+    {
+        public static Node Null { get; } = new(NodeValueType.Null, null);
+
+        public NodeValueType NodeType { get; }
+
+        public object? Value { get; }
+
+        public Node(int value) : this(NodeValueType.Int, value)
+        {
+        }
+
+        public Node(string? value) : this(NodeValueType.String, value)
+        {
+        }
+
+        public Node(bool value) : this(NodeValueType.Bool, value)
+        {
+        }
+
+        public Node(ICollection value) : this(NodeValueType.Collection, value)
+        {
+        }
+
+        public Node(LiteralToken token)
+        {
+            NodeType = token.Value switch
+            {
+                null => NodeValueType.Null,
+                bool => NodeValueType.Bool,
+                int => NodeValueType.Int,
+                string => NodeValueType.String,
+                ICollection => NodeValueType.Collection,
+                _ => throw new FilterTokenNotSupportedException(token),
+            };
+            Value = token.Value;
+        }
+
+        private Node(NodeValueType nodeType, object? value)
+        {
+            NodeType = nodeType;
+            Value = value;
+        }
+
+        public bool IsNull() => NodeType == NodeValueType.Null;
+
+        [MemberNotNullWhen(false, nameof(Value))]
+        public bool IsNullOrStringNull() =>
+            NodeType == NodeValueType.Null ||
+            NodeType == NodeValueType.String && Value is null;
+
+        [MemberNotNullWhen(true, nameof(Value))]
+        public bool IsCollection() => NodeType == NodeValueType.Collection;
+
+        public bool IsString() => NodeType == NodeValueType.String;
+
+        [MemberNotNullWhen(true, nameof(Value))]
+        public bool IsInt() => NodeType == NodeValueType.Int;
+
+        [MemberNotNullWhen(true, nameof(Value))]
+        public bool IsBoolean() => NodeType == NodeValueType.Bool;
+
+        public int AsInt(QueryToken token)
+        {
+            if (!IsInt())
+            {
+                throw new InvalidFilterException(token, GetExpectedMessage(NodeType, NodeValueType.Int));
+            }
+
+            return (int)Value;
+        }
+
+        public bool AsBoolean(QueryToken token)
+        {
+            if (!IsBoolean())
+            {
+                throw new InvalidFilterException(token, GetExpectedMessage(NodeType, NodeValueType.Bool));
+            }
+
+            return (bool)Value;
+        }
+
+        public string? AsString(QueryToken token)
+        {
+            if (!IsString())
+            {
+                throw new InvalidFilterException(token, GetExpectedMessage(NodeType, NodeValueType.String));
+            }
+
+            return (string?)Value;
+        }
+
+        public ICollection AsCollection(QueryToken token)
+        {
+            if (!IsCollection())
+            {
+                throw new InvalidFilterException(token, GetExpectedMessage(NodeType, NodeValueType.Collection));
+            }
+
+            return (ICollection)Value;
+        }
+
+        private static string GetExpectedMessage(NodeValueType actual, NodeValueType expected) =>
+            $"Type '{ToText(actual)}', expect '{ToText(expected)}'.";
+
+        private static string ToText(NodeValueType type) => type switch
+        {
+            NodeValueType.Null => "null",
+            NodeValueType.Bool => "bool",
+            NodeValueType.String => "string",
+            NodeValueType.Int => "int",
+            NodeValueType.Collection => "collection",
+            _ => throw new NotSupportedException(type.ToString()),
+        };
+
+        public enum NodeValueType
+        {
+            Null,
+            Bool,
+            String,
+            Int,
+            Collection,
+        }
+    }
+
+    private sealed class FilterNodeVisitor(IODataFilterModel model) : ISyntacticTreeVisitor<Node>
+    {
+        private readonly UriQueryExpressionParser _parser = new(MaxDepth);
+        private readonly bool _isValidation = ReferenceEquals(model, ValidationModel.Instance);
+
+        public static bool Matches(QueryToken token, IODataFilterModel model) =>
+            token.Accept(new FilterNodeVisitor(model)).AsBoolean(token);
+
+        public static void Validate(QueryToken token) =>
+            token.Accept(new FilterNodeVisitor(ValidationModel.Instance)).AsBoolean(token);
+
+        public Node Visit(BinaryOperatorToken token)
+        {
+            try
+            {
+                var left = Parse(token.Left);
+                var right = Parse(token.Right);
+                return token.OperatorKind switch
+                {
+                    // Non short-circuiting on purpose: both operands must be type checked so an
+                    // invalid filter is rejected up front instead of failing mid fan-out.
+                    BinaryOperatorKind.Or => new(left.AsBoolean(token) | right.AsBoolean(token)),
+                    BinaryOperatorKind.And => new(left.AsBoolean(token) & right.AsBoolean(token)),
+                    BinaryOperatorKind.Equal => new(Equals(left.Value, right.Value)),
+                    BinaryOperatorKind.NotEqual => new(!Equals(left.Value, right.Value)),
+                    BinaryOperatorKind.GreaterThan => Compare(left, right, token, value => value > 0),
+                    BinaryOperatorKind.GreaterThanOrEqual => Compare(left, right, token, value => value >= 0),
+                    BinaryOperatorKind.LessThan => Compare(left, right, token, value => value < 0),
+                    BinaryOperatorKind.LessThanOrEqual => Compare(left, right, token, value => value <= 0),
+                    _ => throw new FilterTokenNotSupportedException(token),
+                };
+            }
+            catch (Exception exception) when (
+                exception is InvalidFilterTokenException or FilterTokenNotSupportedException)
+            {
+                throw new InvalidFilterException(token, exception);
+            }
+        }
+
+        public Node Visit(UnaryOperatorToken token) => token.OperatorKind switch
+        {
+            UnaryOperatorKind.Not => new(!Parse(token.Operand).AsBoolean(token)),
+            _ => throw new FilterTokenNotSupportedException(token),
+        };
+
+        public Node Visit(InToken token)
+        {
+            try
+            {
+                var left = Parse(token.Left).Value;
+                var right = Parse(token.Right);
+                IEnumerable collection = right.IsCollection()
+                    ? right.AsCollection(token)
+                    : ParseInCollection(right.AsString(token)!);
+                return new(Contains(collection, left));
+            }
+            catch (Exception exception) when (
+                exception is InvalidFilterTokenException or FilterTokenNotSupportedException)
+            {
+                throw new InvalidFilterException(token, exception);
+            }
+        }
+
+        public Node Visit(FunctionCallToken token)
+        {
+            try
+            {
+                var arguments = token.Arguments.Select(argument => argument.ValueToken).ToArray();
+                return token.Name switch
+                {
+                    "length" when arguments.Length == 1 => Length(Parse(arguments[0]), token),
+                    "tolower" when arguments.Length == 1 => Transform(Parse(arguments[0]), token, value => value.ToLowerInvariant()),
+                    "toupper" when arguments.Length == 1 => Transform(Parse(arguments[0]), token, value => value.ToUpperInvariant()),
+                    "trim" when arguments.Length == 1 => Transform(Parse(arguments[0]), token, value => value.Trim()),
+                    "contains" when arguments.Length == 2 => StringPredicate(arguments, token, (value, argument) => value.Contains(argument)),
+                    "startswith" when arguments.Length == 2 => StringPredicate(arguments, token, (value, argument) => value.StartsWith(argument)),
+                    "endswith" when arguments.Length == 2 => StringPredicate(arguments, token, (value, argument) => value.EndsWith(argument)),
+                    "indexof" when arguments.Length == 2 => IndexOf(arguments, token),
+                    "concat" when arguments.Length == 2 => Concat(arguments, token),
+                    "substring" when arguments.Length == 2 => Substring(arguments, token),
+                    "substring" when arguments.Length == 3 => Substring(arguments, token),
+                    "length" or "tolower" or "toupper" or "trim" or
+                    "contains" or "startswith" or "endswith" or "indexof" or
+                    "concat" or "substring" => throw new InvalidFilterTokenException(token),
+                    _ => throw new FilterTokenNotSupportedException(token),
+                };
+            }
+            catch (Exception exception) when (
+                exception is InvalidFilterTokenException or FilterTokenNotSupportedException)
+            {
+                throw new InvalidFilterException(token, exception);
+            }
+        }
+
+        public Node Visit(LiteralToken token) => new(token);
+
+        public Node Visit(EndPathToken token)
+        {
+            if (token.Identifier.Equals(nameof(IODataFilterModel.UserId), StringComparison.OrdinalIgnoreCase))
+            {
+                return new(model.UserId);
+            }
+            if (token.Identifier.Equals(nameof(IODataFilterModel.ConnectionId), StringComparison.OrdinalIgnoreCase))
+            {
+                return new(model.ConnectionId);
+            }
+            if (token.Identifier.Equals(nameof(IODataFilterModel.Groups), StringComparison.OrdinalIgnoreCase))
+            {
+                return new(model.Groups);
+            }
+            if (token.Identifier.Equals(nameof(IODataFilterModel.Protocol), StringComparison.OrdinalIgnoreCase))
+            {
+                return new(model.Protocol);
+            }
+
+            throw new FilterTokenNotSupportedException(token);
+        }
+
+        public Node Visit(AllToken token) => throw new FilterTokenNotSupportedException(token);
+        public Node Visit(AnyToken token) => throw new FilterTokenNotSupportedException(token);
+        public Node Visit(LambdaToken token) => throw new FilterTokenNotSupportedException(token);
+        public Node Visit(InnerPathToken token) => throw new FilterTokenNotSupportedException(token);
+        public Node Visit(OrderByToken token) => throw new FilterTokenNotSupportedException(token);
+        public Node Visit(CustomQueryOptionToken token) => throw new FilterTokenNotSupportedException(token);
+        public Node Visit(RangeVariableToken token) => throw new FilterTokenNotSupportedException(token);
+        public Node Visit(DottedIdentifierToken token) => throw new FilterTokenNotSupportedException(token);
+        public Node Visit(CountSegmentToken token) => throw new FilterTokenNotSupportedException(token);
+        public Node Visit(ExpandToken token) => throw new FilterTokenNotSupportedException(token);
+        public Node Visit(ExpandTermToken token) => throw new FilterTokenNotSupportedException(token);
+        public Node Visit(SelectToken token) => throw new FilterTokenNotSupportedException(token);
+        public Node Visit(SelectTermToken token) => throw new FilterTokenNotSupportedException(token);
+        public Node Visit(StarToken token) => throw new FilterTokenNotSupportedException(token);
+        public Node Visit(FunctionParameterToken token) => throw new FilterTokenNotSupportedException(token);
+        public Node Visit(AggregateToken token) => throw new FilterTokenNotSupportedException(token);
+        public Node Visit(AggregateExpressionToken token) => throw new FilterTokenNotSupportedException(token);
+        public Node Visit(EntitySetAggregateToken token) => throw new FilterTokenNotSupportedException(token);
+        public Node Visit(GroupByToken token) => throw new FilterTokenNotSupportedException(token);
+        public Node Visit(RootPathToken token) => throw new FilterTokenNotSupportedException(token);
+
+        private Node Parse(QueryToken token) => token.Accept(this);
+
+        private static Node Compare(Node left, Node right, QueryToken token, Func<int, bool> predicate)
+        {
+            if (left.IsNull() || right.IsNull())
+            {
+                return new(false);
+            }
+
+            return new(predicate(left.AsInt(token).CompareTo(right.AsInt(token))));
+        }
+
+        private static Node Length(Node value, QueryToken token)
+        {
+            if (value.IsNullOrStringNull())
+            {
+                return Node.Null;
+            }
+            if (value.IsString())
+            {
+                return new(value.AsString(token)!.Length);
+            }
+            if (value.IsCollection())
+            {
+                return new(value.AsCollection(token).Count);
+            }
+
+            throw new InvalidFilterTokenException(token);
+        }
+
+        private static Node Transform(Node value, QueryToken token, Func<string, string> transform)
+        {
+            return value.IsNullOrStringNull()
+                ? Node.Null
+                : new(transform(value.AsString(token)!));
+        }
+
+        private Node StringPredicate(
+            QueryToken[] arguments,
+            QueryToken token,
+            Func<string, string, bool> predicate)
+        {
+            var value = Parse(arguments[0]);
+            var argument = Parse(arguments[1]);
+            return value.IsNullOrStringNull() || argument.IsNullOrStringNull()
+                ? new(false)
+                : new(predicate(value.AsString(token)!, argument.AsString(token)!));
+        }
+
+        private Node IndexOf(QueryToken[] arguments, QueryToken token)
+        {
+            var value = Parse(arguments[0]);
+            var argument = Parse(arguments[1]);
+            return value.IsNullOrStringNull() || argument.IsNullOrStringNull()
+                ? new(-1)
+                : new(value.AsString(token)!.IndexOf(argument.AsString(token)!));
+        }
+
+        private Node Concat(QueryToken[] arguments, QueryToken token)
+        {
+            var left = Parse(arguments[0]);
+            var right = Parse(arguments[1]);
+            if (left.IsNullOrStringNull() && right.IsNullOrStringNull())
+            {
+                return Node.Null;
+            }
+            if (left.IsNullOrStringNull() && right.IsString())
+            {
+                return right;
+            }
+            if (right.IsNullOrStringNull() && left.IsString())
+            {
+                return left;
+            }
+
+            return new(string.Concat(left.AsString(token), right.AsString(token)));
+        }
+
+        private Node Substring(QueryToken[] arguments, QueryToken token)
+        {
+            var value = Parse(arguments[0]);
+            var start = Parse(arguments[1]).AsInt(token);
+            var length = arguments.Length == 3
+                ? Parse(arguments[2]).AsInt(token)
+                : (int?)null;
+            if (value.IsNullOrStringNull())
+            {
+                return Node.Null;
+            }
+
+            var text = value.AsString(token)!;
+            if (_isValidation)
+            {
+                return new(string.Empty);
+            }
+            if (start < 0 || start > text.Length ||
+                length < 0 || length > text.Length - start)
+            {
+                return Node.Null;
+            }
+
+            return length is null
+                ? new(text.Substring(start))
+                : new(text.Substring(start, length.Value));
+        }
+
+        private IEnumerable<object?> ParseInCollection(string literal)
+        {
+            if (literal.Length < 2 || literal[0] != '(' || literal[^1] != ')')
+            {
+                throw new InvalidFilterTokenException(literal);
+            }
+
+            foreach (var item in SplitCollectionItems(literal))
+            {
+                yield return Parse(_parser.ParseFilter(item)).Value;
+            }
+        }
+
+        private static IEnumerable<string> SplitCollectionItems(string literal)
+        {
+            var start = 1;
+            var quoted = false;
+            for (var index = 1; index < literal.Length - 1; index++)
+            {
+                if (literal[index] == '\'')
+                {
+                    if (quoted && index + 1 < literal.Length - 1 && literal[index + 1] == '\'')
+                    {
+                        index++;
+                    }
+                    else
+                    {
+                        quoted = !quoted;
+                    }
+                }
+                else if (literal[index] == ',' && !quoted)
+                {
+                    var item = literal[start..index].Trim();
+                    if (item.Length > 0)
+                    {
+                        yield return item;
+                    }
+                    start = index + 1;
+                }
+            }
+
+            if (quoted)
+            {
+                throw new InvalidFilterTokenException(literal);
+            }
+
+            var last = literal[start..^1].Trim();
+            if (last.Length > 0)
+            {
+                yield return last;
+            }
+        }
+
+        private static bool Contains(IEnumerable collection, object? value)
+        {
+            foreach (var item in collection)
+            {
+                if (Equals(item, value))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private sealed class ValidationModel : IODataFilterModel
+        {
+            public static ValidationModel Instance { get; } = new();
+
+            public string ConnectionId => string.Empty;
+            public string? UserId => null;
+            public string[] Groups => [];
+            public string? Protocol => null;
+        }
+    }
+}
+
+internal sealed class InvalidFilterException : ArgumentException
+{
+    public InvalidFilterException(string filter, Exception innerException)
+        : base($"Invalid syntax for '{filter}': {innerException.Message}", "filter", innerException)
+    {
+    }
+
+    public InvalidFilterException(QueryToken token, string detail)
+        : base($"Invalid syntax for '{FilterTokenPrinter.Print(token)}': {detail}", "filter")
+    {
+    }
+
+    public InvalidFilterException(QueryToken token, Exception innerException)
+        : base(
+            $"Invalid syntax for '{FilterTokenPrinter.Print(token)}': {innerException.Message}",
+            "filter",
+            innerException)
+    {
+    }
+}
+
+internal sealed class InvalidFilterTokenException : Exception
+{
+    public InvalidFilterTokenException(string token) : base($"Invalid token '{token}'.")
+    {
+    }
+
+    public InvalidFilterTokenException(QueryToken token)
+        : this(FilterTokenPrinter.Print(token))
+    {
+    }
+}
+
+internal sealed class FilterTokenNotSupportedException : Exception
+{
+    [ThreadStatic]
+    private static bool _isPrinting;
+
+    public FilterTokenNotSupportedException(QueryToken token)
+        : base(GetErrorMessage(token))
+    {
+    }
+
+    private static string GetErrorMessage(QueryToken token)
+    {
+        if (!_isPrinting)
+        {
+            _isPrinting = true;
+            try
+            {
+                return $"Token '{FilterTokenPrinter.Print(token)}' is not supported.";
+            }
+            catch
+            {
+                // Fall back to the OData token kind when the printer cannot describe it.
+            }
+            finally
+            {
+                _isPrinting = false;
+            }
+        }
+
+        return $"Token '{token.Kind}' is not supported.";
+    }
+}
+
+internal sealed class FilterTokenPrinter : ISyntacticTreeVisitor<string>
+{
+    public static string Print(QueryToken token) => token.Accept(new FilterTokenPrinter());
+
+    public string Visit(BinaryOperatorToken token) => token.OperatorKind switch
+    {
+        BinaryOperatorKind.Or => $"{Wrap(token.Left)} or {Wrap(token.Right)}",
+        BinaryOperatorKind.And => $"{Wrap(token.Left)} and {Wrap(token.Right)}",
+        BinaryOperatorKind.Equal => $"{Wrap(token.Left)} eq {Wrap(token.Right)}",
+        BinaryOperatorKind.NotEqual => $"{Wrap(token.Left)} ne {Wrap(token.Right)}",
+        BinaryOperatorKind.GreaterThan => $"{Wrap(token.Left)} gt {Wrap(token.Right)}",
+        BinaryOperatorKind.GreaterThanOrEqual => $"{Wrap(token.Left)} ge {Wrap(token.Right)}",
+        BinaryOperatorKind.LessThan => $"{Wrap(token.Left)} lt {Wrap(token.Right)}",
+        BinaryOperatorKind.LessThanOrEqual => $"{Wrap(token.Left)} le {Wrap(token.Right)}",
+        _ => throw new FilterTokenNotSupportedException(token),
+    };
+
+    public string Visit(UnaryOperatorToken token) =>
+        token.OperatorKind == UnaryOperatorKind.Not
+            ? $"not {Wrap(token.Operand)}"
+            : throw new FilterTokenNotSupportedException(token);
+
+    public string Visit(InToken token) => $"{Print(token.Left)} in {Print(token.Right)}";
+
+    public string Visit(FunctionCallToken token) =>
+        $"{token.Name}({string.Join(',', token.Arguments.Select(argument => Print(argument.ValueToken)))})";
+
+    public string Visit(LiteralToken token)
+    {
+        if (token.Value is null)
+        {
+            return "null";
+        }
+        if (token.Value is string value)
+        {
+            return value.Length > 2 && value[0] == '(' && value[^1] == ')'
+                ? value
+                : $"'{value}'";
+        }
+        return token.Value.ToString()!;
+    }
+
+    public string Visit(EndPathToken token) => token.Identifier;
+    public string Visit(AllToken token) => throw new FilterTokenNotSupportedException(token);
+    public string Visit(AnyToken token) => throw new FilterTokenNotSupportedException(token);
+    public string Visit(LambdaToken token) => throw new FilterTokenNotSupportedException(token);
+    public string Visit(InnerPathToken token) => throw new FilterTokenNotSupportedException(token);
+    public string Visit(OrderByToken token) => throw new FilterTokenNotSupportedException(token);
+    public string Visit(CustomQueryOptionToken token) => throw new FilterTokenNotSupportedException(token);
+    public string Visit(RangeVariableToken token) => throw new FilterTokenNotSupportedException(token);
+    public string Visit(DottedIdentifierToken token) => throw new FilterTokenNotSupportedException(token);
+    public string Visit(CountSegmentToken token) => throw new FilterTokenNotSupportedException(token);
+    public string Visit(ExpandToken token) => throw new FilterTokenNotSupportedException(token);
+    public string Visit(ExpandTermToken token) => throw new FilterTokenNotSupportedException(token);
+    public string Visit(SelectToken token) => throw new FilterTokenNotSupportedException(token);
+    public string Visit(SelectTermToken token) => throw new FilterTokenNotSupportedException(token);
+    public string Visit(StarToken token) => throw new FilterTokenNotSupportedException(token);
+    public string Visit(FunctionParameterToken token) => throw new FilterTokenNotSupportedException(token);
+    public string Visit(AggregateToken token) => throw new FilterTokenNotSupportedException(token);
+    public string Visit(AggregateExpressionToken token) => throw new FilterTokenNotSupportedException(token);
+    public string Visit(EntitySetAggregateToken token) => throw new FilterTokenNotSupportedException(token);
+    public string Visit(GroupByToken token) => throw new FilterTokenNotSupportedException(token);
+    public string Visit(RootPathToken token) => throw new FilterTokenNotSupportedException(token);
+
+    private static string Wrap(QueryToken token) =>
+        token.Kind is QueryTokenKind.BinaryOperator or QueryTokenKind.UnaryOperator or QueryTokenKind.In
+            ? $"({Print(token)})"
+            : Print(token);
+}

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubEmulatorController.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubEmulatorController.cs
@@ -106,42 +106,103 @@ internal sealed class WebPubSubEmulatorController : WebPubSubApiControllerDefini
         {
             return Unauthorized();
         }
-        if (Request.ContentLength is not { } contentLength ||
-            contentLength < 0 ||
-            contentLength > _runtimeOptions.MaxMessageSizeBytes)
-        {
-            return CreateBadRequest("Invalid Content-Length header.");
-        }
-        if (!TryGetDataType(out var dataType, out var encoding))
-        {
-            return StatusCode(StatusCodes.Status415UnsupportedMediaType);
-        }
 
-        var bytes = await ReadBodyAsync(encoding, cancellationToken);
-        if (bytes is null)
+        var (data, error) = await ReadMessageDataAsync(cancellationToken);
+        if (error is not null)
         {
-            return CreateBadRequest("Invalid Content-Length header.");
-        }
-        if (dataType == MessageDataType.Json && !IsValidJson(bytes))
-        {
-            return CreateBadRequest("The request body is not a valid JSON.");
-        }
-
-        IReadOnlyDictionary<string, string>? metadata;
-        try
-        {
-            metadata = GetMetadata();
-            WebPubSubMetadataValidator.Validate(metadata);
-        }
-        catch (InvalidDataException exception)
-        {
-            return CreateBadRequest(exception.Message);
+            return error;
         }
 
         _connections.SendToConnection(
             hub.ToLowerInvariant(),
             connectionId,
-            new MessageData(dataType, bytes, metadata));
+            data!);
+        return Accepted();
+    }
+
+    [HttpHead(
+        "/api/hubs/{hub}/groups/{group}",
+        Name = "WebPubSub_GroupExists")]
+    public IActionResult GroupExists(
+        [RegularExpression(
+            WebPubSubNameValidator.HubNamePattern,
+            ErrorMessage = "Invalid hub name.")]
+        string hub,
+        [StringLength(
+            WebPubSubNameValidator.MaximumGroupNameLength,
+            MinimumLength = 1,
+            ErrorMessage = "Invalid group name.")]
+        [RegularExpression(
+            WebPubSubNameValidator.NotWhitespacePattern,
+            ErrorMessage = "Invalid group name.")]
+        string group,
+        CancellationToken cancellationToken = default)
+    {
+        if (!Authorize())
+        {
+            return Unauthorized();
+        }
+
+        if (_connections.GroupExists(hub.ToLowerInvariant(), group))
+        {
+            return Ok();
+        }
+
+        Response.Headers["x-ms-error-code"] = "Warning.Group.NotExisted";
+        return NotFound();
+    }
+
+    [HttpPost(
+        "/api/hubs/{hub}/groups/{group}/:send",
+        Name = "WebPubSub_SendToGroup")]
+    public async Task<IActionResult> SendToGroup(
+        [RegularExpression(
+            WebPubSubNameValidator.HubNamePattern,
+            ErrorMessage = "Invalid hub name.")]
+        string hub,
+        [StringLength(
+            WebPubSubNameValidator.MaximumGroupNameLength,
+            MinimumLength = 1,
+            ErrorMessage = "Invalid group name.")]
+        [RegularExpression(
+            WebPubSubNameValidator.NotWhitespacePattern,
+            ErrorMessage = "Invalid group name.")]
+        string group,
+        [FromQuery(Name = "messageTtlSeconds")]
+        [Range(0, MaximumMessageTtlSeconds, ErrorMessage = "Invalid messageTtlSeconds.")]
+        uint? messageTtlSeconds,
+        [FromQuery(Name = "filter")]
+        string? filter,
+        CancellationToken cancellationToken = default)
+    {
+        if (!Authorize())
+        {
+            return Unauthorized();
+        }
+
+        try
+        {
+            ODataFilterExecutor.Instance.Validate(filter);
+        }
+        catch (InvalidFilterException exception)
+        {
+            return CreateBadRequest(exception.Message);
+        }
+
+        var (data, error) = await ReadMessageDataAsync(cancellationToken);
+        if (error is not null)
+        {
+            return error;
+        }
+
+        _connections.SendToGroup(
+            hub.ToLowerInvariant(),
+            group,
+            data!,
+            sender: null,
+            noEcho: false,
+            GetExcludedConnectionIds(),
+            filter);
         return Accepted();
     }
 
@@ -253,6 +314,52 @@ internal sealed class WebPubSubEmulatorController : WebPubSubApiControllerDefini
             metadata[key] = lastComma < 0 ? value.Trim() : value[(lastComma + 1)..].Trim();
         }
         return metadata;
+    }
+
+    private IReadOnlySet<string> GetExcludedConnectionIds()
+    {
+        return Request.Query["excluded"]
+            .Where(value => value is not null)
+            .Select(value => value!)
+            .ToHashSet(StringComparer.Ordinal);
+    }
+
+    private async Task<(MessageData? Data, IActionResult? Error)> ReadMessageDataAsync(
+        CancellationToken cancellationToken)
+    {
+        if (Request.ContentLength is not { } contentLength ||
+            contentLength < 0 ||
+            contentLength > _runtimeOptions.MaxMessageSizeBytes)
+        {
+            return (null, CreateBadRequest("Invalid Content-Length header."));
+        }
+        if (!TryGetDataType(out var dataType, out var encoding))
+        {
+            return (null, StatusCode(StatusCodes.Status415UnsupportedMediaType));
+        }
+
+        var bytes = await ReadBodyAsync(encoding, cancellationToken);
+        if (bytes is null)
+        {
+            return (null, CreateBadRequest("Invalid Content-Length header."));
+        }
+        if (dataType == MessageDataType.Json && !IsValidJson(bytes))
+        {
+            return (null, CreateBadRequest("The request body is not a valid JSON."));
+        }
+
+        IReadOnlyDictionary<string, string>? metadata;
+        try
+        {
+            metadata = GetMetadata();
+            WebPubSubMetadataValidator.Validate(metadata);
+        }
+        catch (InvalidDataException exception)
+        {
+            return (null, CreateBadRequest(exception.Message));
+        }
+
+        return (new MessageData(dataType, bytes, metadata), null);
     }
 
     private bool TryGetDataType(out MessageDataType dataType, out Encoding? encoding)

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/EmulatorApplicationTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/EmulatorApplicationTests.cs
@@ -124,7 +124,7 @@ public class EmulatorApplicationTests
 
         using var request = new HttpRequestMessage(
             HttpMethod.Head,
-            "/api/hubs/chat/groups/group?api-version=2024-12-01");
+            "/api/hubs/chat/users/user?api-version=2024-12-01");
         using var response = await application.GetTestClient().SendAsync(request).WaitAsync(TestTimeout);
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/ODataFilterExecutorTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/ODataFilterExecutorTests.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Xunit;
+
+namespace Microsoft.Azure.WebPubSub.Emulator.Tests;
+
+public class ODataFilterExecutorTests
+{
+    [Theory]
+    [InlineData("userId eq 'a'", "a", true)]
+    [InlineData("userId eq 'a'", "A", false)]
+    [InlineData("userId eq null", null, true)]
+    [InlineData("userId in ('user1', 'user2')", "user2", true)]
+    [InlineData("userId in ('Doe, John', 'Alice')", "Doe, John", true)]
+    [InlineData("userId in ('O''Brien, Jane', 'Alice')", "O'Brien, Jane", true)]
+    [InlineData("substring(userId, 1, 1) eq 'b'", "abc", true)]
+    [InlineData("substring(userId, 1) eq 'b'", "", false)]
+    [InlineData("substring(userId, 1, 2) eq 'bc'", "a", false)]
+    [InlineData("contains(userId, 'b')", "aaa", false)]
+    public void MatchesUserFilter(string filter, string? userId, bool expected)
+    {
+        var model = new TestModel { UserId = userId };
+
+        Assert.Equal(expected, ODataFilterExecutor.Instance.Matches(filter, model));
+    }
+
+    [Fact]
+    public void MatchesConnectionGroupAndProtocolFilter()
+    {
+        var model = new TestModel
+        {
+            ConnectionId = "connection-1",
+            Groups = ["group1", "group2"],
+            Protocol = "json.webpubsub.azure.v1",
+        };
+
+        Assert.True(ODataFilterExecutor.Instance.Matches(
+            "connectionId eq 'connection-1' and 'group2' in groups and " +
+            "protocol eq 'json.webpubsub.azure.v1'",
+            model));
+    }
+
+    [Theory]
+    [InlineData(
+        "( not 'a' )",
+        "Invalid syntax for 'not 'a'': Type 'string', expect 'bool'. (Parameter 'filter')")]
+    [InlineData(
+        "userId lt 1",
+        "Invalid syntax for 'userId lt 1': Type 'string', expect 'int'. (Parameter 'filter')")]
+    [InlineData(
+        "invalid(ab,c)",
+        "Invalid syntax for 'invalid(ab,c)': Token 'invalid(ab,c)' is not supported. (Parameter 'filter')")]
+    [InlineData(
+        "ab eq 1",
+        "Invalid syntax for 'ab eq 1': Token 'ab' is not supported. (Parameter 'filter')")]
+    public void ValidateInvalidFilterMatchesRuntimeError(string filter, string expectedError)
+    {
+        var exception = Assert.Throws<InvalidFilterException>(() =>
+            ODataFilterExecutor.Instance.Validate(filter));
+
+        Assert.Equal(expectedError, exception.Message);
+    }
+
+    [Fact]
+    public void ValidateSubstring_DoesNotDependOnValidationModelLength()
+    {
+        ODataFilterExecutor.Instance.Validate("substring(connectionId, 1) eq 'onnection-1'");
+    }
+
+    private sealed class TestModel : IODataFilterModel
+    {
+        public string ConnectionId { get; init; } = string.Empty;
+
+        public string? UserId { get; init; }
+
+        public string[] Groups { get; init; } = [];
+
+        public string? Protocol { get; init; }
+    }
+}

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/RestApiTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/RestApiTests.cs
@@ -157,6 +157,79 @@ public class RestApiTests
     }
 
     [Fact]
+    public async Task OfficialServerSdkCanCheckAndSendToGroup()
+    {
+        await using var application = EmulatorApplication.Build(
+            ["--urls=http://127.0.0.1:0"]);
+        await application.StartAsync().WaitAsync(TestTimeout);
+        var server = application.Services.GetRequiredService<IServer>();
+        var endpoint = Assert.Single(
+            server.Features.Get<IServerAddressesFeature>()!.Addresses);
+        var connectionString =
+            $"Endpoint={endpoint};AccessKey={EmulatorOptions.DefaultAccessKey};Version=1.0;";
+        var serviceClient = new WebPubSubServiceClient(connectionString, Hub);
+        using var firstSocket = new ClientWebSocket();
+        firstSocket.Options.AddSubProtocol(WebPubSubJsonV1PayloadProcessor.SubprotocolName);
+        await firstSocket.ConnectAsync(
+            serviceClient.GetClientAccessUri(),
+            CancellationToken.None).WaitAsync(TestTimeout);
+        using var firstConnected = await ReceiveJsonAsync(firstSocket);
+        var firstConnectionId = firstConnected.RootElement
+            .GetProperty("connectionId")
+            .GetString()!;
+        using var secondSocket = new ClientWebSocket();
+        secondSocket.Options.AddSubProtocol(WebPubSubJsonV1PayloadProcessor.SubprotocolName);
+        await secondSocket.ConnectAsync(
+            serviceClient.GetClientAccessUri(),
+            CancellationToken.None).WaitAsync(TestTimeout);
+        using var secondConnected = await ReceiveJsonAsync(secondSocket);
+        var secondConnectionId = secondConnected.RootElement
+            .GetProperty("connectionId")
+            .GetString()!;
+
+        Assert.False((await serviceClient.GroupExistsAsync("room")
+            .WaitAsync(TestTimeout)).Value);
+        await serviceClient.AddConnectionToGroupAsync("room", firstConnectionId)
+            .WaitAsync(TestTimeout);
+        await serviceClient.AddConnectionToGroupAsync("room", secondConnectionId)
+            .WaitAsync(TestTimeout);
+        Assert.True((await serviceClient.GroupExistsAsync("room")
+            .WaitAsync(TestTimeout)).Value);
+
+        var sendResponse = await serviceClient.SendToGroupAsync(
+            "room",
+            BinaryData.FromString("from-group-sdk"),
+            ContentType.TextPlain,
+            excluded: [secondConnectionId],
+            filter: $"connectionId eq '{firstConnectionId}'").WaitAsync(TestTimeout);
+        using var firstMessage = await ReceiveJsonAsync(firstSocket);
+
+        Assert.Equal((int)HttpStatusCode.Accepted, sendResponse.Status);
+        Assert.Equal("group", firstMessage.RootElement.GetProperty("from").GetString());
+        Assert.Equal("room", firstMessage.RootElement.GetProperty("group").GetString());
+        Assert.Equal("from-group-sdk", firstMessage.RootElement.GetProperty("data").GetString());
+
+        await serviceClient.SendToConnectionAsync(
+            secondConnectionId,
+            BinaryData.FromString("excluded"),
+            ContentType.TextPlain).WaitAsync(TestTimeout);
+        using var secondMessage = await ReceiveJsonAsync(secondSocket);
+        Assert.Equal("server", secondMessage.RootElement.GetProperty("from").GetString());
+        Assert.Equal("excluded", secondMessage.RootElement.GetProperty("data").GetString());
+
+        await serviceClient.RemoveConnectionFromGroupAsync("room", firstConnectionId)
+            .WaitAsync(TestTimeout);
+        await serviceClient.RemoveConnectionFromGroupAsync("room", secondConnectionId)
+            .WaitAsync(TestTimeout);
+        Assert.False((await serviceClient.GroupExistsAsync("room")
+            .WaitAsync(TestTimeout)).Value);
+        await serviceClient.SendToGroupAsync(
+            "missing",
+            BinaryData.FromString("ignored"),
+            ContentType.TextPlain).WaitAsync(TestTimeout);
+    }
+
+    [Fact]
     public async Task DetachedReliableMembershipChangesAffectGroupDeliveryAfterRecovery()
     {
         await using var application = await StartApplicationAsync();
@@ -205,6 +278,180 @@ public class RestApiTests
 
         Assert.Equal(HttpStatusCode.NoContent, removeResponse.StatusCode);
         Assert.False(connection.Groups.ContainsKey("Room"));
+    }
+
+    [Fact]
+    public async Task SendToGroupQueuesForDetachedReliableConnection()
+    {
+        await using var application = await StartApplicationAsync();
+        var initial = await ConnectReliableAsync(application);
+        using var initialSocket = initial.WebSocket;
+        var manager = application.Services.GetRequiredService<ConnectionManager>();
+        Assert.True(manager.TryGet(Hub, initial.ConnectionId, out var connection));
+        Assert.True(connection.TryAddToGroup("room"));
+        initialSocket.Abort();
+        var path = "/api/hubs/CHAT/groups/room/:send" +
+            "?api-version=2024-12-01&messageTtlSeconds=1";
+        using var request = CreateAuthorizedRequest(HttpMethod.Post, path);
+        request.Content = new StringContent(
+            """{"value":42}""",
+            Encoding.UTF8,
+            "application/json");
+        request.Headers.Add("X-WebPubSub-Metadata-Trace", "group-send");
+
+        using var response = await application.GetTestClient()
+            .SendAsync(request)
+            .WaitAsync(TestTimeout);
+        using var recovered = await ConnectRecoveryAsync(
+            application,
+            initial.ConnectionId,
+            initial.ReconnectionToken);
+        using var delivered = await ReceiveJsonAsync(recovered);
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        Assert.Equal("group", delivered.RootElement.GetProperty("from").GetString());
+        Assert.Equal("room", delivered.RootElement.GetProperty("group").GetString());
+        Assert.Equal("json", delivered.RootElement.GetProperty("dataType").GetString());
+        Assert.Equal(
+            42,
+            delivered.RootElement.GetProperty("data").GetProperty("value").GetInt32());
+        Assert.Equal(
+            "group-send",
+            delivered.RootElement.GetProperty("metadata").GetProperty("trace").GetString());
+    }
+
+    [Fact]
+    public async Task GroupExistsMissingResponseUsesServiceErrorCode()
+    {
+        await using var application = await StartApplicationAsync();
+        const string path =
+            "/api/hubs/chat/groups/missing?api-version=2024-12-01";
+        using var request = CreateAuthorizedRequest(HttpMethod.Head, path);
+
+        using var response = await application.GetTestClient()
+            .SendAsync(request)
+            .WaitAsync(TestTimeout);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.Equal(
+            "Warning.Group.NotExisted",
+            response.Headers.GetValues("x-ms-error-code").Single());
+    }
+
+    [Fact]
+    public async Task SendToGroupAppliesFilterAndExclusions()
+    {
+        await using var application = await StartApplicationAsync();
+        using var matchingSocket = await ConnectAsync(application);
+        using var matchingConnected = await ReceiveJsonAsync(matchingSocket);
+        var matchingConnectionId = matchingConnected.RootElement
+            .GetProperty("connectionId")
+            .GetString()!;
+        using var excludedSocket = await ConnectAsync(application);
+        using var excludedConnected = await ReceiveJsonAsync(excludedSocket);
+        var excludedConnectionId = excludedConnected.RootElement
+            .GetProperty("connectionId")
+            .GetString()!;
+        using var nonmatchingSocket = await ConnectAsync(application);
+        using var nonmatchingConnected = await ReceiveJsonAsync(nonmatchingSocket);
+        var nonmatchingConnectionId = nonmatchingConnected.RootElement
+            .GetProperty("connectionId")
+            .GetString()!;
+        var manager = application.Services.GetRequiredService<ConnectionManager>();
+        Assert.True(manager.AddConnectionToGroup(Hub, "room", matchingConnectionId));
+        Assert.True(manager.AddConnectionToGroup(Hub, "room", excludedConnectionId));
+        Assert.True(manager.AddConnectionToGroup(Hub, "room", nonmatchingConnectionId));
+        var filter = $"connectionId in ('{matchingConnectionId}','{excludedConnectionId}') " +
+            "and 'room' in groups and protocol eq 'json.webpubsub.azure.v1'";
+        var path = "/api/hubs/chat/groups/room/:send?api-version=2024-12-01" +
+            $"&excluded={Uri.EscapeDataString(excludedConnectionId)}" +
+            $"&filter={Uri.EscapeDataString(filter)}";
+        using var request = CreateAuthorizedRequest(HttpMethod.Post, path);
+        request.Content = new StringContent("filtered", Encoding.UTF8, "text/plain");
+
+        using var response = await application.GetTestClient()
+            .SendAsync(request)
+            .WaitAsync(TestTimeout);
+        using var delivered = await ReceiveJsonAsync(matchingSocket);
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        Assert.Equal("filtered", delivered.RootElement.GetProperty("data").GetString());
+
+        await AssertReceivesDirectSentinelAsync(
+            application,
+            excludedSocket,
+            excludedConnectionId,
+            "excluded-sentinel");
+        await AssertReceivesDirectSentinelAsync(
+            application,
+            nonmatchingSocket,
+            nonmatchingConnectionId,
+            "nonmatching-sentinel");
+    }
+
+    [Fact]
+    public async Task SendToGroupFilterAppliesToDetachedReliableConnection()
+    {
+        await using var application = await StartApplicationAsync();
+        var initial = await ConnectReliableAsync(application);
+        using var initialSocket = initial.WebSocket;
+        var manager = application.Services.GetRequiredService<ConnectionManager>();
+        Assert.True(manager.TryGet(Hub, initial.ConnectionId, out var connection));
+        Assert.True(connection.TryAddToGroup("room"));
+        initialSocket.Abort();
+        var filter = $"connectionId eq '{initial.ConnectionId}' and 'room' in groups and " +
+            "protocol eq 'json.reliable.webpubsub.azure.v1'";
+        var path = "/api/hubs/chat/groups/room/:send?api-version=2024-12-01" +
+            $"&filter={Uri.EscapeDataString(filter)}";
+        using var request = CreateAuthorizedRequest(HttpMethod.Post, path);
+        request.Content = new StringContent("filtered-replay", Encoding.UTF8, "text/plain");
+
+        using var response = await application.GetTestClient()
+            .SendAsync(request)
+            .WaitAsync(TestTimeout);
+        using var recovered = await ConnectRecoveryAsync(
+            application,
+            initial.ConnectionId,
+            initial.ReconnectionToken);
+        using var delivered = await ReceiveJsonAsync(recovered);
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        Assert.Equal("filtered-replay", delivered.RootElement.GetProperty("data").GetString());
+    }
+
+    [Fact]
+    public async Task SendToGroupRejectsInvalidFilterBeforeReadingBody()
+    {
+        await using var application = await StartApplicationAsync();
+        using var webSocket = await ConnectAsync(application);
+        using var connected = await ReceiveJsonAsync(webSocket);
+        var connectionId = connected.RootElement.GetProperty("connectionId").GetString()!;
+        var manager = application.Services.GetRequiredService<ConnectionManager>();
+        Assert.True(manager.AddConnectionToGroup(Hub, "room", connectionId));
+        const string path = "/api/hubs/chat/groups/room/:send" +
+            "?api-version=2024-12-01&filter=userId%20lt%201";
+        using var request = CreateAuthorizedRequest(HttpMethod.Post, path);
+        request.Content = new UnknownLengthContent("ignored"u8.ToArray());
+        request.Content.Headers.ContentType = new MediaTypeHeaderValue("text/plain");
+
+        using var response = await application.GetTestClient()
+            .SendAsync(request)
+            .WaitAsync(TestTimeout);
+        using var error = JsonDocument.Parse(
+            await response.Content.ReadAsByteArrayAsync().WaitAsync(TestTimeout));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("Error.BadRequest", error.RootElement.GetProperty("code").GetString());
+        Assert.Equal("Request", error.RootElement.GetProperty("target").GetString());
+        Assert.Equal(
+            "Invalid syntax for 'userId lt 1': Type 'string', expect 'int'. " +
+            "(Parameter 'filter')",
+            error.RootElement.GetProperty("message").GetString());
+            await AssertReceivesDirectSentinelAsync(
+                application,
+                webSocket,
+                connectionId,
+                "invalid-filter-sentinel");
     }
 
     [Fact]
@@ -863,6 +1110,24 @@ public class RestApiTests
             "Bearer",
             CreateToken($"http://localhost{path}"));
         return request;
+    }
+
+    private static async Task AssertReceivesDirectSentinelAsync(
+        WebApplication application,
+        WebSocket webSocket,
+        string connectionId,
+        string sentinel)
+    {
+        var path = $"/api/hubs/chat/connections/{connectionId}/:send?api-version=2024-12-01";
+        using var request = CreateAuthorizedRequest(HttpMethod.Post, path);
+        request.Content = new StringContent(sentinel, Encoding.UTF8, "text/plain");
+        using var response = await application.GetTestClient()
+            .SendAsync(request)
+            .WaitAsync(TestTimeout);
+        using var delivered = await ReceiveJsonAsync(webSocket);
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        Assert.Equal(sentinel, delivered.RootElement.GetProperty("data").GetString());
     }
 
     private static string CreateToken(string audience)


### PR DESCRIPTION
## Summary

- add service-compatible group existence checks, including the missing-group response header
- add authenticated group sends for text, JSON, and binary payloads with exclusions and accepted TTL parameters
- evaluate OData filters over connection ID, user ID, groups, and protocol for active and detached reliable connections
- add official server SDK, REST integration, and filter evaluator coverage, and update emulator documentation

## Validation

- `dotnet test tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/Microsoft.Azure.WebPubSub.Emulator.Tests.csproj --configuration Release --no-restore` (149 passed)
- `git show --check HEAD`

Part of #1048.