### PR TITLE
Add HTTP event handlers to Web PubSub emulator

### DIFF
--- a/tools/emulator/Directory.Packages.props
+++ b/tools/emulator/Directory.Packages.props
@@ -4,6 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="Azure.Messaging.WebPubSub" Version="1.6.0" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.11" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />

--- a/tools/emulator/README.md
+++ b/tools/emulator/README.md
@@ -124,6 +124,36 @@ $env:WebPubSub__AccessKey = "custom-emulator-access-key-1234567890"
 dotnet run --project tools\emulator\src\Microsoft.Azure.WebPubSub.Emulator
 ```
 
+## Configure event handlers
+
+Configure HTTP upstream handlers under `WebPubSub:Hubs`. A hub-specific entry takes precedence
+over the optional `_default` entry. Handler user-event patterns support the service wildcard
+syntax. For example:
+
+```json
+{
+  "WebPubSub": {
+    "Hubs": {
+      "chat": {
+        "EventHandlers": [
+          {
+            "UrlTemplate": "https://localhost:7071/runtime/webhooks/webpubsub?hub={hub}&event={event}",
+            "EventPattern": "chat-*",
+            "SystemEvents": ["connect", "connected", "disconnected"]
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+HTTP handlers default to no authentication. Set `Auth:Type` to `ManagedIdentity` and
+`Auth:ManagedIdentity:Resource` to the handler resource
+when bearer authentication is required. `WebPubSub:ManagedIdentityClientId` selects a user-assigned
+managed identity. Event handler requests use binary CloudEvents headers and preserve message
+content type and Web PubSub metadata.
+
 `WebPubSub:AllowUnvalidatedEntraTokens` is disabled by default. Enable it only for trusted local
 server SDK `TokenCredential` testing. With an HTTPS emulator endpoint, the SDK can use
 `DefaultAzureCredential`:

--- a/tools/emulator/SUPPORTED_FEATURES.md
+++ b/tools/emulator/SUPPORTED_FEATURES.md
@@ -17,6 +17,7 @@ local Azure Web PubSub development.
 | Connection state | Tracks active connections and temporarily retains reliable logical connections after unexpected disconnects. | ✅ |
 | Groups and roles | Supports connection-scoped token groups and authorized join, leave, and group send, including wildcard roles. | ✅ |
 | Outbound delivery | Uses a bounded, single-writer queue for each WebSocket connection. | ✅ |
+| HTTP upstream event handlers | Supports `connect`, `connected`, `disconnected`, JSON user events, and raw `message` events with CloudEvents headers, responses, connection state, metadata, and managed identity authentication. | ✅ |
 | REST connection operations | Authenticated connection presence, direct text, JSON, and binary sends, close, and single-connection group membership changes for GA API versions from `2021-10-01` through `2024-12-01`. | ✅ |
 | REST group operations | Authenticated group presence and text, JSON, or binary fan-out with excluded connection IDs and OData filters. | ✅ |
 | REST broadcast | Authenticated text, JSON, or binary fan-out with excluded connection IDs and OData filters. | ✅ |
@@ -47,13 +48,12 @@ runtime's new contract and decode the original user ID path segment exactly once
 
 The following areas are planned for follow-up changes:
 
-- HTTP upstream event handlers
 - Tunnel connections (`tunnel://` upstream URLs)
 - Event Hubs listeners
 - Protobuf subprotocols
 - Client message streaming
 - Production Microsoft Entra ID validation
 
-Client events require an upstream event handler. Until upstream handlers are implemented, JSON
-events with an `ackId` receive an `InternalServerError` acknowledgement; events without an
-`ackId` are logged without closing the client connection. Raw `sendEvent` mode is not available.
+Client events require a matching HTTP event handler. JSON events with an `ackId` receive an
+`InternalServerError` acknowledgement when no configured handler matches. Raw
+messages require a matching HTTP event handler unless raw `sendToGroup` mode is selected.

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientConnectionHandler.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientConnectionHandler.cs
@@ -8,10 +8,14 @@ namespace Microsoft.Azure.WebPubSub.Emulator;
 
 internal sealed class ClientConnectionHandler
 {
+    private readonly UpstreamEventDispatcher _events;
     private readonly ILogger<ClientConnectionHandler> _logger;
 
-    public ClientConnectionHandler(ILogger<ClientConnectionHandler> logger)
+    public ClientConnectionHandler(
+        UpstreamEventDispatcher events,
+        ILogger<ClientConnectionHandler> logger)
     {
+        _events = events;
         _logger = logger;
     }
 
@@ -28,6 +32,7 @@ internal sealed class ClientConnectionHandler
             transport.Aborted);
         using var detachOnCancellation = linkedCancellation.Token.Register(
             () => connection.Detach(transport));
+        string? disconnectReason = null;
         try
         {
             if (!await connection.ProcessIfCurrentAsync(
@@ -37,6 +42,10 @@ internal sealed class ClientConnectionHandler
                     if (isInitialConnection)
                     {
                         processor.OnConnected(connection);
+                        _ = _events.DispatchNotificationAsync(
+                            connection.CreateSystemEvent(
+                                "connected",
+                                new MessageData(MessageDataType.Json, "{}"u8.ToArray())));
                     }
                     return ValueTask.CompletedTask;
                 },
@@ -94,6 +103,7 @@ internal sealed class ClientConnectionHandler
                                 terminalCloseStatus = WebSocketCloseStatus.NormalClosure;
                                 terminalCloseDescription =
                                     message.CloseStatusDescription ?? string.Empty;
+                                disconnectReason = terminalCloseDescription;
                                 connection.CloseIfCurrent(
                                     transport,
                                     terminalCloseStatus.Value,
@@ -174,6 +184,7 @@ internal sealed class ClientConnectionHandler
                 transport,
                 WebSocketCloseStatus.MessageTooBig,
                 "The client message is too large.");
+            disconnectReason = "The client message is too large.";
             await transport.CloseAsync(
                 WebSocketCloseStatus.MessageTooBig,
                 "The client message is too large.");
@@ -188,6 +199,7 @@ internal sealed class ClientConnectionHandler
                 transport,
                 WebSocketCloseStatus.ProtocolError,
                 "The client frame is invalid.");
+            disconnectReason = "The client frame is invalid.";
             await transport.CloseAsync(
                 WebSocketCloseStatus.ProtocolError,
                 "The client frame is invalid.");
@@ -200,6 +212,10 @@ internal sealed class ClientConnectionHandler
                 "WebSocket connection {ConnectionId} ended.",
                 connectionId);
             transport.Abort();
+        }
+        finally
+        {
+            connection.Detach(transport, disconnectReason);
         }
     }
 }

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientWebSocketEndpoint.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientWebSocketEndpoint.cs
@@ -3,6 +3,7 @@
 
 using System.Net.WebSockets;
 using System.Security.Claims;
+using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Tokens;
@@ -19,6 +20,7 @@ internal sealed class ClientWebSocketEndpoint
     private readonly ClientPayloadProcessorFactory _payloadProcessorFactory;
     private readonly ClientConnectionHandler _connectionHandler;
     private readonly WebPubSubTokenService _tokenService;
+    private readonly UpstreamEventDispatcher _events;
     private readonly ILogger<ClientWebSocketEndpoint> _logger;
 
     public ClientWebSocketEndpoint(
@@ -26,12 +28,14 @@ internal sealed class ClientWebSocketEndpoint
         ClientPayloadProcessorFactory payloadProcessorFactory,
         ClientConnectionHandler connectionHandler,
         WebPubSubTokenService tokenService,
+        UpstreamEventDispatcher events,
         ILogger<ClientWebSocketEndpoint> logger)
     {
         _connections = connections;
         _payloadProcessorFactory = payloadProcessorFactory;
         _connectionHandler = connectionHandler;
         _tokenService = tokenService;
+        _events = events;
         _logger = logger;
     }
 
@@ -101,13 +105,43 @@ internal sealed class ClientWebSocketEndpoint
         }
 
         var hub = rawHub.ToLowerInvariant();
+        var connectionId = Guid.NewGuid().ToString("N");
+        var connectResult = await _events.DispatchConnectAsync(
+            CreateConnectEvent(context, hub, connectionId, user),
+            context.RequestAborted);
+        if (!connectResult.Succeeded)
+        {
+            context.Response.StatusCode = (int)connectResult.StatusCode;
+            if (connectResult.Error is not null)
+            {
+                await context.Response.WriteAsync(connectResult.Error);
+            }
+            return;
+        }
+
+        if (!TryApplyConnectResponse(
+            context,
+            user,
+            selectedSubprotocol,
+            connectResult.Response,
+            out user,
+            out selectedSubprotocol,
+            out var connectError))
+        {
+            context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+            await context.Response.WriteAsync(connectError);
+            return;
+        }
+
         var connection = _connections.Create(
-            Guid.NewGuid().ToString("N"),
+            connectionId,
             hub,
             user,
             rawSendToGroup,
             WebPubSubJsonV1PayloadProcessor.IsReliableSubprotocol(selectedSubprotocol),
-            selectedSubprotocol);
+            selectedSubprotocol,
+            host: context.Request.Host.ToString());
+        connection.ConnectionState = connectResult.ConnectionState;
         var processor = _payloadProcessorFactory.Get(selectedSubprotocol);
 
         using var webSocket = await context.WebSockets.AcceptWebSocketAsync(selectedSubprotocol);
@@ -210,6 +244,95 @@ internal sealed class ClientWebSocketEndpoint
         {
             _logger.LogDebug(exception, "Closing a WebSocket request failed.");
         }
+    }
+
+    private static UpstreamEvent CreateConnectEvent(
+        HttpContext context,
+        string hub,
+        string connectionId,
+        ClaimsPrincipal user)
+    {
+        var claims = user.Claims
+            .GroupBy(claim => claim.Type, StringComparer.Ordinal)
+            .ToDictionary(
+                group => group.Key,
+                group => group.Select(claim => claim.Value).ToArray(),
+                StringComparer.Ordinal);
+        var query = context.Request.Query
+            .Where(item => !string.Equals(item.Key, AccessTokenQueryName, StringComparison.OrdinalIgnoreCase))
+            .ToDictionary(item => item.Key, item => item.Value.ToArray(), StringComparer.OrdinalIgnoreCase);
+        var headers = context.Request.Headers
+            .Where(item => !string.Equals(item.Key, "Authorization", StringComparison.OrdinalIgnoreCase))
+            .ToDictionary(item => item.Key, item => item.Value.ToArray(), StringComparer.OrdinalIgnoreCase);
+        var body = JsonSerializer.SerializeToUtf8Bytes(new
+        {
+            claims,
+            query,
+            headers,
+            subprotocols = context.WebSockets.WebSocketRequestedProtocols,
+            clientCertificates = Array.Empty<object>(),
+        });
+
+        return new UpstreamEvent(
+            0,
+            hub,
+            "connect",
+            UpstreamEventCategory.System,
+            connectionId,
+            user.FindFirstValue("sub") ?? user.FindFirstValue(ClaimTypes.NameIdentifier),
+            null,
+            null,
+            new MessageData(MessageDataType.Json, body),
+            context.Request.Host.ToString());
+    }
+
+    private static bool TryApplyConnectResponse(
+        HttpContext context,
+        ClaimsPrincipal user,
+        string? selectedSubprotocol,
+        ConnectEventResponse? response,
+        out ClaimsPrincipal resultUser,
+        out string? resultSubprotocol,
+        out string error)
+    {
+        resultUser = user;
+        resultSubprotocol = selectedSubprotocol;
+        error = string.Empty;
+        if (response is null)
+        {
+            return true;
+        }
+
+        if (response.Subprotocol is not null)
+        {
+            if (!context.WebSockets.WebSocketRequestedProtocols.Contains(
+                response.Subprotocol,
+                StringComparer.Ordinal))
+            {
+                error = $"The connect event handler selected unrequested subprotocol '{response.Subprotocol}'.";
+                return false;
+            }
+            resultSubprotocol = response.Subprotocol;
+        }
+
+        var claims = user.Claims.ToList();
+        if (response.UserId is not null)
+        {
+            claims.RemoveAll(claim => claim.Type is "sub" || claim.Type == ClaimTypes.NameIdentifier);
+            claims.Add(new Claim("sub", response.UserId));
+        }
+        if (response.Roles is not null)
+        {
+            claims.RemoveAll(claim => claim.Type is "role" || claim.Type == ClaimTypes.Role);
+            claims.AddRange(response.Roles.Select(role => new Claim("role", role)));
+        }
+        if (response.Groups?.Length > 0)
+        {
+            claims.RemoveAll(claim => claim.Type == "webpubsub.group");
+            claims.AddRange(response.Groups.Select(group => new Claim("webpubsub.group", group)));
+        }
+        resultUser = new ClaimsPrincipal(new ClaimsIdentity(claims, user.Identity?.AuthenticationType));
+        return true;
     }
 
     private static bool TryGetRawSendToGroup(

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ConnectionManager.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ConnectionManager.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Net.WebSockets;
 using System.Security.Claims;
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebPubSub.Emulator;
@@ -14,13 +15,16 @@ internal sealed class ConnectionManager
     private readonly ConcurrentDictionary<(string Hub, string ConnectionId), LogicalConnection> _connections = [];
     private readonly EmulatorRuntimeOptions _runtimeOptions;
     private readonly ILogger<ConnectionManager> _logger;
+    private readonly UpstreamEventDispatcher _events;
 
     public ConnectionManager(
         EmulatorRuntimeOptions runtimeOptions,
-        ILogger<ConnectionManager> logger)
+        ILogger<ConnectionManager> logger,
+        UpstreamEventDispatcher events)
     {
         _runtimeOptions = runtimeOptions;
         _logger = logger;
+        _events = events;
     }
 
     public LogicalConnection Create(
@@ -29,7 +33,8 @@ internal sealed class ConnectionManager
         ClaimsPrincipal user,
         string? rawSendToGroup = null,
         bool reliable = false,
-        string? subprotocol = null)
+        string? subprotocol = null,
+        string host = "localhost")
     {
         return new LogicalConnection(
             connectionId,
@@ -40,7 +45,8 @@ internal sealed class ConnectionManager
             _runtimeOptions,
             reliable,
             subprotocol,
-            _logger);
+            _logger,
+            host);
     }
 
     public bool TryActivate(LogicalConnection connection)
