### PR TITLE
Emulator: support broadcast and user sends

### DIFF
--- a/tools/emulator/CHANGELOG.md
+++ b/tools/emulator/CHANGELOG.md
@@ -16,3 +16,5 @@
 - Add authenticated REST and official .NET server SDK support for closing a connection.
 - Add authenticated REST and official .NET server SDK support for adding and removing a connection from a group.
 - Add authenticated REST and official .NET server SDK support for checking group presence and sending to a group with excluded connection IDs and OData filters.
+- Add authenticated REST and official .NET server SDK support for broadcasting with excluded connection IDs and OData filters.
+- Add authenticated REST and official .NET server SDK support for checking user presence and sending to all of a user's connections with OData filters.

--- a/tools/emulator/README.md
+++ b/tools/emulator/README.md
@@ -61,10 +61,10 @@ emulator process. The replay buffer is limited to 1,000 messages and 16 MiB per 
 
 ## Use a server SDK
 
-The emulator supports checking whether connections and groups exist, sending text, JSON, or binary
-data to connections and groups, changing connection group membership, and closing a connection
-through the Azure Web PubSub REST API. For example, use the generated connection string with the
-Azure Web PubSub .NET server SDK:
+The emulator supports checking whether connections, users, and groups exist, broadcasting or
+sending text, JSON, or binary data to connections, users, and groups, changing connection group
+membership, and closing a connection through the Azure Web PubSub REST API. For example, use the
+generated connection string with the Azure Web PubSub .NET server SDK:
 
 ```csharp
 using Azure.Core;
@@ -74,11 +74,22 @@ var serviceClient = new WebPubSubServiceClient(
   "Endpoint=http://localhost:8080;AccessKey=ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGH;Version=1.0;",
   "chat");
 
+await serviceClient.SendToAllAsync(
+  BinaryData.FromString("Hello, everyone"),
+  ContentType.TextPlain,
+  excluded: new[] { connectionId },
+  filter: "protocol eq 'json.webpubsub.azure.v1'");
 bool exists = await serviceClient.ConnectionExistsAsync(connectionId);
 await serviceClient.SendToConnectionAsync(
   connectionId,
   BinaryData.FromString("Hello"),
   ContentType.TextPlain);
+bool userExists = await serviceClient.UserExistsAsync(userId);
+await serviceClient.SendToUserAsync(
+  userId,
+  RequestContent.Create(BinaryData.FromString("Hello, user")),
+  ContentType.TextPlain,
+  filter: "protocol eq 'json.webpubsub.azure.v1'");
 await serviceClient.AddConnectionToGroupAsync("room", connectionId);
 bool groupExists = await serviceClient.GroupExistsAsync("room");
 await serviceClient.SendToGroupAsync(
@@ -90,11 +101,12 @@ await serviceClient.RemoveConnectionFromGroupAsync("room", connectionId);
 await serviceClient.CloseConnectionAsync(connectionId, "Done");
 ```
 
-Connection and group sends return success when the target does not exist, matching the service's
-fire-and-forget behavior. Group sends support repeated `excluded` connection IDs and OData `filter`
-expressions over `connectionId`, `userId`, `groups`, and `protocol`. Invalid filters return an
-`Error.BadRequest` response before the message body is processed. Valid `messageTtlSeconds` values
-are accepted, but the emulator does not model message expiration.
+Connection, user, and group sends return success when the target does not exist, matching the
+service's fire-and-forget behavior. Broadcast and group sends support repeated `excluded`
+connection IDs. Broadcast, user, and group sends support OData `filter` expressions over
+`connectionId`, `userId`, `groups`, and `protocol`. Invalid filters return an `Error.BadRequest`
+response before the message body is processed. Valid `messageTtlSeconds` values are accepted, but
+the emulator does not model message expiration.
 
 Set the ASP.NET Core `Urls` configuration value to use another address. The generated connection
 string automatically uses the address and port that the emulator actually binds. For example:

--- a/tools/emulator/SUPPORTED_FEATURES.md
+++ b/tools/emulator/SUPPORTED_FEATURES.md
@@ -19,8 +19,10 @@ local Azure Web PubSub development.
 | Outbound delivery | Uses a bounded, single-writer queue for each WebSocket connection. | ✅ |
 | REST connection operations | Authenticated connection presence, direct text, JSON, and binary sends, close, and single-connection group membership changes for GA API versions from `2021-10-01` through `2024-12-01`. | ✅ |
 | REST group operations | Authenticated group presence and text, JSON, or binary fan-out with excluded connection IDs and OData filters. | ✅ |
+| REST broadcast | Authenticated text, JSON, or binary fan-out with excluded connection IDs and OData filters. | ✅ |
+| REST user operations | Authenticated user presence and text, JSON, or binary fan-out to all matching connections with OData filters. | ✅ |
 | REST send TTL | Accepts valid `messageTtlSeconds` values; delivery is immediate and expiration is not modeled. | ⚠️ |
-| Other REST APIs | User, permission, and broadcast operations. | ❌ |
+| Other REST APIs | User-group and permission operations. | ❌ |
 
 ## Not yet implemented
 

--- a/tools/emulator/SUPPORTED_FEATURES.md
+++ b/tools/emulator/SUPPORTED_FEATURES.md
@@ -24,15 +24,24 @@ local Azure Web PubSub development.
 | REST send TTL | Accepts valid `messageTtlSeconds` values; delivery is immediate and expiration is not modeled. | ⚠️ |
 | Other REST APIs | User-group and permission operations. | ❌ |
 
-REST user operations pass ASP.NET Core route-bound user IDs through unchanged, matching the
-current runtime implementation rather than adding another URL-decoding step. In particular,
-`tenant%2Falice` in the request path targets the literal user ID `tenant%2Falice`, not
-`tenant/alice`.
-A slash-containing user ID can still be used in a client token, but these REST user operations
-do not resolve `%2F` to a slash in that ID.
-Separately, double-encoded paths such as `tenant%252Falice` currently return `401` when the
-access-key token audience uses the original request URL. This existing emulator authentication
-limitation is not changed by preserving runtime route binding.
+For the currently supported API versions (`2021-10-01` through `2024-12-01`) and versionless
+requests, REST user operations preserve the legacy runtime route-binding behavior and pass the
+ASP.NET Core route value through without another URL-decoding step. For example:
+
+| Request path segment | User ID targeted by current API versions |
+| --- | --- |
+| `tenant%2Falice` | `tenant%2Falice` (not `tenant/alice`) |
+| `tenant%252Falice` | `tenant%2Falice` |
+| `alice%20smith` | `alice smith` |
+| `alice+bob` | `alice+bob` (not `alice bob`) |
+
+As in the runtime, access-key authentication compares a URL-decoded token audience with the
+request path, allowing a token created from the original `tenant%252Falice` URL to authenticate
+while preserving the legacy route value above.
+
+Support for this behavior in a new API version is planned. The new version will adopt the
+runtime's new contract and decode the original user ID path segment exactly once: for example,
+`tenant%2Falice` targets `tenant/alice`, while `tenant%252Falice` targets `tenant%2Falice`.
 
 ## Not yet implemented
 

