### PR TITLE
Emulator: support user group membership APIs

### DIFF
--- a/tools/emulator/SUPPORTED_FEATURES.md
+++ b/tools/emulator/SUPPORTED_FEATURES.md
@@ -20,9 +20,9 @@ local Azure Web PubSub development.
 | REST connection operations | Authenticated connection presence, direct text, JSON, and binary sends, close, and single-connection group membership changes for GA API versions from `2021-10-01` through `2024-12-01`. | ✅ |
 | REST group operations | Authenticated group presence and text, JSON, or binary fan-out with excluded connection IDs and OData filters. | ✅ |
 | REST broadcast | Authenticated text, JSON, or binary fan-out with excluded connection IDs and OData filters. | ✅ |
-| REST user operations | Authenticated user presence and text, JSON, or binary fan-out to all matching connections with OData filters. | ✅ |
+| REST user operations | Authenticated user presence, group membership changes, and text, JSON, or binary fan-out to all matching connections with OData filters. | ✅ |
 | REST send TTL | Accepts valid `messageTtlSeconds` values; delivery is immediate and expiration is not modeled. | ⚠️ |
-| Other REST APIs | User-group and permission operations. | ❌ |
+| Other REST APIs | Permission operations. | ❌ |
 
 For the currently supported API versions (`2021-10-01` through `2024-12-01`) and versionless
 requests, REST user operations preserve the legacy runtime route-binding behavior and pass the

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ConnectionManager.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ConnectionManager.cs
@@ -108,6 +108,36 @@ internal sealed class ConnectionManager
         }
     }
 
+    public bool AddUserToGroup(string hub, string userId, string group)
+    {
+        var connections = GetUserConnections(hub, userId).ToArray();
+        foreach (var connection in connections)
+        {
+            connection.TryAddToGroup(group);
+        }
+
+        return connections.Length > 0;
+    }
+
+    public void RemoveUserFromGroup(string hub, string userId, string group)
+    {
+        foreach (var connection in GetUserConnections(hub, userId))
+        {
+            connection.RemoveFromGroup(group);
+        }
+    }
+
+    public void RemoveUserFromAllGroups(string hub, string userId)
+    {
+        foreach (var connection in GetUserConnections(hub, userId))
+        {
+            foreach (var group in connection.Groups.Keys)
+            {
+                connection.RemoveFromGroup(group);
+            }
+        }
+    }
+
     public bool AddConnectionToGroup(string hub, string group, string connectionId)
     {
         return _connections.TryGetValue((hub, connectionId), out var connection) &&

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubEmulatorController.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubEmulatorController.cs
@@ -234,6 +234,86 @@ internal sealed class WebPubSubEmulatorController : WebPubSubApiControllerDefini
         return Accepted();
     }
 
+    [HttpPut(
+        "/api/hubs/{hub}/users/{userId}/groups/{group}",
+        Name = "WebPubSub_AddUserToGroup")]
+    public IActionResult AddUserToGroup(
+        [RegularExpression(
+            WebPubSubNameValidator.HubNamePattern,
+            ErrorMessage = "Invalid hub name.")]
+        string hub,
+        [MinLength(1, ErrorMessage = "Invalid user ID.")]
+        string userId,
+        [StringLength(
+            WebPubSubNameValidator.MaximumGroupNameLength,
+            MinimumLength = 1,
+            ErrorMessage = "Invalid group name.")]
+        [RegularExpression(
+            WebPubSubNameValidator.NotWhitespacePattern,
+            ErrorMessage = "Invalid group name.")]
+        string group,
+        CancellationToken cancellationToken = default)
+    {
+        if (!Authorize())
+        {
+            return Unauthorized();
+        }
+
+        return _connections.AddUserToGroup(hub.ToLowerInvariant(), userId, group)
+            ? Ok()
+            : NotFound();
+    }
+
+    [HttpDelete(
+        "/api/hubs/{hub}/users/{userId}/groups/{group}",
+        Name = "WebPubSub_RemoveUserFromGroup")]
+    public IActionResult RemoveUserFromGroup(
+        [RegularExpression(
+            WebPubSubNameValidator.HubNamePattern,
+            ErrorMessage = "Invalid hub name.")]
+        string hub,
+        [MinLength(1, ErrorMessage = "Invalid user ID.")]
+        string userId,
+        [StringLength(
+            WebPubSubNameValidator.MaximumGroupNameLength,
+            MinimumLength = 1,
+            ErrorMessage = "Invalid group name.")]
+        [RegularExpression(
+            WebPubSubNameValidator.NotWhitespacePattern,
+            ErrorMessage = "Invalid group name.")]
+        string group,
+        CancellationToken cancellationToken = default)
+    {
+        if (!Authorize())
+        {
+            return Unauthorized();
+        }
+
+        _connections.RemoveUserFromGroup(hub.ToLowerInvariant(), userId, group);
+        return NoContent();
+    }
+
+    [HttpDelete(
+        "/api/hubs/{hub}/users/{userId}/groups",
+        Name = "WebPubSub_RemoveUserFromAllGroups")]
+    public IActionResult RemoveUserFromAllGroups(
+        [RegularExpression(
+            WebPubSubNameValidator.HubNamePattern,
+            ErrorMessage = "Invalid hub name.")]
+        string hub,
+        [MinLength(1, ErrorMessage = "Invalid user ID.")]
+        string userId,
+        CancellationToken cancellationToken = default)
+    {
+        if (!Authorize())
+        {
+            return Unauthorized();
+        }
+
+        _connections.RemoveUserFromAllGroups(hub.ToLowerInvariant(), userId);
+        return NoContent();
+    }
+
     [HttpHead(
         "/api/hubs/{hub}/groups/{group}",
         Name = "WebPubSub_GroupExists")]

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/RestApiTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/RestApiTests.cs
@@ -449,6 +449,120 @@ public class RestApiTests
         Assert.Equal((int)HttpStatusCode.Accepted, missingResponse.Status);
     }
 