@@ -171,7 +177,17 @@ internal sealed class ConnectionManager
 
     public void Remove(LogicalConnection connection)
     {
-        _connections.TryRemove((connection.Hub, connection.ConnectionId), out _);
+        if (_connections.TryRemove((connection.Hub, connection.ConnectionId), out _))
+        {
+            var body = JsonSerializer.SerializeToUtf8Bytes(new
+            {
+                reason = connection.GetDisconnectReason(),
+            });
+            _ = _events.DispatchNotificationAsync(
+                connection.CreateSystemEvent(
+                    "disconnected",
+                    new MessageData(MessageDataType.Json, body)));
+        }
     }
 
     public void ScheduleExpiration(LogicalConnection connection, long generation)

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorApplication.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorApplication.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 using System.Reflection;
+using Azure.Core;
+using Azure.Identity;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Controllers;
@@ -26,12 +28,28 @@ internal static class EmulatorApplication
                 options => EmulatorOptions.IsValidAccessKey(options.AccessKey),
                 "WebPubSub:AccessKey must be at least 32 UTF-8 bytes and cannot contain " +
                     "leading or trailing whitespace, semicolons, or control characters.")
+            .Validate(
+                ValidateEventConfiguration,
+                "WebPubSub event handler or event listener configuration is invalid.")
             .ValidateOnStart();
         builder.Services.AddSingleton(runtimeOptions ?? new EmulatorRuntimeOptions());
+        builder.Services.AddSingleton<TokenCredential>(services =>
+        {
+            var options = services.GetRequiredService<IOptions<EmulatorOptions>>().Value;
+            return new DefaultAzureCredential(new DefaultAzureCredentialOptions
+            {
+                ManagedIdentityClientId = options.ManagedIdentityClientId,
+            });
+        });
         builder.Services.AddSingleton<WebPubSubTokenService>();
         builder.Services.AddSingleton<ConnectionManager>();
         builder.Services.AddSingleton<SimpleWebSocketPayloadProcessor>();
         builder.Services.AddSingleton<WebPubSubJsonV1Protocol>();