--- a/tools/emulator/SUPPORTED_FEATURES.md
+++ b/tools/emulator/SUPPORTED_FEATURES.md
@@ -24,6 +24,16 @@ local Azure Web PubSub development.
 | REST send TTL | Accepts valid `messageTtlSeconds` values; delivery is immediate and expiration is not modeled. | ⚠️ |
 | Other REST APIs | User-group and permission operations. | ❌ |
 
+REST user operations pass ASP.NET Core route-bound user IDs through unchanged, matching the
+current runtime implementation rather than adding another URL-decoding step. In particular,
+`tenant%2Falice` in the request path targets the literal user ID `tenant%2Falice`, not
+`tenant/alice`.
+A slash-containing user ID can still be used in a client token, but these REST user operations
+do not resolve `%2F` to a slash in that ID.
+Separately, double-encoded paths such as `tenant%252Falice` currently return `401` when the
+access-key token audience uses the original request URL. This existing emulator authentication
+limitation is not changed by preserving runtime route binding.
+
 ## Not yet implemented
 
 The following areas are planned for follow-up changes:

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ConnectionManager.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ConnectionManager.cs
@@ -68,9 +68,41 @@ internal sealed class ConnectionManager
         return GetHubConnections(hub).Any(connection => connection.Groups.ContainsKey(group));
     }
 
+    public bool UserExists(string hub, string userId)
+    {
+        return GetUserConnections(hub, userId).Any();
+    }
+
+    public void SendToAll(
+        string hub,
+        MessageData data,
+        IReadOnlySet<string>? excludedConnectionIds = null,
+        string? filter = null)
+    {
+        foreach (var connection in GetHubConnections(hub)
+            .Where(connection => excludedConnectionIds?.Contains(connection.ConnectionId) != true)
+            .Where(connection => ODataFilterExecutor.Instance.Matches(filter, connection)))
+        {
+            connection.SendServerData(data);
+        }
+    }
+
     public void SendToConnection(string hub, string connectionId, MessageData data)
     {
         if (_connections.TryGetValue((hub, connectionId), out var connection))
+        {
+            connection.SendServerData(data);
+        }
+    }
+
+    public void SendToUser(
+        string hub,
+        string userId,
+        MessageData data,
+        string? filter = null)
+    {
+        foreach (var connection in GetUserConnections(hub, userId)
+            .Where(connection => ODataFilterExecutor.Instance.Matches(filter, connection)))
         {
             connection.SendServerData(data);
         }
@@ -141,6 +173,15 @@ internal sealed class ConnectionManager
         return _connections
             .Where(item => string.Equals(item.Key.Hub, hub, StringComparison.Ordinal))
             .Select(item => item.Value);
+    }
+
+    private IEnumerable<LogicalConnection> GetUserConnections(string hub, string userId)
+    {
+        return GetHubConnections(hub)
+            .Where(connection => string.Equals(
+                connection.UserId,
+                userId,
+                StringComparison.Ordinal));
     }
 
     private async Task ExpireAsync(LogicalConnection connection, long generation)

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubEmulatorController.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubEmulatorController.cs
@@ -5,6 +5,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Text;
 using System.Text.Json;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Microsoft.Azure.WebPubSub.Emulator;
@@ -32,6 +33,49 @@ internal sealed class WebPubSubEmulatorController : WebPubSubApiControllerDefini
         CancellationToken cancellationToken = default)
     {
         return Task.FromResult<IActionResult>(Ok());
+    }
+
+    [HttpPost(
+        "/api/hubs/{hub}/:send",
+        Name = "WebPubSub_SendToAll")]
+    public async Task<IActionResult> SendToAll(
+        [RegularExpression(
+            WebPubSubNameValidator.HubNamePattern,
+            ErrorMessage = "Invalid hub name.")]
+        string hub,
+        [FromQuery(Name = "messageTtlSeconds")]
+        [Range(0, MaximumMessageTtlSeconds, ErrorMessage = "Invalid messageTtlSeconds.")]
+        uint? messageTtlSeconds,
+        [FromQuery(Name = "filter")]
+        string? filter,
+        CancellationToken cancellationToken = default)
+    {
+        if (!Authorize())
+        {
+            return Unauthorized();
+        }
+
+        try
+        {
+            ODataFilterExecutor.Instance.Validate(filter);
+        }
+        catch (InvalidFilterException exception)
+        {
+            return CreateBadRequest(exception.Message);
+        }
+
+        var (data, error) = await ReadMessageDataAsync(cancellationToken);
+        if (error is not null)
+        {
+            return error;
+        }
+
+        _connections.SendToAll(
+            hub.ToLowerInvariant(),
+            data!,
+            GetExcludedConnectionIds(),
+            filter);
+        return Accepted();
     }
 
     [HttpHead(
@@ -117,6 +161,78 @@ internal sealed class WebPubSubEmulatorController : WebPubSubApiControllerDefini
             hub.ToLowerInvariant(),
             connectionId,
             data!);
+        return Accepted();
+    }
+
+    [HttpHead(
+        "/api/hubs/{hub}/users/{userId}",
+        Name = "WebPubSub_UserExists")]
+    public IActionResult UserExists(
+        [RegularExpression(
+            WebPubSubNameValidator.HubNamePattern,
+            ErrorMessage = "Invalid hub name.")]
+        string hub,
+        [MinLength(1, ErrorMessage = "Invalid user ID.")]
+        string userId,
+        CancellationToken cancellationToken = default)
+    {
+        if (!Authorize())
+        {
+            return Unauthorized();
+        }
+
+        userId = DecodeUserId(userId);
+        if (_connections.UserExists(hub.ToLowerInvariant(), userId))
+        {
+            return Ok();
+        }
+
+        Response.Headers["x-ms-error-code"] = "Warning.User.NotExisted";
+        return NotFound();
+    }
+
+    [HttpPost(
+        "/api/hubs/{hub}/users/{userId}/:send",
+        Name = "WebPubSub_SendToUser")]
+    public async Task<IActionResult> SendToUser(
+        [RegularExpression(
+            WebPubSubNameValidator.HubNamePattern,
+            ErrorMessage = "Invalid hub name.")]
+        string hub,
+        [MinLength(1, ErrorMessage = "Invalid user ID.")]
+        string userId,
+        [FromQuery(Name = "messageTtlSeconds")]
+        [Range(0, MaximumMessageTtlSeconds, ErrorMessage = "Invalid messageTtlSeconds.")]
+        uint? messageTtlSeconds,
+        [FromQuery(Name = "filter")]
+        string? filter,
+        CancellationToken cancellationToken = default)
+    {
+        if (!Authorize())
+        {
+            return Unauthorized();
+        }
+
+        try
+        {
+            ODataFilterExecutor.Instance.Validate(filter);
+        }
+        catch (InvalidFilterException exception)
+        {
+            return CreateBadRequest(exception.Message);
+        }
+
+        var (data, error) = await ReadMessageDataAsync(cancellationToken);
+        if (error is not null)
+        {
+            return error;
+        }
+
+        _connections.SendToUser(
+            hub.ToLowerInvariant(),
+            DecodeUserId(userId),
+            data!,
+            filter);
         return Accepted();
     }
 