+    [Fact]
+    public async Task OfficialServerSdkCanManageUserGroupMembership()
+    {
+        const string userId = "tenant-alice";
+        await using var application = EmulatorApplication.Build(
+            ["--urls=http://127.0.0.1:0"]);
+        await application.StartAsync().WaitAsync(TestTimeout);
+        var server = application.Services.GetRequiredService<IServer>();
+        var endpoint = Assert.Single(
+            server.Features.Get<IServerAddressesFeature>()!.Addresses);
+        var connectionString =
+            $"Endpoint={endpoint};AccessKey={EmulatorOptions.DefaultAccessKey};Version=1.0;";
+        var serviceClient = new WebPubSubServiceClient(connectionString, Hub);
+        using var firstSocket = new ClientWebSocket();
+        firstSocket.Options.AddSubProtocol(WebPubSubJsonV1PayloadProcessor.SubprotocolName);
+        await firstSocket.ConnectAsync(
+            serviceClient.GetClientAccessUri(userId: userId),
+            CancellationToken.None).WaitAsync(TestTimeout);
+        using var firstConnected = await ReceiveJsonAsync(firstSocket);
+        var firstConnectionId = firstConnected.RootElement
+            .GetProperty("connectionId")
+            .GetString()!;
+        using var secondSocket = new ClientWebSocket();
+        secondSocket.Options.AddSubProtocol(WebPubSubJsonV1PayloadProcessor.SubprotocolName);
+        await secondSocket.ConnectAsync(
+            serviceClient.GetClientAccessUri(userId: userId),
+            CancellationToken.None).WaitAsync(TestTimeout);
+        using var secondConnected = await ReceiveJsonAsync(secondSocket);
+        var secondConnectionId = secondConnected.RootElement
+            .GetProperty("connectionId")
+            .GetString()!;
+        using var otherSocket = new ClientWebSocket();
+        otherSocket.Options.AddSubProtocol(WebPubSubJsonV1PayloadProcessor.SubprotocolName);
+        await otherSocket.ConnectAsync(
+            serviceClient.GetClientAccessUri(userId: userId.ToUpperInvariant()),
+            CancellationToken.None).WaitAsync(TestTimeout);
+        using var otherConnected = await ReceiveJsonAsync(otherSocket);
+        var otherConnectionId = otherConnected.RootElement
+            .GetProperty("connectionId")
+            .GetString()!;
+
+        var addResponse = await serviceClient.AddUserToGroupAsync("room", userId)
+            .WaitAsync(TestTimeout);
+        Assert.Equal((int)HttpStatusCode.OK, addResponse.Status);
+        await serviceClient.SendToGroupAsync(
+            "room",
+            BinaryData.FromString("user-group-send"),
+            ContentType.TextPlain).WaitAsync(TestTimeout);
+        using var firstGroupMessage = await ReceiveJsonAsync(firstSocket);
+        using var secondGroupMessage = await ReceiveJsonAsync(secondSocket);
+        Assert.Equal(
+            "user-group-send",
+            firstGroupMessage.RootElement.GetProperty("data").GetString());
+        Assert.Equal(
+            "user-group-send",
+            secondGroupMessage.RootElement.GetProperty("data").GetString());
+        await serviceClient.SendToConnectionAsync(
+            otherConnectionId,
+            BinaryData.FromString("case-sensitive-user-sentinel"),
+            ContentType.TextPlain).WaitAsync(TestTimeout);
+        using var otherSentinel = await ReceiveJsonAsync(otherSocket);
+        Assert.Equal(
+            "case-sensitive-user-sentinel",
+            otherSentinel.RootElement.GetProperty("data").GetString());
+
+        var removeResponse = await serviceClient.RemoveUserFromGroupAsync("room", userId)
+            .WaitAsync(TestTimeout);
+        Assert.Equal((int)HttpStatusCode.NoContent, removeResponse.Status);
+        await serviceClient.SendToGroupAsync(
+            "room",
+            BinaryData.FromString("removed-user-send"),
+            ContentType.TextPlain).WaitAsync(TestTimeout);
+        await serviceClient.SendToConnectionAsync(
+            firstConnectionId,
+            BinaryData.FromString("removed-first-sentinel"),
+            ContentType.TextPlain).WaitAsync(TestTimeout);
+        using var firstSentinel = await ReceiveJsonAsync(firstSocket);
+        Assert.Equal(
+            "removed-first-sentinel",
+            firstSentinel.RootElement.GetProperty("data").GetString());
+        await serviceClient.SendToConnectionAsync(
+            secondConnectionId,
+            BinaryData.FromString("removed-second-sentinel"),
+            ContentType.TextPlain).WaitAsync(TestTimeout);
+        using var secondSentinel = await ReceiveJsonAsync(secondSocket);
+        Assert.Equal(
+            "removed-second-sentinel",
+            secondSentinel.RootElement.GetProperty("data").GetString());
+
+        await serviceClient.AddUserToGroupAsync("first-room", userId)
+            .WaitAsync(TestTimeout);
+        await serviceClient.AddUserToGroupAsync("second-room", userId)
+            .WaitAsync(TestTimeout);
+        var removeAllResponse = await serviceClient.RemoveUserFromAllGroupsAsync(userId)
+            .WaitAsync(TestTimeout);
+        Assert.Equal((int)HttpStatusCode.NoContent, removeAllResponse.Status);
+        var manager = application.Services.GetRequiredService<ConnectionManager>();
+        Assert.True(manager.TryGet(Hub, firstConnectionId, out var firstConnection));
+        Assert.True(manager.TryGet(Hub, secondConnectionId, out var secondConnection));
+        Assert.Empty(firstConnection.Groups);
+        Assert.Empty(secondConnection.Groups);
+
+        var exception = await Assert.ThrowsAsync<RequestFailedException>(() =>
+            serviceClient.AddUserToGroupAsync("room", "missing"));
+        Assert.Equal((int)HttpStatusCode.NotFound, exception.Status);
+        var missingRemoveResponse = await serviceClient.RemoveUserFromGroupAsync(
+            "room",
+            "missing").WaitAsync(TestTimeout);
+        Assert.Equal((int)HttpStatusCode.NoContent, missingRemoveResponse.Status);
+        var missingRemoveAllResponse = await serviceClient.RemoveUserFromAllGroupsAsync(
+            "missing").WaitAsync(TestTimeout);
+        Assert.Equal((int)HttpStatusCode.NoContent, missingRemoveAllResponse.Status);
+    }
+
     [Theory]
     [InlineData("tenant%2Falice", "tenant%2Falice", HttpStatusCode.NotFound)]
     [InlineData("tenant%2falice", "tenant%2falice", HttpStatusCode.NotFound)]


### PR DESCRIPTION
## Summary

- add REST APIs to add a user to a group, remove a user from a group, and remove a user from all groups
- apply membership changes to every current connection for the exact, case-sensitive user ID, including retained reliable connections
- update the supported feature matrix and cover the public behavior through the official .NET server SDK

## Behavior

- adding an online user returns `200 OK`; adding a missing user returns `404 Not Found`
- remove and remove-all operations are idempotent and return `204 No Content`
- membership is connection-scoped, matching the current runtime/umbrella behavior; this PR does not introduce offline user membership persistence

## Scope

This is the next focused emulator slice after #1120 and preserves the behavior intended by umbrella PR #1048. Permission operations, bulk group operations, upstream handlers, and offline membership persistence remain out of scope.

## Validation

- `dotnet test tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/Microsoft.Azure.WebPubSub.Emulator.Tests.csproj --configuration Release --no-restore` (`163/163` passed)
- `git diff --check`