+        builder.Services.AddSingleton<UpstreamEventDispatcher>();
+        builder.Services.AddHttpClient(UpstreamEventDispatcher.HttpClientName, client =>
+        {
+            client.Timeout = Timeout.InfiniteTimeSpan;
+        });
         builder.Services.AddSingleton<
             IWebPubSubConnectionLifetimeHandler,
             WebPubSubClientConnectionLifetimeHandler>();
@@ -82,6 +100,34 @@ internal static class EmulatorApplication
             (HttpContext context, ClientWebSocketEndpoint endpoint) => endpoint.HandleAsync(context));
 
         return app;
+    }
+
+    private static bool ValidateEventConfiguration(EmulatorOptions options)
+    {
+        foreach (var hub in options.Hubs.Values)
+        {
+            foreach (var handler in hub.EventHandlers)
+            {
+                if (!EventHandlerUrlTemplate.TryResolve(handler.UrlTemplate, "hub", "event", out _) ||
+                    handler.EventPattern?.Split(',')
+                        .Select(pattern => pattern.Trim())
+                        .Any(pattern => !WildcardPattern.TryCreate(pattern, out _)) == true)
+                {
+                    return false;
+                }
+
+                var auth = handler.Auth;
+                if (auth is not null &&
+                    !string.Equals(auth.Type, "None", StringComparison.OrdinalIgnoreCase) &&
+                    (!string.Equals(auth.Type, "ManagedIdentity", StringComparison.OrdinalIgnoreCase) ||
+                        string.IsNullOrWhiteSpace(auth.ManagedIdentity?.Resource)))
+                {
+                    return false;
+                }
+            }
+
+        }
+        return true;
     }
 
     private sealed class EmulatorControllerFeatureProvider : ControllerFeatureProvider

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorOptions.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorOptions.cs
@@ -13,6 +13,11 @@ internal sealed class EmulatorOptions
 
     public bool AllowUnvalidatedEntraTokens { get; set; }
 
+    public string? ManagedIdentityClientId { get; set; }
+
+    public Dictionary<string, HubOptions> Hubs { get; set; } =
+        new(StringComparer.OrdinalIgnoreCase);
+
     public string GetConnectionString(Uri endpoint)
     {
         return $"Endpoint={endpoint.GetLeftPart(UriPartial.Authority)};" +
@@ -26,6 +31,34 @@ internal sealed class EmulatorOptions
             !accessKey.Any(character => character == ';' || char.IsControl(character)) &&
             System.Text.Encoding.UTF8.GetByteCount(accessKey) >= 32;
     }
+}
+
+internal sealed class HubOptions
+{
+    public EventHandlerOptions[] EventHandlers { get; set; } = [];
+}
+
+internal sealed class EventHandlerOptions
+{
+    public string UrlTemplate { get; set; } = string.Empty;
+
+    public string? EventPattern { get; set; }
+
+    public string[] SystemEvents { get; set; } = [];
+
+    public EventHandlerAuthOptions? Auth { get; set; }
+}
+
+internal sealed class EventHandlerAuthOptions
+{
+    public string Type { get; set; } = "None";
+
+    public ManagedIdentityAuthOptions? ManagedIdentity { get; set; }
+}
+
+internal sealed class ManagedIdentityAuthOptions
+{
+    public string Resource { get; set; } = string.Empty;
 }
 
 internal sealed class EmulatorRuntimeOptions

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EventHandlerUrlTemplate.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EventHandlerUrlTemplate.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text.RegularExpressions;
+
+namespace Microsoft.Azure.WebPubSub.Emulator;
+
+internal static partial class EventHandlerUrlTemplate
+{
+    [GeneratedRegex(
+        "\\{(?:hub|event|@Microsoft\\.KeyVault\\(SecretUri=(?<secretIdentity>.+?)\\))\\}",
+        RegexOptions.IgnoreCase)]
+    private static partial Regex ParameterRegex();
+
+    public static bool TryResolve(
+        string urlTemplate,
+        string hub,
+        string eventName,
+        out Uri? uri)
+    {
+        var resolved = ParameterRegex().Replace(urlTemplate, match =>
+        {
+            if (match.Value.Equals("{hub}", StringComparison.OrdinalIgnoreCase))
+            {
+                return Uri.EscapeDataString(hub);
+            }
+            if (match.Value.Equals("{event}", StringComparison.OrdinalIgnoreCase))
+            {
+                return Uri.EscapeDataString(eventName);
+            }
+            return match.Value;
+        });
+        return Uri.TryCreate(resolved, UriKind.Absolute, out uri) &&
+            uri.Scheme is "http" or "https";
+    }
+
+    public static Uri Resolve(string urlTemplate, string hub, string eventName)
+    {
+        if (!TryResolve(urlTemplate, hub, eventName, out var uri))
+        {
+            throw new InvalidDataException(
+                $"Event handler URL '{urlTemplate}' is not an absolute HTTP or HTTPS URL.");
+        }
+        return uri!;
+    }
+}

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/LogicalConnection.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/LogicalConnection.cs
@@ -33,10 +33,12 @@ internal sealed class LogicalConnection : IODataFilterModel
     private SocketTransport? _activeTransport;
     private SocketTransport? _detachedTransport;
     private long _generation;
+    private int _nextEventId;
     private ulong _nextSequenceId;
     private long _unacknowledgedBytes;
     private bool _closed;
     private bool _reconnecting;
+    private string _disconnectReason = "The connection ended.";
 
     public LogicalConnection(
         string connectionId,
@@ -47,10 +49,12 @@ internal sealed class LogicalConnection : IODataFilterModel
         EmulatorRuntimeOptions runtimeOptions,
         bool reliable = false,
         string? subprotocol = null,
-        ILogger? logger = null)
+        ILogger? logger = null,
+        string host = "localhost")
     {
         ConnectionId = connectionId;
         Hub = hub;
+        Host = host;
         RawSendToGroup = rawSendToGroup;
         IsReliable = reliable;
         Subprotocol = subprotocol;
@@ -91,6 +95,8 @@ internal sealed class LogicalConnection : IODataFilterModel
 
     public string Hub { get; }
 
+    public string Host { get; }
+
     public string? RawSendToGroup { get; }
 
     public string? UserId { get; }
@@ -99,6 +105,8 @@ internal sealed class LogicalConnection : IODataFilterModel
 
     public string? Subprotocol { get; }
 
+    public string? ConnectionState { get; set; }
+
     public AckCache AckIdCache { get; } = new();
 
     public ConcurrentDictionary<string, byte> Groups { get; } = new(StringComparer.Ordinal);
@@ -106,6 +114,36 @@ internal sealed class LogicalConnection : IODataFilterModel
     string[] IODataFilterModel.Groups => Groups.Keys.ToArray();
 
     string? IODataFilterModel.Protocol => Subprotocol;
+
+    public UpstreamEvent CreateUserEvent(string eventName, MessageData data)
+    {
+        return new UpstreamEvent(
+            Interlocked.Increment(ref _nextEventId),
+            Hub,
+            eventName,
+            UpstreamEventCategory.User,
+            ConnectionId,
+            UserId,
+            Subprotocol,
+            ConnectionState,
+            data,
+            Host);
+    }
+
+    public UpstreamEvent CreateSystemEvent(string eventName, MessageData data)
+    {
+        return new UpstreamEvent(
+            Interlocked.Increment(ref _nextEventId),
+            Hub,
+            eventName,
+            UpstreamEventCategory.System,
+            ConnectionId,
+            UserId,
+            Subprotocol,
+            ConnectionState,
+            data,
+            Host);
+    }
 
     public SocketTransport? TryAttach(
         WebSocket webSocket,
@@ -512,6 +550,7 @@ internal sealed class LogicalConnection : IODataFilterModel
             }
 
             transport.TryCloseOutput(closeStatus, closeDescription);
+            _disconnectReason = GetDisconnectReason(closeDescription);
             _closed = true;
             _activeTransport = null;
             _detachedTransport = null;
@@ -539,13 +578,15 @@ internal sealed class LogicalConnection : IODataFilterModel
         return Close(
             WebSocketCloseStatus.NormalClosure,
             string.Empty,
-            processor => processor.EncodeDisconnected(message));
+            processor => processor.EncodeDisconnected(message),
+            message);
     }
 
     private SocketTransport? Close(
         WebSocketCloseStatus closeStatus,
         string closeDescription,
-        Func<IClientPayloadProcessor, WebSocketPayload?>? finalPayloadFactory)
+        Func<IClientPayloadProcessor, WebSocketPayload?>? finalPayloadFactory,
+        string? disconnectReason = null)
     {
         SocketTransport? transport;
         lock (_stateLock)
@@ -560,6 +601,7 @@ internal sealed class LogicalConnection : IODataFilterModel
                 ? finalPayloadFactory?.Invoke(_activePayloadProcessor)
                 : null;
             transport?.TryCloseOutput(closeStatus, closeDescription, finalPayload);
+            _disconnectReason = GetDisconnectReason(disconnectReason ?? closeDescription);
             _closed = true;
             _activeTransport = null;
             _detachedTransport = null;
@@ -571,7 +613,7 @@ internal sealed class LogicalConnection : IODataFilterModel
         return transport;
     }
 