@@ -322,6 +438,29 @@ internal sealed class WebPubSubEmulatorController : WebPubSubApiControllerDefini
             .Where(value => value is not null)
             .Select(value => value!)
             .ToHashSet(StringComparer.Ordinal);
+    }
+
+    private string DecodeUserId(string userId)
+    {
+        var rawTarget = HttpContext.Features.Get<IHttpRequestFeature>()?.RawTarget;
+        if (string.IsNullOrEmpty(rawTarget))
+        {
+            return userId.Replace("%2F", "/", StringComparison.OrdinalIgnoreCase);
+        }
+
+        const string userSegment = "/users/";
+        var userStart = rawTarget.IndexOf(userSegment, StringComparison.OrdinalIgnoreCase);
+        if (userStart < 0)
+        {
+            return userId;
+        }
+
+        userStart += userSegment.Length;
+        var userEnd = rawTarget.IndexOfAny(['/', '?'], userStart);
+        var rawUserId = userEnd < 0
+            ? rawTarget[userStart..]
+            : rawTarget[userStart..userEnd];
+        return Uri.UnescapeDataString(rawUserId);
     }
 
     private async Task<(MessageData? Data, IActionResult? Error)> ReadMessageDataAsync(

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubEmulatorController.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubEmulatorController.cs
@@ -5,7 +5,6 @@ using System.ComponentModel.DataAnnotations;
 using System.Text;
 using System.Text.Json;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Microsoft.Azure.WebPubSub.Emulator;
@@ -181,7 +180,6 @@ internal sealed class WebPubSubEmulatorController : WebPubSubApiControllerDefini
             return Unauthorized();
         }
 
-        userId = DecodeUserId(userId);
         if (_connections.UserExists(hub.ToLowerInvariant(), userId))
         {
             return Ok();
@@ -230,7 +228,7 @@ internal sealed class WebPubSubEmulatorController : WebPubSubApiControllerDefini
 
         _connections.SendToUser(
             hub.ToLowerInvariant(),
-            DecodeUserId(userId),
+            userId,
             data!,
             filter);
         return Accepted();
@@ -438,29 +436,6 @@ internal sealed class WebPubSubEmulatorController : WebPubSubApiControllerDefini
             .Where(value => value is not null)
             .Select(value => value!)
             .ToHashSet(StringComparer.Ordinal);
-    }
-
-    private string DecodeUserId(string userId)
-    {
-        var rawTarget = HttpContext.Features.Get<IHttpRequestFeature>()?.RawTarget;
-        if (string.IsNullOrEmpty(rawTarget))
-        {
-            return userId.Replace("%2F", "/", StringComparison.OrdinalIgnoreCase);
-        }
-
-        const string userSegment = "/users/";
-        var userStart = rawTarget.IndexOf(userSegment, StringComparison.OrdinalIgnoreCase);
-        if (userStart < 0)
-        {
-            return userId;
-        }
-
-        userStart += userSegment.Length;
-        var userEnd = rawTarget.IndexOfAny(['/', '?'], userStart);
-        var rawUserId = userEnd < 0
-            ? rawTarget[userStart..]
-            : rawTarget[userStart..userEnd];
-        return Uri.UnescapeDataString(rawUserId);
     }
 
     private async Task<(MessageData? Data, IActionResult? Error)> ReadMessageDataAsync(

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubTokenService.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubTokenService.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.IdentityModel.Tokens.Jwt;
+using System.Net;
 using System.Security.Claims;
 using System.Text;
 using Microsoft.Extensions.Logging;
@@ -97,7 +98,11 @@ internal sealed class WebPubSubTokenService
                 {
                     var parameters = CreateValidationParameters(audience);
                     parameters.AudienceValidator = (audiences, _, _) => audiences.Any(
-                        input => string.Equals(input, audience, StringComparison.OrdinalIgnoreCase));
+                        input => string.Equals(input, audience, StringComparison.OrdinalIgnoreCase) ||
+                            string.Equals(
+                                WebUtility.UrlDecode(input),
+                                audience,
+                                StringComparison.OrdinalIgnoreCase));
                     _handler.ValidateToken(
                         token,
                         parameters,

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/EmulatorApplicationTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/EmulatorApplicationTests.cs
@@ -115,7 +115,7 @@ public class EmulatorApplicationTests
     }
 
     [Fact]
-    public async Task OtherServiceApiEndpoint_HeadReturnsNotFound()
+    public async Task UnimplementedPermissionEndpoint_HeadReturnsNotFound()
     {
         var builder = EmulatorApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
@@ -124,7 +124,8 @@ public class EmulatorApplicationTests
 
         using var request = new HttpRequestMessage(
             HttpMethod.Head,
-            "/api/hubs/chat/users/user?api-version=2024-12-01");
+            "/api/hubs/chat/connections/connection/permissions/sendToGroup/room" +
+                "?api-version=2024-12-01");
         using var response = await application.GetTestClient().SendAsync(request).WaitAsync(TestTimeout);
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/RestApiTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/RestApiTests.cs
@@ -452,7 +452,9 @@ public class RestApiTests
     [Theory]
     [InlineData("tenant%2Falice", "tenant%2Falice", HttpStatusCode.NotFound)]
     [InlineData("tenant%2falice", "tenant%2falice", HttpStatusCode.NotFound)]
-    [InlineData("tenant%252Falice", "tenant%2Falice", HttpStatusCode.Unauthorized)]
+    [InlineData("tenant%252Falice", "tenant%2Falice", HttpStatusCode.NotFound)]
+    [InlineData("alice%20smith", "alice smith", HttpStatusCode.NotFound)]
+    [InlineData("alice+bob", "alice+bob", HttpStatusCode.NotFound)]
     public async Task UserRestApisPreserveEncodedUserCompatibility(
         string userPathSegment,
         string boundUserId,
@@ -491,10 +493,7 @@ public class RestApiTests
         using var missingSendRequest = CreateUserRequest(HttpMethod.Post, sendPath);
         missingSendRequest.Content = new StringContent("missing-user-send", Encoding.UTF8, "text/plain");
         using var missingSendResponse = await httpClient.SendAsync(missingSendRequest).WaitAsync(TestTimeout);
-        var sendStatus = missingStatus == HttpStatusCode.Unauthorized
-            ? HttpStatusCode.Unauthorized
-            : HttpStatusCode.Accepted;
-        Assert.Equal(sendStatus, missingSendResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.Accepted, missingSendResponse.StatusCode);
 
         // A literal percent-encoded user is distinct from the user containing a slash.
         using var literalSocket = new ClientWebSocket();
@@ -506,26 +505,13 @@ public class RestApiTests
         Assert.Equal(boundUserId, literalConnected.RootElement.GetProperty("userId").GetString());
         using var existsRequest = CreateUserRequest(HttpMethod.Head, existsPath);
         using var existsResponse = await httpClient.SendAsync(existsRequest).WaitAsync(TestTimeout);
-        // Double-encoded paths currently fail audience validation even with the literal user online.
-        // Keep that existing limitation separate from route binding; do not change authentication here.
-        Assert.Equal(
-            missingStatus == HttpStatusCode.Unauthorized ? HttpStatusCode.Unauthorized : HttpStatusCode.OK,
-            existsResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, existsResponse.StatusCode);
         using var sendRequest = CreateUserRequest(HttpMethod.Post, sendPath);
         sendRequest.Content = new StringContent("literal-user-send", Encoding.UTF8, "text/plain");
         using var sendResponse = await httpClient.SendAsync(sendRequest).WaitAsync(TestTimeout);
-        Assert.Equal(sendStatus, sendResponse.StatusCode);
-        if (sendStatus == HttpStatusCode.Unauthorized)
-        {
-            await serviceClient.SendToConnectionAsync(
-                literalConnected.RootElement.GetProperty("connectionId").GetString()!,
-                BinaryData.FromString("literal-user-sentinel"),
-                ContentType.TextPlain).WaitAsync(TestTimeout);
-        }
+        Assert.Equal(HttpStatusCode.Accepted, sendResponse.StatusCode);
         using var delivered = await ReceiveJsonAsync(literalSocket);
-        Assert.Equal(
-            sendStatus == HttpStatusCode.Unauthorized ? "literal-user-sentinel" : "literal-user-send",
-            delivered.RootElement.GetProperty("data").GetString());
+        Assert.Equal("literal-user-send", delivered.RootElement.GetProperty("data").GetString());
 
         await serviceClient.SendToConnectionAsync(
             slashConnectionId,

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/RestApiTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/RestApiTests.cs
@@ -9,6 +9,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.WebSockets;
+using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
@@ -154,6 +155,390 @@ public class RestApiTests
             "room",
             "missing").WaitAsync(TestTimeout);
         Assert.Equal((int)HttpStatusCode.NoContent, missingRemoveResponse.Status);
+    }
+
+    [Fact]
+    public async Task OfficialServerSdkCanSendToAllWithFilterAndExclusions()
+    {
+        await using var application = EmulatorApplication.Build(
+            ["--urls=http://127.0.0.1:0"]);
+        await application.StartAsync().WaitAsync(TestTimeout);
+        var server = application.Services.GetRequiredService<IServer>();
+        var endpoint = Assert.Single(
+            server.Features.Get<IServerAddressesFeature>()!.Addresses);
+        var connectionString =
+            $"Endpoint={endpoint};AccessKey={EmulatorOptions.DefaultAccessKey};Version=1.0;";
+        var serviceClient = new WebPubSubServiceClient(connectionString, Hub);
+        using var matchingSocket = new ClientWebSocket();
+        matchingSocket.Options.AddSubProtocol(WebPubSubJsonV1PayloadProcessor.SubprotocolName);
+        await matchingSocket.ConnectAsync(
+            serviceClient.GetClientAccessUri(),
+            CancellationToken.None).WaitAsync(TestTimeout);
+        using var matchingConnected = await ReceiveJsonAsync(matchingSocket);
+        var matchingConnectionId = matchingConnected.RootElement
+            .GetProperty("connectionId")
+            .GetString()!;
+        using var excludedSocket = new ClientWebSocket();
+        excludedSocket.Options.AddSubProtocol(WebPubSubJsonV1PayloadProcessor.SubprotocolName);
+        await excludedSocket.ConnectAsync(
+            serviceClient.GetClientAccessUri(),
+            CancellationToken.None).WaitAsync(TestTimeout);
+        using var excludedConnected = await ReceiveJsonAsync(excludedSocket);
+        var excludedConnectionId = excludedConnected.RootElement
+            .GetProperty("connectionId")
+            .GetString()!;
+        using var secondExcludedSocket = new ClientWebSocket();
+        secondExcludedSocket.Options.AddSubProtocol(WebPubSubJsonV1PayloadProcessor.SubprotocolName);
+        await secondExcludedSocket.ConnectAsync(
+            serviceClient.GetClientAccessUri(),
+            CancellationToken.None).WaitAsync(TestTimeout);
+        using var secondExcludedConnected = await ReceiveJsonAsync(secondExcludedSocket);
+        var secondExcludedConnectionId = secondExcludedConnected.RootElement
+            .GetProperty("connectionId")
+            .GetString()!;
+        using var nonmatchingSocket = new ClientWebSocket();
+        nonmatchingSocket.Options.AddSubProtocol(WebPubSubJsonV1PayloadProcessor.SubprotocolName);
+        await nonmatchingSocket.ConnectAsync(
+            serviceClient.GetClientAccessUri(),
+            CancellationToken.None).WaitAsync(TestTimeout);
+        using var nonmatchingConnected = await ReceiveJsonAsync(nonmatchingSocket);
+        var nonmatchingConnectionId = nonmatchingConnected.RootElement
+            .GetProperty("connectionId")
+            .GetString()!;
+        var filter = $"connectionId in ('{matchingConnectionId}','{excludedConnectionId}'," +
+            $"'{secondExcludedConnectionId}')";
+
+        var sendResponse = await serviceClient.SendToAllAsync(
+            BinaryData.FromString("from-broadcast-sdk"),
+            ContentType.TextPlain,
+            excluded: [excludedConnectionId, secondExcludedConnectionId],
+            filter: filter).WaitAsync(TestTimeout);
+        using var matchingMessage = await ReceiveJsonAsync(matchingSocket);
+
+        Assert.Equal((int)HttpStatusCode.Accepted, sendResponse.Status);
+        Assert.Equal("server", matchingMessage.RootElement.GetProperty("from").GetString());
+        Assert.Equal(
+            "from-broadcast-sdk",
+            matchingMessage.RootElement.GetProperty("data").GetString());
+
+        await serviceClient.SendToConnectionAsync(
+            excludedConnectionId,
+            BinaryData.FromString("excluded-sentinel"),
+            ContentType.TextPlain).WaitAsync(TestTimeout);
+        using var excludedMessage = await ReceiveJsonAsync(excludedSocket);
+        Assert.Equal(
+            "excluded-sentinel",
+            excludedMessage.RootElement.GetProperty("data").GetString());
+
+        await serviceClient.SendToConnectionAsync(
+            secondExcludedConnectionId,
+            BinaryData.FromString("second-excluded-sentinel"),
+            ContentType.TextPlain).WaitAsync(TestTimeout);
+        using var secondExcludedMessage = await ReceiveJsonAsync(secondExcludedSocket);
+        Assert.Equal(
+            "second-excluded-sentinel",
+            secondExcludedMessage.RootElement.GetProperty("data").GetString());
+
+        await serviceClient.SendToConnectionAsync(
+            nonmatchingConnectionId,
+            BinaryData.FromString("nonmatching-sentinel"),
+            ContentType.TextPlain).WaitAsync(TestTimeout);
+        using var nonmatchingMessage = await ReceiveJsonAsync(nonmatchingSocket);
+        Assert.Equal(
+            "nonmatching-sentinel",
+            nonmatchingMessage.RootElement.GetProperty("data").GetString());
+
+        var emptyHubClient = new WebPubSubServiceClient(connectionString, "empty");
+        var emptyHubResponse = await emptyHubClient.SendToAllAsync(
+            BinaryData.FromString("ignored"),
+            ContentType.TextPlain).WaitAsync(TestTimeout);
+        Assert.Equal((int)HttpStatusCode.Accepted, emptyHubResponse.Status);
+    }
+
+    [Fact]
+    public async Task SendToAllPreservesRawBinaryPayload()
+    {
+        await using var application = await StartApplicationAsync();
+        using var webSocket = await ConnectRawAsync(application);
+        var payload = new byte[] { 0, 1, 2, 3 };
+        const string path = "/api/hubs/CHAT/:send" +
+            "?api-version=2024-12-01&messageTtlSeconds=1";
+        using var request = CreateAuthorizedRequest(HttpMethod.Post, path);
+        request.Content = new ByteArrayContent(payload);
+        request.Content.Headers.ContentType =
+            new MediaTypeHeaderValue("application/octet-stream");
+
+        using var response = await application.GetTestClient()
+            .SendAsync(request)
+            .WaitAsync(TestTimeout);
+        var buffer = new byte[16];
+        var received = await webSocket.ReceiveAsync(buffer, CancellationToken.None)
+            .WaitAsync(TestTimeout);
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        Assert.Equal(WebSocketMessageType.Binary, received.MessageType);
+        Assert.True(received.EndOfMessage);
+        Assert.Equal(payload, buffer[..received.Count]);
+    }
+
+    [Fact]
+    public async Task SendToAllQueuesForFilteredDetachedReliableConnection()
+    {
+        await using var application = await StartApplicationAsync();
+        var initial = await ConnectReliableAsync(application);
+        using var initialSocket = initial.WebSocket;
+        initialSocket.Abort();
+        var filter = $"connectionId eq '{initial.ConnectionId}' and " +
+            "protocol eq 'json.reliable.webpubsub.azure.v1'";
+        var path = "/api/hubs/CHAT/:send?api-version=2024-12-01" +
+            $"&filter={Uri.EscapeDataString(filter)}";
+        using var request = CreateAuthorizedRequest(HttpMethod.Post, path);
+        request.Content = new StringContent(
+            """{"value":42}""",
+            Encoding.UTF8,
+            "application/json");
+        request.Headers.Add("X-WebPubSub-Metadata-Trace", "broadcast");
+
+        using var response = await application.GetTestClient()
+            .SendAsync(request)
+            .WaitAsync(TestTimeout);
+        using var recovered = await ConnectRecoveryAsync(
+            application,
+            initial.ConnectionId,
+            initial.ReconnectionToken);
+        using var delivered = await ReceiveJsonAsync(recovered);
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        Assert.Equal("server", delivered.RootElement.GetProperty("from").GetString());
+        Assert.Equal("json", delivered.RootElement.GetProperty("dataType").GetString());
+        Assert.Equal(
+            42,
+            delivered.RootElement.GetProperty("data").GetProperty("value").GetInt32());
+        Assert.Equal(
+            "broadcast",
+            delivered.RootElement.GetProperty("metadata").GetProperty("trace").GetString());
+    }
+
+    [Fact]
+    public async Task SendToAllRejectsInvalidFilterBeforeReadingBody()
+    {
+        await using var application = await StartApplicationAsync();
+        using var webSocket = await ConnectAsync(application);
+        using var connected = await ReceiveJsonAsync(webSocket);
+        var connectionId = connected.RootElement.GetProperty("connectionId").GetString()!;
+        const string path = "/api/hubs/chat/:send" +
+            "?api-version=2024-12-01&filter=userId%20lt%201";
+        using var request = CreateAuthorizedRequest(HttpMethod.Post, path);
+        request.Content = new UnknownLengthContent("ignored"u8.ToArray());
+        request.Content.Headers.ContentType = new MediaTypeHeaderValue("text/plain");
+
+        using var response = await application.GetTestClient()
+            .SendAsync(request)
+            .WaitAsync(TestTimeout);
+        using var error = JsonDocument.Parse(
+            await response.Content.ReadAsByteArrayAsync().WaitAsync(TestTimeout));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("Error.BadRequest", error.RootElement.GetProperty("code").GetString());
+        Assert.Equal("Request", error.RootElement.GetProperty("target").GetString());
+        Assert.Equal(
+            "Invalid syntax for 'userId lt 1': Type 'string', expect 'int'. " +
+            "(Parameter 'filter')",
+            error.RootElement.GetProperty("message").GetString());
+        await AssertReceivesDirectSentinelAsync(
+            application,
+            webSocket,
+            connectionId,
+            "invalid-broadcast-filter-sentinel");
+    }
+
+    [Fact]
+    public async Task OfficialServerSdkCanCheckAndSendToEncodedUser()
+    {
+        const string userId = "tenant/alice";
+        await using var application = EmulatorApplication.Build(
+            ["--urls=http://127.0.0.1:0"]);
+        await application.StartAsync().WaitAsync(TestTimeout);
+        var server = application.Services.GetRequiredService<IServer>();
+        var endpoint = Assert.Single(
+            server.Features.Get<IServerAddressesFeature>()!.Addresses);
+        var connectionString =
+            $"Endpoint={endpoint};AccessKey={EmulatorOptions.DefaultAccessKey};Version=1.0;";
+        var serviceClient = new WebPubSubServiceClient(connectionString, Hub);
+        using var firstSocket = new ClientWebSocket();
+        firstSocket.Options.AddSubProtocol(WebPubSubJsonV1PayloadProcessor.SubprotocolName);
+        await firstSocket.ConnectAsync(
+            serviceClient.GetClientAccessUri(userId: userId),
+            CancellationToken.None).WaitAsync(TestTimeout);
+        using var firstConnected = await ReceiveJsonAsync(firstSocket);
+        var firstConnectionId = firstConnected.RootElement
+            .GetProperty("connectionId")
+            .GetString()!;
+        using var secondSocket = new ClientWebSocket();
+        secondSocket.Options.AddSubProtocol(WebPubSubJsonV1PayloadProcessor.SubprotocolName);
+        await secondSocket.ConnectAsync(
+            serviceClient.GetClientAccessUri(userId: userId),
+            CancellationToken.None).WaitAsync(TestTimeout);
+        using var secondConnected = await ReceiveJsonAsync(secondSocket);
+        var secondConnectionId = secondConnected.RootElement
+            .GetProperty("connectionId")
+            .GetString()!;
+        using var otherSocket = new ClientWebSocket();
+        otherSocket.Options.AddSubProtocol(WebPubSubJsonV1PayloadProcessor.SubprotocolName);
+        await otherSocket.ConnectAsync(
+            serviceClient.GetClientAccessUri(userId: "Tenant/alice"),
+            CancellationToken.None).WaitAsync(TestTimeout);
+        using var otherConnected = await ReceiveJsonAsync(otherSocket);
+        var otherConnectionId = otherConnected.RootElement
+            .GetProperty("connectionId")
+            .GetString()!;
+
+        Assert.True((await serviceClient.UserExistsAsync(userId)
+            .WaitAsync(TestTimeout)).Value);
+        Assert.False((await serviceClient.UserExistsAsync("tenant/Alice")
+            .WaitAsync(TestTimeout)).Value);
+        Assert.False((await serviceClient.UserExistsAsync("missing")
+            .WaitAsync(TestTimeout)).Value);
+
+        var fanOutResponse = await serviceClient.SendToUserAsync(
+            userId,
+            BinaryData.FromString("user-fan-out"),
+            ContentType.TextPlain).WaitAsync(TestTimeout);
+        using var firstFanOut = await ReceiveJsonAsync(firstSocket);
+        using var secondFanOut = await ReceiveJsonAsync(secondSocket);
+        Assert.Equal((int)HttpStatusCode.Accepted, fanOutResponse.Status);
+        Assert.Equal(
+            "user-fan-out",
+            firstFanOut.RootElement.GetProperty("data").GetString());
+        Assert.Equal(
+            "user-fan-out",
+            secondFanOut.RootElement.GetProperty("data").GetString());
+
+        var filteredResponse = await serviceClient.SendToUserAsync(
+            userId,
+            RequestContent.Create(BinaryData.FromString("filtered-user-send")),
+            ContentType.TextPlain,
+            filter: $"connectionId eq '{firstConnectionId}'").WaitAsync(TestTimeout);
+        using var filtered = await ReceiveJsonAsync(firstSocket);
+        Assert.Equal((int)HttpStatusCode.Accepted, filteredResponse.Status);
+        Assert.Equal(
+            "filtered-user-send",
+            filtered.RootElement.GetProperty("data").GetString());
+
+        await serviceClient.SendToConnectionAsync(
+            secondConnectionId,
+            BinaryData.FromString("second-sentinel"),
+            ContentType.TextPlain).WaitAsync(TestTimeout);
+        using var secondSentinel = await ReceiveJsonAsync(secondSocket);
+        Assert.Equal(
+            "second-sentinel",
+            secondSentinel.RootElement.GetProperty("data").GetString());
+        await serviceClient.SendToConnectionAsync(
+            otherConnectionId,
+            BinaryData.FromString("case-sentinel"),
+            ContentType.TextPlain).WaitAsync(TestTimeout);
+        using var caseSentinel = await ReceiveJsonAsync(otherSocket);
+        Assert.Equal(
+            "case-sentinel",
+            caseSentinel.RootElement.GetProperty("data").GetString());
+
+        var missingResponse = await serviceClient.SendToUserAsync(
+            "missing",
+            BinaryData.FromString("ignored"),
+            ContentType.TextPlain).WaitAsync(TestTimeout);
+        Assert.Equal((int)HttpStatusCode.Accepted, missingResponse.Status);
+    }
+
+    [Fact]
+    public async Task UserExistsMissingResponseUsesServiceErrorCode()
+    {
+        await using var application = await StartApplicationAsync();
+        const string path =
+            "/api/hubs/chat/users/missing?api-version=2024-12-01";
+        using var request = CreateAuthorizedRequest(HttpMethod.Head, path);
+
+        using var response = await application.GetTestClient()
+            .SendAsync(request)
+            .WaitAsync(TestTimeout);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.Equal(
+            "Warning.User.NotExisted",
+            response.Headers.GetValues("x-ms-error-code").Single());
+    }
+
+    [Fact]
+    public async Task SendToUserQueuesForFilteredDetachedReliableConnection()
+    {
+        const string userId = "tenant/alice";
+        await using var application = await StartApplicationAsync();
+        var initial = await ConnectReliableAsync(application, userId);
+        using var initialSocket = initial.WebSocket;
+        initialSocket.Abort();
+        var filter = $"userId eq '{userId}' and connectionId eq '{initial.ConnectionId}' and " +
+            "protocol eq 'json.reliable.webpubsub.azure.v1'";
+        var path = "/api/hubs/CHAT/users/tenant%2Falice/:send" +
+            "?api-version=2024-12-01&messageTtlSeconds=1" +
+            $"&filter={Uri.EscapeDataString(filter)}";
+        using var request = CreateAuthorizedRequest(HttpMethod.Post, path);
+        request.Content = new StringContent(
+            """{"value":42}""",
+            Encoding.UTF8,
+            "application/json");
+        request.Headers.Add("X-WebPubSub-Metadata-Trace", "user-send");
+
+        using var response = await application.GetTestClient()
+            .SendAsync(request)
+            .WaitAsync(TestTimeout);
+        using var recovered = await ConnectRecoveryAsync(
+            application,
+            initial.ConnectionId,
+            initial.ReconnectionToken);
+        using var delivered = await ReceiveJsonAsync(recovered);
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        Assert.Equal("server", delivered.RootElement.GetProperty("from").GetString());
+        Assert.Equal("json", delivered.RootElement.GetProperty("dataType").GetString());
+        Assert.Equal(
+            42,
+            delivered.RootElement.GetProperty("data").GetProperty("value").GetInt32());
+        Assert.Equal(
+            "user-send",
+            delivered.RootElement.GetProperty("metadata").GetProperty("trace").GetString());
+    }
+
+    [Fact]
+    public async Task SendToUserRejectsInvalidFilterBeforeReadingBody()
+    {
+        const string userId = "alice";
+        await using var application = await StartApplicationAsync();
+        using var webSocket = await ConnectAsync(application, userId);
+        using var connected = await ReceiveJsonAsync(webSocket);
+        var connectionId = connected.RootElement.GetProperty("connectionId").GetString()!;
+        const string path = "/api/hubs/chat/users/alice/:send" +
+            "?api-version=2024-12-01&filter=userId%20lt%201";
+        using var request = CreateAuthorizedRequest(HttpMethod.Post, path);
+        request.Content = new UnknownLengthContent("ignored"u8.ToArray());
+        request.Content.Headers.ContentType = new MediaTypeHeaderValue("text/plain");
+
+        using var response = await application.GetTestClient()
+            .SendAsync(request)
+            .WaitAsync(TestTimeout);
+        using var error = JsonDocument.Parse(
+            await response.Content.ReadAsByteArrayAsync().WaitAsync(TestTimeout));
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("Error.BadRequest", error.RootElement.GetProperty("code").GetString());
+        Assert.Equal("Request", error.RootElement.GetProperty("target").GetString());
+        Assert.Equal(
+            "Invalid syntax for 'userId lt 1': Type 'string', expect 'int'. " +
+            "(Parameter 'filter')",
+            error.RootElement.GetProperty("message").GetString());
+        await AssertReceivesDirectSentinelAsync(
+            application,
+            webSocket,
+            connectionId,
+            "invalid-user-filter-sentinel");
     }
 
     [Fact]
@@ -1062,10 +1447,22 @@ public class RestApiTests
         return application;
     }
 