-    public void Detach(SocketTransport transport)
+    public void Detach(SocketTransport transport, string? reason = null)
     {
         var remove = false;
         var expire = false;
@@ -583,6 +625,7 @@ internal sealed class LogicalConnection : IODataFilterModel
                 _activeTransport = null;
                 if (_closed || !IsReliable || transport.IsClosing)
                 {
+                    _disconnectReason = GetDisconnectReason(reason);
                     _activePayloadProcessor = null;
                     _detachedTransport = null;
                     _closed = true;
@@ -618,6 +661,7 @@ internal sealed class LogicalConnection : IODataFilterModel
             }
 
             _closed = true;
+            _disconnectReason = "The connection recovery timeout expired.";
             _activePayloadProcessor = null;
             _detachedTransport?.Abort();
             _detachedTransport = null;
@@ -639,6 +683,10 @@ internal sealed class LogicalConnection : IODataFilterModel
 
     private void FailConnection(SocketTransport? transport, string reason)
     {
+        lock (_stateLock)
+        {
+            _disconnectReason = reason;
+        }
         _manager.Remove(this);
         _logger?.LogDebug(
             "Closing connection {ConnectionId}: {Reason}",
@@ -651,5 +699,20 @@ internal sealed class LogicalConnection : IODataFilterModel
     {
         _unacknowledgedMessages.Clear();
         _unacknowledgedBytes = 0;
+    }
+
+    public string GetDisconnectReason()
+    {
+        lock (_stateLock)
+        {
+            return _disconnectReason;
+        }
+    }
+
+    private static string GetDisconnectReason(string? closeDescription)
+    {
+        return string.IsNullOrEmpty(closeDescription)
+            ? "The connection ended."
+            : closeDescription;
     }
 }

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/Microsoft.Azure.WebPubSub.Emulator.csproj
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/Microsoft.Azure.WebPubSub.Emulator.csproj
@@ -26,6 +26,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.OData.Core" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
   </ItemGroup>

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/SimpleWebSocketPayloadProcessor.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/SimpleWebSocketPayloadProcessor.cs
@@ -8,39 +8,76 @@ namespace Microsoft.Azure.WebPubSub.Emulator;
 internal sealed class SimpleWebSocketPayloadProcessor : IClientPayloadProcessor
 {
     private readonly ConnectionManager _connections;
-    public SimpleWebSocketPayloadProcessor(ConnectionManager connections)
+    private readonly IWebPubSubConnectionLifetimeHandler? _lifetimeHandler;
+
+    public SimpleWebSocketPayloadProcessor(
+        ConnectionManager connections,
+        IWebPubSubConnectionLifetimeHandler? lifetimeHandler = null)
     {
         _connections = connections;
+        _lifetimeHandler = lifetimeHandler;
     }
 
     public void OnConnected(LogicalConnection connection)
     {
     }
 
-    public ValueTask<PayloadProcessingResult> ProcessAsync(
+    public async ValueTask<PayloadProcessingResult> ProcessAsync(
         LogicalConnection connection,
         WebSocketMessageType messageType,
         byte[] payload,
         CancellationToken cancellationToken)
     {
         var sendToGroup = connection.RawSendToGroup;
-        if (sendToGroup is null || !connection.CanSendToGroup(sendToGroup))
+        if (sendToGroup is not null)
         {
-            return ValueTask.FromResult(PayloadProcessingResult.Close(
-                WebSocketCloseStatus.PolicyViolation,
-                "The connection is not authorized for raw sendToGroup mode."));
+            if (!connection.CanSendToGroup(sendToGroup))
+            {
+                return PayloadProcessingResult.Close(
+                    WebSocketCloseStatus.PolicyViolation,
+                    "The connection is not authorized for raw sendToGroup mode.");
+            }
+
+            var groupDataType = messageType == WebSocketMessageType.Binary
+                ? MessageDataType.Binary
+                : MessageDataType.Text;
+            _connections.SendToGroup(
+                connection.Hub,
+                sendToGroup,
+                new MessageData(groupDataType, payload),
+                connection,
+                noEcho: false);
+            return PayloadProcessingResult.Continue;
         }
 
         var dataType = messageType == WebSocketMessageType.Binary
             ? MessageDataType.Binary
             : MessageDataType.Text;
-        _connections.SendToGroup(
-            connection.Hub,
-            sendToGroup,
-            new MessageData(dataType, payload),
-            connection,
-            noEcho: false);
-        return ValueTask.FromResult(PayloadProcessingResult.Continue);
+        if (_lifetimeHandler is null)
+        {
+            return PayloadProcessingResult.Close(
+                WebSocketCloseStatus.InternalServerError,
+                "No event handler is configured.");
+        }
+
+        try
+        {
+            var result = await _lifetimeHandler.SendMessageAsync(
+                connection,
+                new ClientMessagePayload("message", new MessageData(dataType, payload)),
+                cancellationToken);
+            if (result.Response is not null)
+            {
+                connection.SendServerData(result.Response);
+            }
+            return PayloadProcessingResult.Continue;
+        }
+        catch (InvalidOperationException exception)
+        {
+            return PayloadProcessingResult.Close(
+                WebSocketCloseStatus.InternalServerError,
+                exception.Message);
+        }
     }
 
     public WebSocketPayload EncodeGroupData(

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/UpstreamEventDispatcher.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/UpstreamEventDispatcher.cs
@@ -1,0 +1,345 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Azure.Core;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.WebPubSub.Emulator;
+
+internal sealed class UpstreamEventDispatcher
+{
+    public const string HttpClientName = "WebPubSubEventHandler";
+
+    private const int MaximumResponseBytes = 16 * 1024 * 1024;
+    private const string MetadataHeaderPrefix = "X-WebPubSub-Metadata-";
+    private readonly EmulatorOptions _options;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly TokenCredential _credential;
+    private readonly ILogger<UpstreamEventDispatcher> _logger;
+
+    public UpstreamEventDispatcher(
+        IOptions<EmulatorOptions> options,
+        IHttpClientFactory httpClientFactory,
+        TokenCredential credential,
+        ILogger<UpstreamEventDispatcher> logger)
+    {
+        _options = options.Value;
+        _httpClientFactory = httpClientFactory;
+        _credential = credential;
+        _logger = logger;
+    }
+
+    public async Task<ConnectDispatchResult> DispatchConnectAsync(
+        UpstreamEvent upstreamEvent,
+        CancellationToken cancellationToken)
+    {
+        var handler = GetMatchingHandler(upstreamEvent);
+        if (handler is null)
+        {
+            return new(HttpStatusCode.OK, null, null, null);
+        }
+
+        try
+        {
+            using var response = await SendToHandlerAsync(handler, upstreamEvent, cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                return new(
+                    response.StatusCode,
+                    null,
+                    null,
+                    $"The connect event handler returned {(int)response.StatusCode}.");
+            }
+
+            var bytes = await ReadContentAsync(response.Content, cancellationToken);
+            var connectResponse = bytes.Length == 0
+                ? null
+                : JsonSerializer.Deserialize<ConnectEventResponse>(bytes, JsonSerializerOptions.Web);
+            return new(
+                response.StatusCode,
+                connectResponse,
+                GetHeaderValue(response, "ce-connectionState"),
+                null);
+        }
+        catch (Exception exception) when (
+            exception is JsonException or InvalidDataException or HttpRequestException or TaskCanceledException)
+        {
+            _logger.LogWarning(exception, "Dispatching the connect event failed.");
+            return new(
+                HttpStatusCode.InternalServerError,
+                null,
+                null,
+                "Dispatching the connect event failed.");
+        }
+    }
+
+    public async Task<UserEventDispatchResult> DispatchUserEventAsync(
+        UpstreamEvent upstreamEvent,
+        CancellationToken cancellationToken)
+    {
+        var handler = GetMatchingHandler(upstreamEvent);
+        if (handler is null)
+        {
+            return new(false, null, null, "No event handler is configured.");
+        }
+
+        try
+        {
+            using var response = await SendToHandlerAsync(handler, upstreamEvent, cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                return new(false, null, null, $"The event handler returned {(int)response.StatusCode}.");
+            }
+
+            var bytes = await ReadContentAsync(response.Content, cancellationToken);
+            var metadata = GetMetadata(response);
+            WebPubSubMetadataValidator.Validate(metadata);
+            var responseData = bytes.Length == 0 && metadata is null
+                ? null
+                : new MessageData(GetDataType(response.Content.Headers.ContentType), bytes, metadata);
+            return new(
+                true,
+                responseData,
+                GetHeaderValue(response, "ce-connectionState"),
+                null);
+        }
+        catch (Exception exception) when (
+            exception is HttpRequestException or TaskCanceledException or InvalidDataException)
+        {
+            _logger.LogWarning(
+                exception,
+                "Dispatching user event {EventName} for connection {ConnectionId} failed.",
+                upstreamEvent.EventName,
+                upstreamEvent.ConnectionId);
+            return new(false, null, null, "Dispatching the event failed.");
+        }
+    }
+
+    public async Task DispatchNotificationAsync(
+        UpstreamEvent upstreamEvent,
+        CancellationToken cancellationToken = default)
+    {
+        var handler = GetMatchingHandler(upstreamEvent);
+        if (handler is null)
+        {
+            return;
+        }
+
+        try
+        {
+            using var response = await SendToHandlerAsync(handler, upstreamEvent, cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "The {EventName} event handler returned {StatusCode} for connection {ConnectionId}.",
+                    upstreamEvent.EventName,
+                    (int)response.StatusCode,
+                    upstreamEvent.ConnectionId);
+            }
+        }
+        catch (Exception exception) when (
+            exception is HttpRequestException or TaskCanceledException or InvalidDataException)
+        {
+            _logger.LogWarning(
+                exception,
+                "Dispatching {EventName} for connection {ConnectionId} failed.",
+                upstreamEvent.EventName,
+                upstreamEvent.ConnectionId);
+        }
+    }
+
+    private async Task<HttpResponseMessage> SendToHandlerAsync(
+        EventHandlerOptions handler,
+        UpstreamEvent upstreamEvent,
+        CancellationToken cancellationToken)
+    {
+        var uri = EventHandlerUrlTemplate.Resolve(
+            handler.UrlTemplate,
+            upstreamEvent.Hub,
+            upstreamEvent.EventName);
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, uri)
+        {
+            Version = HttpVersion.Version20,
+            VersionPolicy = HttpVersionPolicy.RequestVersionOrLower,
+            Content = new ByteArrayContent(upstreamEvent.Data.Bytes.ToArray()),
+        };
+        request.Content.Headers.ContentType = new MediaTypeHeaderValue(GetContentType(upstreamEvent.Data.Type));
+        AddCloudEventHeaders(request, upstreamEvent);
+        AddMetadataHeaders(request, upstreamEvent.Data.Metadata);
+        await AddAuthorizationAsync(request, handler.Auth, cancellationToken);
+
+        return await _httpClientFactory.CreateClient(HttpClientName).SendAsync(
+            request,
+            HttpCompletionOption.ResponseHeadersRead,
+            cancellationToken);
+    }
+
+    private async Task AddAuthorizationAsync(
+        HttpRequestMessage request,
+        EventHandlerAuthOptions? auth,
+        CancellationToken cancellationToken)
+    {
+        if (auth is null || string.Equals(auth.Type, "None", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+        if (!string.Equals(auth.Type, "ManagedIdentity", StringComparison.OrdinalIgnoreCase) ||
+            string.IsNullOrWhiteSpace(auth.ManagedIdentity?.Resource))
+        {
+            throw new InvalidDataException(
+                "Event handler auth must be None or ManagedIdentity with a resource.");
+        }
+
+        var scope = $"{auth.ManagedIdentity.Resource.TrimEnd('/')}/.default";
+        var token = await _credential.GetTokenAsync(
+            new TokenRequestContext([scope]),
+            cancellationToken);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token.Token);
+    }
+
+    private EventHandlerOptions? GetMatchingHandler(UpstreamEvent upstreamEvent)
+    {
+        return GetHubOptions(upstreamEvent.Hub)?.EventHandlers.FirstOrDefault(handler =>
+            upstreamEvent.Category == UpstreamEventCategory.User
+                ? MatchesPatternList(handler.EventPattern, upstreamEvent.EventName)
+                : handler.SystemEvents.Contains(upstreamEvent.EventName, StringComparer.OrdinalIgnoreCase));
+    }
+
+    private HubOptions? GetHubOptions(string hub)
+    {
+        return _options.Hubs.TryGetValue(hub, out var options) ||
+            _options.Hubs.TryGetValue("_default", out options)
+            ? options
+            : null;
+    }
+
+    private static bool MatchesPatternList(string? patterns, string input)
+    {
+        return patterns?.Split(',')
+            .Select(value => value.Trim())
+            .Any(value => MatchesPattern(value, input)) == true;
+    }
+
+    private static bool MatchesPattern(string pattern, string input)
+    {
+        return WildcardPattern.TryCreate(pattern, out var matcher) &&
+            matcher!.Matches(input, ignoreCase: true);
+    }
+
+    private void AddCloudEventHeaders(HttpRequestMessage request, UpstreamEvent upstreamEvent)
+    {
+        request.Headers.TryAddWithoutValidation("ce-specversion", "1.0");
+        request.Headers.TryAddWithoutValidation("ce-awpsversion", "1.0");
+        request.Headers.TryAddWithoutValidation("ce-type", upstreamEvent.Type);
+        request.Headers.TryAddWithoutValidation("ce-source", upstreamEvent.Source);
+        request.Headers.TryAddWithoutValidation("ce-id", upstreamEvent.Id.ToString());
+        request.Headers.TryAddWithoutValidation("ce-time", DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ"));
+        request.Headers.TryAddWithoutValidation("ce-connectionId", upstreamEvent.ConnectionId);
+        request.Headers.TryAddWithoutValidation("ce-hub", upstreamEvent.Hub);
+        request.Headers.TryAddWithoutValidation("ce-eventName", upstreamEvent.EventName);
+        var signature = HMACSHA256.HashData(
+            Encoding.UTF8.GetBytes(_options.AccessKey),
+            Encoding.UTF8.GetBytes(upstreamEvent.ConnectionId));
+        request.Headers.TryAddWithoutValidation("ce-signature", $"sha256={Convert.ToHexStringLower(signature)}");
+        request.Headers.TryAddWithoutValidation("WebHook-Request-Origin", upstreamEvent.Host);
+        AddIfNotEmpty(request, "ce-userId", upstreamEvent.UserId);
+        AddIfNotEmpty(request, "ce-subprotocol", upstreamEvent.Subprotocol);
+        AddIfNotEmpty(request, "ce-connectionState", upstreamEvent.ConnectionState);
+    }
+
+    private static void AddIfNotEmpty(HttpRequestMessage request, string name, string? value)
+    {
+        if (!string.IsNullOrEmpty(value))
+        {
+            request.Headers.TryAddWithoutValidation(name, value);
+        }
+    }
+
+    private static void AddMetadataHeaders(
+        HttpRequestMessage request,
+        IReadOnlyDictionary<string, string>? metadata)
+    {
+        if (metadata is null)
+        {
+            return;
+        }
+        foreach (var item in metadata)
+        {
+            request.Headers.TryAddWithoutValidation($"{MetadataHeaderPrefix}{item.Key.ToLowerInvariant()}", item.Value);
+        }
+    }
+
+    private static IReadOnlyDictionary<string, string>? GetMetadata(HttpResponseMessage response)
+    {
+        Dictionary<string, string>? metadata = null;
+        foreach (var header in response.Headers)
+        {
+            if (!header.Key.StartsWith(MetadataHeaderPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+            var key = header.Key[MetadataHeaderPrefix.Length..].ToLowerInvariant();
+            if (key.Length == 0)
+            {
+                continue;
+            }
+            metadata ??= new Dictionary<string, string>(StringComparer.Ordinal);
+            metadata[key] = header.Value.LastOrDefault() ?? string.Empty;
+        }
+        return metadata;
+    }
+
+    private static string? GetHeaderValue(HttpResponseMessage response, string name)
+    {
+        return response.Headers.TryGetValues(name, out var values) ? values.LastOrDefault() : null;
+    }
+
+    private static string GetContentType(MessageDataType dataType)
+    {
+        return dataType switch
+        {
+            MessageDataType.Text => "text/plain",
+            MessageDataType.Binary => "application/octet-stream",
+            MessageDataType.Json => "application/json",
+            _ => throw new InvalidOperationException($"Unsupported data type '{dataType}'."),
+        };
+    }
+
+    private static MessageDataType GetDataType(MediaTypeHeaderValue? contentType)
+    {
+        return contentType?.MediaType?.ToLowerInvariant() switch
+        {
+            null or "text/plain" => MessageDataType.Text,
+            "application/json" => MessageDataType.Json,
+            "application/octet-stream" => MessageDataType.Binary,
+            _ => throw new InvalidDataException($"Unsupported event handler response content type '{contentType}'."),
+        };
+    }
+
+    private static async Task<byte[]> ReadContentAsync(HttpContent content, CancellationToken cancellationToken)
+    {
+        await using var stream = await content.ReadAsStreamAsync(cancellationToken);
+        using var buffer = new MemoryStream();
+        var bytes = new byte[81920];
+        while (true)
+        {
+            var read = await stream.ReadAsync(bytes, cancellationToken);
+            if (read == 0)
+            {
+                return buffer.ToArray();
+            }
+            if (buffer.Length + read > MaximumResponseBytes)
+            {
+                throw new InvalidDataException($"Event handler response exceeds {MaximumResponseBytes} bytes.");
+            }
+            buffer.Write(bytes, 0, read);
+        }
+    }
+}

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/UpstreamEventModels.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/UpstreamEventModels.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Net;
+
+namespace Microsoft.Azure.WebPubSub.Emulator;
+
+internal enum UpstreamEventCategory
+{
+    System,
+    User,
+}
+
+internal sealed record UpstreamEvent(
+    int Id,
+    string Hub,
+    string EventName,
+    UpstreamEventCategory Category,
+    string ConnectionId,
+    string? UserId,
+    string? Subprotocol,
+    string? ConnectionState,
+    MessageData Data,
+    string Host)
+{
+    public string Type => Category == UpstreamEventCategory.User
+        ? $"azure.webpubsub.user.{EventName}"
+        : $"azure.webpubsub.sys.{EventName}";
+
+    public string Source => $"/hubs/{Hub}/client/{ConnectionId}";
+}
+
+internal sealed record UserEventDispatchResult(
+    bool Succeeded,
+    MessageData? Response,
+    string? ConnectionState,
+    string? Error);
+
+internal sealed record ConnectEventResponse(
+    string? Subprotocol,
+    string[]? Roles,
+    string? UserId,
+    string[]? Groups);
+
+internal sealed record ConnectDispatchResult(
+    HttpStatusCode StatusCode,
+    ConnectEventResponse? Response,
+    string? ConnectionState,
+    string? Error)
+{
+    public bool Succeeded => (int)StatusCode is >= 200 and <= 299;
+}

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubClientConnectionLifetimeHandler.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubClientConnectionLifetimeHandler.cs
@@ -20,12 +20,27 @@ internal sealed record UpstreamEventResult(MessageData? Response = null);
 internal sealed class WebPubSubClientConnectionLifetimeHandler :
     IWebPubSubConnectionLifetimeHandler
 {
-    public Task<UpstreamEventResult> SendMessageAsync(
+    private readonly UpstreamEventDispatcher _events;
+
+    public WebPubSubClientConnectionLifetimeHandler(UpstreamEventDispatcher events)
+    {
+        _events = events;
+    }
+
+    public async Task<UpstreamEventResult> SendMessageAsync(
         LogicalConnection connection,
         ClientMessagePayload message,
         CancellationToken cancellationToken = default)
     {
-        throw new NotImplementedException(
-            "HTTP upstream event handlers are not implemented.");
+        var result = await _events.DispatchUserEventAsync(
+            connection.CreateUserEvent(message.EventName, message.Data),
+            cancellationToken);
+        if (!result.Succeeded)
+        {
+            throw new InvalidOperationException(result.Error);
+        }
+
+        connection.ConnectionState = result.ConnectionState ?? connection.ConnectionState;
+        return new UpstreamEventResult(result.Response);
     }
 }

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/EmulatorApplicationTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/EmulatorApplicationTests.cs
@@ -21,6 +21,21 @@ public class EmulatorApplicationTests
     private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(30);
 
     [Fact]
+    public void EventHandlerUrlTemplateResolvesRuntimeParameters()
+    {
+        const string template =
+            "https://example.test/{HUB}/{event}/{unknown}/" +
+            "{@Microsoft.KeyVault(SecretUri=https://vault.example/secrets/path)}";
+
+        var uri = EventHandlerUrlTemplate.Resolve(template, "tenant/chat", "message sent");
+
+        Assert.Equal(
+            "https://example.test/tenant%2Fchat/message%20sent/{unknown}/" +
+                "{@Microsoft.KeyVault(SecretUri=https://vault.example/secrets/path)}",
+            uri.OriginalString);
+    }
+
+    [Fact]
     public async Task EffectiveEndpointComesFromBoundAddress()
     {
         const string accessKey = "custom-emulator-access-key-1234567890";
@@ -91,6 +106,24 @@ public class EmulatorApplicationTests
 
         Assert.Contains(
             "WebPubSub:AccessKey must be at least 32 UTF-8 bytes",
+            exception.Message,
+            StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("WebPubSub:Hubs:chat:EventHandlers:0:UrlTemplate", "not-a-url")]
+    [InlineData("WebPubSub:Hubs:chat:EventHandlers:0:Auth:Type", "ApiKey")]
+    public async Task InvalidEventConfigurationIsRejected(string key, string value)
+    {
+        var builder = EmulatorApplication.CreateBuilder([$"--{key}={value}"]);
+        builder.WebHost.UseTestServer();
+        await using var application = EmulatorApplication.Build(builder);
+
+        var exception = await Assert.ThrowsAsync<OptionsValidationException>(
+            () => application.StartAsync());
+
+        Assert.Contains(
+            "event handler or event listener configuration is invalid",
             exception.Message,
             StringComparison.Ordinal);
     }

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/UpstreamEventIntegrationTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/UpstreamEventIntegrationTests.cs
@@ -1,0 +1,420 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Net.WebSockets;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Microsoft.Azure.WebPubSub.Emulator.Tests;
+
+public class UpstreamEventIntegrationTests
+{
+    private const string Hub = "testHub";
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(30);
+
+    [Fact]
+    public async Task HttpHandlerProcessesConnectionLifecycleAndUserEvent()
+    {
+        var handler = new RecordingEventHandler(request =>
+        {
+            var eventName = request.Headers.GetValues("ce-eventName").Single();
+            if (eventName == "connect")
+            {
+                var response = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = JsonContent.Create(new
+                    {
+                        userId = "handler-user",
+                        roles = new[] { "webpubsub.sendToGroups.room-*" },
+                        groups = new[] { "room-a" },
+                    }),
+                };
+                response.Headers.TryAddWithoutValidation("ce-connectionState", "initial-state");
+                return response;
+            }
+            if (eventName == "chat-message")
+            {
+                var response = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("handler-response", Encoding.UTF8, "text/plain"),
+                };
+                response.Headers.TryAddWithoutValidation("ce-connectionState", "updated-state");
+                response.Headers.TryAddWithoutValidation("X-WebPubSub-Metadata-Result", "handled");
+                return response;
+            }
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        });
+        await using var application = await StartApplicationAsync(handler, new Dictionary<string, string?>
+        {
+            ["WebPubSub:Hubs:testHub:EventHandlers:0:UrlTemplate"] = "http://handler/events/{hub}/{event}",
+            ["WebPubSub:Hubs:testHub:EventHandlers:0:EventPattern"] = "chat-*",
+            ["WebPubSub:Hubs:testHub:EventHandlers:0:SystemEvents:0"] = "connect",
+            ["WebPubSub:Hubs:testHub:EventHandlers:0:SystemEvents:1"] = "connected",
+            ["WebPubSub:Hubs:testHub:EventHandlers:0:SystemEvents:2"] = "disconnected",
+        });
+        using var webSocket = await ConnectAsync(application, WebPubSubJsonV1PayloadProcessor.SubprotocolName);
+
+        using (var connected = await ReceiveJsonAsync(webSocket))
+        {
+            Assert.Equal("handler-user", connected.RootElement.GetProperty("userId").GetString());
+        }
+        var connect = await handler.ReadAsync();
+        Assert.Equal("connect", connect.EventName);
+        Assert.Equal("0", connect.Headers["ce-id"]);
+        Assert.Equal("azure.webpubsub.sys.connect", connect.Headers["ce-type"]);
+        using (var connectBody = JsonDocument.Parse(connect.Body))
+        {
+            Assert.False(connectBody.RootElement.GetProperty("query").TryGetProperty("access_token", out _));
+        }
+        var connectedEvent = await handler.ReadAsync();
+        Assert.Equal("connected", connectedEvent.EventName);
+        Assert.Equal("1", connectedEvent.Headers["ce-id"]);
+        Assert.Equal("initial-state", connectedEvent.Headers["ce-connectionState"]);
+
+        await SendTextAsync(
+            webSocket,
+            """{"type":"event","event":"chat-message","dataType":"text","data":"client-payload","metadata":{"TraceId":"abc-123"},"ackId":7}""");
+        using (var response = await ReceiveJsonAsync(webSocket))
+        {
+            Assert.Equal("handler-response", response.RootElement.GetProperty("data").GetString());
+            Assert.Equal("handled", response.RootElement.GetProperty("metadata").GetProperty("result").GetString());
+        }
+        using (var ack = await ReceiveJsonAsync(webSocket))
+        {
+            Assert.True(ack.RootElement.GetProperty("success").GetBoolean());
+        }
+        var userEvent = await handler.ReadAsync();
+        Assert.Equal("chat-message", userEvent.EventName);
+        Assert.Equal("abc-123", userEvent.Headers["X-WebPubSub-Metadata-traceid"]);
+        Assert.Equal("client-payload", Encoding.UTF8.GetString(userEvent.Body));
+
+        await webSocket.CloseAsync(
+            WebSocketCloseStatus.NormalClosure,
+            "Test complete.",
+            CancellationToken.None).WaitAsync(TestTimeout);
+        var disconnected = await handler.ReadAsync();
+        Assert.Equal("disconnected", disconnected.EventName);
+        Assert.Equal("updated-state", disconnected.Headers["ce-connectionState"]);
+    }
+
+    [Theory]
+    [InlineData(null, "token-group")]
+    [InlineData("[]", "token-group")]
+    [InlineData("[\"handler-group\"]", "handler-group")]
+    public async Task ConnectResponseGroupsOverrideOnlyWhenNonEmpty(
+        string? responseGroups,
+        string expectedGroup)
+    {
+        var handler = new RecordingEventHandler(request =>
+        {
+            if (request.Headers.GetValues("ce-eventName").Single() != "connect")
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    responseGroups is null ? "{}" : $"{{\"groups\":{responseGroups}}}",
+                    Encoding.UTF8,
+                    "application/json"),
+            };
+        });
+        await using var application = await StartApplicationAsync(handler, new Dictionary<string, string?>
+        {
+            ["WebPubSub:Hubs:testHub:EventHandlers:0:UrlTemplate"] = "http://handler/events/{hub}/{event}",
+            ["WebPubSub:Hubs:testHub:EventHandlers:0:SystemEvents:0"] = "connect",
+        });
+        using var webSocket = await ConnectAsync(
+            application,
+            WebPubSubJsonV1PayloadProcessor.SubprotocolName,
+            [new Claim("webpubsub.group", "token-group")]);
+        using var connected = await ReceiveJsonAsync(webSocket);
+        var connectionId = connected.RootElement.GetProperty("connectionId").GetString()!;
+
+        var connections = application.Services.GetRequiredService<ConnectionManager>();
+        Assert.True(connections.TryGet(Hub.ToLowerInvariant(), connectionId, out var connection));
+        Assert.Equal([expectedGroup], connection.Groups.Keys);
+    }
+
+    [Fact]
+    public async Task RawMessageIsDispatchedAndHandlerResponseIsReturned()
+    {
+        var handler = new RecordingEventHandler(request => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("raw-response", Encoding.UTF8, "text/plain"),
+        });
+        await using var application = await StartApplicationAsync(handler, new Dictionary<string, string?>
+        {
+            ["WebPubSub:Hubs:testHub:EventHandlers:0:UrlTemplate"] = "http://handler/events/{hub}/{event}",
+            ["WebPubSub:Hubs:testHub:EventHandlers:0:EventPattern"] = "message",
+        });
+        using var webSocket = await ConnectAsync(application, subprotocol: null);
+
+        await webSocket.SendAsync(
+            "raw-request"u8.ToArray(),
+            WebSocketMessageType.Text,
+            endOfMessage: true,
+            CancellationToken.None).WaitAsync(TestTimeout);
+        var buffer = new byte[128];
+        var result = await webSocket.ReceiveAsync(buffer, CancellationToken.None).WaitAsync(TestTimeout);
+
+        Assert.Equal(WebSocketMessageType.Text, result.MessageType);
+        Assert.Equal("raw-response", Encoding.UTF8.GetString(buffer, 0, result.Count));
+        var upstream = await handler.ReadAsync();
+        Assert.Equal("message", upstream.EventName);
+        Assert.Equal("raw-request", Encoding.UTF8.GetString(upstream.Body));
+    }
+
+    [Fact]
+    public async Task ConnectHandlerCanSelectRequestedCustomSubprotocol()
+    {
+        const string customSubprotocol = "custom.protocol";
+        var handler = new RecordingEventHandler(request =>
+        {
+            var eventName = request.Headers.GetValues("ce-eventName").Single();
+            return eventName == "connect"
+                ? new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = JsonContent.Create(new { subprotocol = customSubprotocol }),
+                }
+                : new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("custom-response", Encoding.UTF8, "text/plain"),
+                };
+        });
+        await using var application = await StartApplicationAsync(handler, new Dictionary<string, string?>
+        {
+            ["WebPubSub:Hubs:testHub:EventHandlers:0:UrlTemplate"] =
+                "http://handler/events/{hub}/{event}",
+            ["WebPubSub:Hubs:testHub:EventHandlers:0:EventPattern"] = "message",
+            ["WebPubSub:Hubs:testHub:EventHandlers:0:SystemEvents:0"] = "connect",
+        });
+        using var webSocket = await ConnectAsync(application, customSubprotocol);
+
+        Assert.Equal(customSubprotocol, webSocket.SubProtocol);
+        await webSocket.SendAsync(
+            "custom-request"u8.ToArray(),
+            WebSocketMessageType.Text,
+            endOfMessage: true,
+            CancellationToken.None).WaitAsync(TestTimeout);
+        var buffer = new byte[128];
+        var result = await webSocket.ReceiveAsync(buffer, CancellationToken.None).WaitAsync(TestTimeout);
+
+        Assert.Equal(WebSocketMessageType.Text, result.MessageType);
+        Assert.Equal("custom-response", Encoding.UTF8.GetString(buffer, 0, result.Count));
+        Assert.Equal("connect", (await handler.ReadAsync()).EventName);
+        var upstream = await handler.ReadAsync();
+        Assert.Equal("message", upstream.EventName);
+        Assert.Equal(customSubprotocol, upstream.Headers["ce-subprotocol"]);
+        Assert.Equal("custom-request", Encoding.UTF8.GetString(upstream.Body));
+    }
+
+    [Fact]
+    public async Task AppServerCloseReportsReasonToDisconnectedHandler()
+    {
+        var handler = new RecordingEventHandler(_ => new HttpResponseMessage(HttpStatusCode.OK));
+        await using var application = await StartApplicationAsync(handler, new Dictionary<string, string?>
+        {
+            ["WebPubSub:Hubs:testHub:EventHandlers:0:UrlTemplate"] = "http://handler/events/{hub}/{event}",
+            ["WebPubSub:Hubs:testHub:EventHandlers:0:SystemEvents:0"] = "disconnected",
+        });
+        using var webSocket = await ConnectAsync(application, WebPubSubJsonV1PayloadProcessor.SubprotocolName);
+        using var connected = await ReceiveJsonAsync(webSocket);
+        var connectionId = connected.RootElement.GetProperty("connectionId").GetString()!;
+
+        var connections = application.Services.GetRequiredService<ConnectionManager>();
+        var normalizedHub = Hub.ToLowerInvariant();
+        Assert.True(connections.TryGet(normalizedHub, connectionId, out _));
+        connections.CloseConnection(normalizedHub, connectionId, "server-close");
+        Assert.False(connections.TryGet(normalizedHub, connectionId, out _));
+
+        var disconnected = await handler.ReadAsync();
+        using var body = JsonDocument.Parse(disconnected.Body);
+        Assert.Equal("disconnected", disconnected.EventName);
+        Assert.Equal(
+            "Application server closed the connection. Reason: server-close",
+            body.RootElement.GetProperty("reason").GetString());
+    }
+
+    [Fact]
+    public async Task ManagedIdentityHandlerAuthUsesConfiguredResourceScope()
+    {
+        var credential = new RecordingTokenCredential();
+        var handler = new RecordingEventHandler(request =>
+        {
+            Assert.Equal("Bearer", request.Headers.Authorization?.Scheme);
+            Assert.Equal("test-token", request.Headers.Authorization?.Parameter);
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        });
+        await using var application = await StartApplicationAsync(
+            handler,
+            new Dictionary<string, string?>
+            {
+                ["WebPubSub:Hubs:testHub:EventHandlers:0:UrlTemplate"] =
+                    "http://handler/events/{hub}/{event}",
+                ["WebPubSub:Hubs:testHub:EventHandlers:0:EventPattern"] = "telemetry",
+                ["WebPubSub:Hubs:testHub:EventHandlers:0:Auth:Type"] = "ManagedIdentity",
+                ["WebPubSub:Hubs:testHub:EventHandlers:0:Auth:ManagedIdentity:Resource"] =
+                    "https://handler.example/",
+            },
+            credential: credential);
+        using var webSocket = await ConnectAsync(application, WebPubSubJsonV1PayloadProcessor.SubprotocolName);
+        using var connected = await ReceiveJsonAsync(webSocket);
+
+        await SendTextAsync(
+            webSocket,
+            """{"type":"event","event":"telemetry","data":"value","ackId":1}""");
+        using var ack = await ReceiveJsonAsync(webSocket);
+
+        Assert.True(ack.RootElement.GetProperty("success").GetBoolean());
+        Assert.Equal("https://handler.example/.default", Assert.Single(credential.Scopes));
+    }
+
+    private static async Task<WebApplication> StartApplicationAsync(
+        RecordingEventHandler handler,
+        IReadOnlyDictionary<string, string?> configuration,
+        TokenCredential? credential = null)
+    {
+        var builder = EmulatorApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Configuration.AddInMemoryCollection(configuration);
+        builder.Services.AddHttpClient(UpstreamEventDispatcher.HttpClientName)
+            .ConfigurePrimaryHttpMessageHandler(() => handler);
+        if (credential is not null)
+        {
+            builder.Services.AddSingleton(credential);
+        }
+        var application = EmulatorApplication.Build(builder);
+        await application.StartAsync().WaitAsync(TestTimeout);
+        return application;
+    }
+
+    private static async Task<WebSocket> ConnectAsync(
+        WebApplication application,
+        string? subprotocol,
+        IEnumerable<Claim>? claims = null)
+    {
+        var client = application.GetTestServer().CreateWebSocketClient();
+        if (subprotocol is not null)
+        {
+            client.SubProtocols.Add(subprotocol);
+        }
+        var token = CreateToken(claims);
+        var uri = new Uri(
+            $"ws://localhost{WebPubSubTokenService.ClientPathPrefix}{Hub}?access_token={Uri.EscapeDataString(token)}");
+        return await client.ConnectAsync(uri, CancellationToken.None).WaitAsync(TestTimeout);
+    }
+
+    private static Task SendTextAsync(WebSocket webSocket, string message)
+    {
+        return webSocket.SendAsync(
+            Encoding.UTF8.GetBytes(message),
+            WebSocketMessageType.Text,
+            endOfMessage: true,
+            CancellationToken.None).WaitAsync(TestTimeout);
+    }
+
+    private static async Task<JsonDocument> ReceiveJsonAsync(WebSocket webSocket)
+    {
+        var buffer = new byte[4096];
+        var result = await webSocket.ReceiveAsync(buffer, CancellationToken.None).WaitAsync(TestTimeout);
+        Assert.Equal(WebSocketMessageType.Text, result.MessageType);
+        return JsonDocument.Parse(buffer.AsMemory(0, result.Count));
+    }
+
+    private static string CreateToken(IEnumerable<Claim>? claims = null)
+    {
+        var token = new JwtSecurityToken(
+            audience: $"http://localhost{WebPubSubTokenService.ClientPathPrefix}{Hub}",
+            claims: [new Claim("sub", "token-user"), .. claims ?? []],
+            expires: DateTime.UtcNow.AddHours(1),
+            signingCredentials: new SigningCredentials(
+                new SymmetricSecurityKey(Encoding.UTF8.GetBytes(EmulatorOptions.DefaultAccessKey)),
+                SecurityAlgorithms.HmacSha256));
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    private sealed class RecordingEventHandler : HttpMessageHandler
+    {
+        private readonly ConcurrentQueue<ReceivedEvent> _events = new();
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _responseFactory;
+        private readonly SemaphoreSlim _available = new(0);
+
+        public RecordingEventHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory)
+        {
+            _responseFactory = responseFactory;
+        }
+
+        public async Task<ReceivedEvent> ReadAsync()
+        {
+            await _available.WaitAsync(TestTimeout);
+            Assert.True(_events.TryDequeue(out var item));
+            return item;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var body = request.Content is null
+                ? []
+                : await request.Content.ReadAsByteArrayAsync(cancellationToken);
+            var headers = request.Headers
+                .Concat(request.Content?.Headers ??
+                    Enumerable.Empty<KeyValuePair<string, IEnumerable<string>>>())
+                .ToDictionary(
+                    item => item.Key,
+                    item => item.Value.LastOrDefault() ?? string.Empty,
+                    StringComparer.OrdinalIgnoreCase);
+            _events.Enqueue(new ReceivedEvent(headers["ce-eventName"], headers, body));
+            _available.Release();
+            return _responseFactory(request);
+        }
+    }
+
+    private sealed record ReceivedEvent(
+        string EventName,
+        IReadOnlyDictionary<string, string> Headers,
+        byte[] Body);
+
+    private sealed class RecordingTokenCredential : TokenCredential
+    {
+        public List<string> Scopes { get; } = [];
+
+        public override AccessToken GetToken(
+            TokenRequestContext requestContext,
+            CancellationToken cancellationToken)
+        {
+            Scopes.AddRange(requestContext.Scopes);
+            return new AccessToken("test-token", DateTimeOffset.UtcNow.AddHours(1));
+        }
+
+        public override ValueTask<AccessToken> GetTokenAsync(
+            TokenRequestContext requestContext,
+            CancellationToken cancellationToken)
+        {
+            return ValueTask.FromResult(GetToken(requestContext, cancellationToken));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add HTTP upstream event handler configuration and dispatch to the Web PubSub emulator
- support synchronous `connect` and user events, plus asynchronous `connected` and `disconnected` notifications
- apply connect response user ID, roles, groups, subprotocol, and connection state using runtime-compatible semantics
- support CloudEvents headers, metadata, response payloads, HMAC signatures, and Managed Identity authentication
- document configuration and supported behavior

This follows #1122. Event Hubs listeners remain in a separate follow-up change.

## Validation

- `dotnet restore tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/Microsoft.Azure.WebPubSub.Emulator.Tests.csproj --configfile tools/emulator/NuGet.Config`
- `dotnet test tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/Microsoft.Azure.WebPubSub.Emulator.Tests.csproj --no-restore` (172 passed)
- `dotnet pack tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/Microsoft.Azure.WebPubSub.Emulator.csproj --configuration Release --no-restore`
- `git diff --check origin/main...HEAD`