-    private static async Task<WebSocket> ConnectAsync(WebApplication application)
+    private static async Task<WebSocket> ConnectAsync(
+        WebApplication application,
+        string? userId = null)
     {
         var client = application.GetTestServer().CreateWebSocketClient();
         client.SubProtocols.Add(WebPubSubJsonV1PayloadProcessor.SubprotocolName);
+        var path = $"{WebPubSubTokenService.ClientPathPrefix}{Hub}";
+        var token = CreateToken($"http://localhost{path}", userId);
+        return await client.ConnectAsync(
+            new Uri($"ws://localhost{path}?access_token={Uri.EscapeDataString(token)}"),
+            CancellationToken.None).WaitAsync(TestTimeout);
+    }
+
+    private static async Task<WebSocket> ConnectRawAsync(WebApplication application)
+    {
+        var client = application.GetTestServer().CreateWebSocketClient();
         var path = $"{WebPubSubTokenService.ClientPathPrefix}{Hub}";
         var token = CreateToken($"http://localhost{path}");
         return await client.ConnectAsync(
@@ -1074,12 +1471,12 @@ public class RestApiTests
     }
 
     private static async Task<(WebSocket WebSocket, string ConnectionId, string ReconnectionToken)>
-        ConnectReliableAsync(WebApplication application)
+        ConnectReliableAsync(WebApplication application, string? userId = null)
     {
         var client = application.GetTestServer().CreateWebSocketClient();
         client.SubProtocols.Add(WebPubSubJsonV1PayloadProcessor.ReliableSubprotocolName);
         var path = $"{WebPubSubTokenService.ClientPathPrefix}{Hub}";
-        var token = CreateToken($"http://localhost{path}");
+        var token = CreateToken($"http://localhost{path}", userId);
         var webSocket = await client.ConnectAsync(
             new Uri($"ws://localhost{path}?access_token={Uri.EscapeDataString(token)}"),
             CancellationToken.None).WaitAsync(TestTimeout);
@@ -1130,10 +1527,11 @@ public class RestApiTests
         Assert.Equal(sentinel, delivered.RootElement.GetProperty("data").GetString());
     }
 
-    private static string CreateToken(string audience)
+    private static string CreateToken(string audience, string? userId = null)
     {
         var token = new JwtSecurityToken(
             audience: audience,
+            claims: userId is null ? [] : [new Claim("sub", userId)],
             expires: DateTime.UtcNow.AddHours(1),
             signingCredentials: new SigningCredentials(
                 new SymmetricSecurityKey(Encoding.UTF8.GetBytes(EmulatorOptions.DefaultAccessKey)),

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/RestApiTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/RestApiTests.cs
@@ -353,9 +353,9 @@ public class RestApiTests
     }
 
     [Fact]
-    public async Task OfficialServerSdkCanCheckAndSendToEncodedUser()
+    public async Task OfficialServerSdkCanCheckAndSendToUser()
     {
-        const string userId = "tenant/alice";
+        const string userId = "tenant-alice";
         await using var application = EmulatorApplication.Build(
             ["--urls=http://127.0.0.1:0"]);
         await application.StartAsync().WaitAsync(TestTimeout);
@@ -386,7 +386,7 @@ public class RestApiTests
         using var otherSocket = new ClientWebSocket();
         otherSocket.Options.AddSubProtocol(WebPubSubJsonV1PayloadProcessor.SubprotocolName);
         await otherSocket.ConnectAsync(
-            serviceClient.GetClientAccessUri(userId: "Tenant/alice"),
+            serviceClient.GetClientAccessUri(userId: userId.ToUpperInvariant()),
             CancellationToken.None).WaitAsync(TestTimeout);
         using var otherConnected = await ReceiveJsonAsync(otherSocket);
         var otherConnectionId = otherConnected.RootElement
@@ -395,7 +395,7 @@ public class RestApiTests
 
         Assert.True((await serviceClient.UserExistsAsync(userId)
             .WaitAsync(TestTimeout)).Value);
-        Assert.False((await serviceClient.UserExistsAsync("tenant/Alice")
+        Assert.False((await serviceClient.UserExistsAsync("tenant-Alice")
             .WaitAsync(TestTimeout)).Value);
         Assert.False((await serviceClient.UserExistsAsync("missing")
             .WaitAsync(TestTimeout)).Value);
@@ -449,6 +449,100 @@ public class RestApiTests
         Assert.Equal((int)HttpStatusCode.Accepted, missingResponse.Status);
     }
 
+    [Theory]
+    [InlineData("tenant%2Falice", "tenant%2Falice", HttpStatusCode.NotFound)]
+    [InlineData("tenant%2falice", "tenant%2falice", HttpStatusCode.NotFound)]
+    [InlineData("tenant%252Falice", "tenant%2Falice", HttpStatusCode.Unauthorized)]
+    public async Task UserRestApisPreserveEncodedUserCompatibility(
+        string userPathSegment,
+        string boundUserId,
+        HttpStatusCode missingStatus)
+    {
+        // Use Kestrel so requests exercise real HTTP path decoding before MVC binding.
+        await using var application = EmulatorApplication.Build(
+            ["--urls=http://127.0.0.1:0"]);
+        await application.StartAsync().WaitAsync(TestTimeout);
+        var server = application.Services.GetRequiredService<IServer>();
+        var endpoint = Assert.Single(
+            server.Features.Get<IServerAddressesFeature>()!.Addresses);
+        var connectionString =
+            $"Endpoint={endpoint};AccessKey={EmulatorOptions.DefaultAccessKey};Version=1.0;";
+        var serviceClient = new WebPubSubServiceClient(connectionString, Hub);
+        using var httpClient = new HttpClient { BaseAddress = new Uri(endpoint) };
+        using var slashSocket = new ClientWebSocket();
+        slashSocket.Options.AddSubProtocol(WebPubSubJsonV1PayloadProcessor.SubprotocolName);
+        await slashSocket.ConnectAsync(
+            serviceClient.GetClientAccessUri(userId: "tenant/alice"),
+            CancellationToken.None).WaitAsync(TestTimeout);
+        using var slashConnected = await ReceiveJsonAsync(slashSocket);
+        Assert.Equal("tenant/alice", slashConnected.RootElement.GetProperty("userId").GetString());
+        var slashConnectionId = slashConnected.RootElement.GetProperty("connectionId").GetString()!;
+        var userPath = $"/api/hubs/{Hub}/users/{userPathSegment}";
+        var existsPath = userPath + "?api-version=2024-12-01";
+        var sendPath = userPath + "/:send?api-version=2024-12-01";
+
+        using var missingRequest = CreateUserRequest(HttpMethod.Head, existsPath);
+        using var missingResponse = await httpClient.SendAsync(missingRequest).WaitAsync(TestTimeout);
+        Assert.Equal(missingStatus, missingResponse.StatusCode);
+        if (missingStatus == HttpStatusCode.NotFound)
+        {
+            Assert.Equal("Warning.User.NotExisted", missingResponse.Headers.GetValues("x-ms-error-code").Single());
+        }
+        using var missingSendRequest = CreateUserRequest(HttpMethod.Post, sendPath);
+        missingSendRequest.Content = new StringContent("missing-user-send", Encoding.UTF8, "text/plain");
+        using var missingSendResponse = await httpClient.SendAsync(missingSendRequest).WaitAsync(TestTimeout);
+        var sendStatus = missingStatus == HttpStatusCode.Unauthorized
+            ? HttpStatusCode.Unauthorized
+            : HttpStatusCode.Accepted;
+        Assert.Equal(sendStatus, missingSendResponse.StatusCode);
+
+        // A literal percent-encoded user is distinct from the user containing a slash.
+        using var literalSocket = new ClientWebSocket();
+        literalSocket.Options.AddSubProtocol(WebPubSubJsonV1PayloadProcessor.SubprotocolName);
+        await literalSocket.ConnectAsync(
+            serviceClient.GetClientAccessUri(userId: boundUserId),
+            CancellationToken.None).WaitAsync(TestTimeout);
+        using var literalConnected = await ReceiveJsonAsync(literalSocket);
+        Assert.Equal(boundUserId, literalConnected.RootElement.GetProperty("userId").GetString());
+        using var existsRequest = CreateUserRequest(HttpMethod.Head, existsPath);
+        using var existsResponse = await httpClient.SendAsync(existsRequest).WaitAsync(TestTimeout);
+        // Double-encoded paths currently fail audience validation even with the literal user online.
+        // Keep that existing limitation separate from route binding; do not change authentication here.
+        Assert.Equal(
+            missingStatus == HttpStatusCode.Unauthorized ? HttpStatusCode.Unauthorized : HttpStatusCode.OK,
+            existsResponse.StatusCode);
+        using var sendRequest = CreateUserRequest(HttpMethod.Post, sendPath);
+        sendRequest.Content = new StringContent("literal-user-send", Encoding.UTF8, "text/plain");
+        using var sendResponse = await httpClient.SendAsync(sendRequest).WaitAsync(TestTimeout);
+        Assert.Equal(sendStatus, sendResponse.StatusCode);
+        if (sendStatus == HttpStatusCode.Unauthorized)
+        {
+            await serviceClient.SendToConnectionAsync(
+                literalConnected.RootElement.GetProperty("connectionId").GetString()!,
+                BinaryData.FromString("literal-user-sentinel"),
+                ContentType.TextPlain).WaitAsync(TestTimeout);
+        }
+        using var delivered = await ReceiveJsonAsync(literalSocket);
+        Assert.Equal(
+            sendStatus == HttpStatusCode.Unauthorized ? "literal-user-sentinel" : "literal-user-send",
+            delivered.RootElement.GetProperty("data").GetString());
+
+        await serviceClient.SendToConnectionAsync(
+            slashConnectionId,
+            BinaryData.FromString("slash-user-sentinel"),
+            ContentType.TextPlain).WaitAsync(TestTimeout);
+        using var sentinel = await ReceiveJsonAsync(slashSocket);
+        Assert.Equal("slash-user-sentinel", sentinel.RootElement.GetProperty("data").GetString());
+
+        HttpRequestMessage CreateUserRequest(HttpMethod method, string path)
+        {
+            var request = new HttpRequestMessage(method, path);
+            request.Headers.Authorization = new AuthenticationHeaderValue(
+                "Bearer", CreateToken($"{endpoint}{path}"));
+            return request;
+        }
+    }
+
     [Fact]
     public async Task UserExistsMissingResponseUsesServiceErrorCode()
     {
@@ -470,14 +564,14 @@ public class RestApiTests
     [Fact]
     public async Task SendToUserQueuesForFilteredDetachedReliableConnection()
     {
-        const string userId = "tenant/alice";
+        const string userId = "tenant-alice";
         await using var application = await StartApplicationAsync();
         var initial = await ConnectReliableAsync(application, userId);
         using var initialSocket = initial.WebSocket;
         initialSocket.Abort();
         var filter = $"userId eq '{userId}' and connectionId eq '{initial.ConnectionId}' and " +
             "protocol eq 'json.reliable.webpubsub.azure.v1'";
-        var path = "/api/hubs/CHAT/users/tenant%2Falice/:send" +
+        var path = "/api/hubs/CHAT/users/tenant-alice/:send" +
             "?api-version=2024-12-01&messageTtlSeconds=1" +
             $"&filter={Uri.EscapeDataString(filter)}";
         using var request = CreateAuthorizedRequest(HttpMethod.Post, path);


### PR DESCRIPTION
Summary adds SendToAll with repeated connection exclusions and OData filters; UserExists and SendToUser with case-sensitive user matching, per-connection filtering and reliable replay; updates docs and REST/official SDK tests.

Compatibility reviewed against production runtime and umbrella #1048; missing-user HEAD returns Warning.User.NotExisted and missing-user sends return 202. REST access-key audience validation now matches runtime behavior for double-encoded user paths while preserving the current API versions' legacy route binding.

Scope excludes user-group persistence, close-user operations and permissions; message TTL accepted/validated but expiration not modeled.

Validation rebased onto latest main, Release emulator tests 162/162, git diff --check clean.