### PR TITLE
Emulator: add HTTP lifecycle notifications (H1)

### DIFF
--- a/tools/emulator/README.md
+++ b/tools/emulator/README.md
@@ -124,6 +124,39 @@ $env:WebPubSub__AccessKey = "custom-emulator-access-key-1234567890"
 dotnet run --project tools\emulator\src\Microsoft.Azure.WebPubSub.Emulator
 ```
 
+## HTTP lifecycle notifications
+
+Configure per-hub `connected` and `disconnected` handlers through ASP.NET Core configuration:
+
+```json
+{
+  "WebPubSub": {
+    "Hubs": {
+      "chat": {
+        "EventHandlers": [{
+          "UrlTemplate": "http://localhost:7071/events/{hub}/{event}",
+          "SystemEvents": ["connected", "disconnected"]
+        }]
+      }
+    }
+  }
+}
+```
+
+Hub names and event names match case-insensitively; the first matching handler is used.
+There is no `_default` fallback. URL parameters are escaped. Notifications use binary-mode
+CloudEvents with JSON bodies (`{}` for connected, `{"reason":"..."}` for disconnected),
+an access-key signature, and cookies isolated to each logical connection. Notification failures
+are logged without rejecting the WebSocket. Reliable reconnects do not produce another connected
+notification; disconnected is sent only on final close or recovery expiration.
+
+This slice sends notifications directly, without webhook endpoint validation, retries, or bearer
+authentication. The HTTP client retains its default 100-second timeout to response headers.
+Connect interception, user-event responses, Key Vault URL references, and Event Hubs listeners
+are not supported yet. Unsupported handler configuration is rejected at startup.
+
+## Local server SDK authentication
+
 `WebPubSub:AllowUnvalidatedEntraTokens` is disabled by default. Enable it only for trusted local
 server SDK `TokenCredential` testing. With an HTTPS emulator endpoint, the SDK can use
 `DefaultAzureCredential`:

--- a/tools/emulator/SUPPORTED_FEATURES.md
+++ b/tools/emulator/SUPPORTED_FEATURES.md
@@ -17,6 +17,7 @@ local Azure Web PubSub development.
 | Connection state | Tracks active connections and temporarily retains reliable logical connections after unexpected disconnects. | ✅ |
 | Groups and roles | Supports connection-scoped token groups and authorized join, leave, and group send, including wildcard roles. | ✅ |
 | Outbound delivery | Uses a bounded, single-writer queue for each WebSocket connection. | ✅ |
+| HTTP lifecycle notifications | Sends `connected` and final `disconnected` CloudEvents to per-hub HTTP handlers; no connect interception or user events yet. See [configuration and limitations](README.md#http-lifecycle-notifications). | ⚠️ |
 | REST connection operations | Authenticated connection presence, direct text, JSON, and binary sends, close, and single-connection group membership changes for GA API versions from `2021-10-01` through `2024-12-01`. | ✅ |
 | REST group operations | Authenticated group presence and text, JSON, or binary fan-out with excluded connection IDs and OData filters. | ✅ |
 | REST broadcast | Authenticated text, JSON, or binary fan-out with excluded connection IDs and OData filters. | ✅ |
@@ -47,13 +48,13 @@ runtime's new contract and decode the original user ID path segment exactly once
 
 The following areas are planned for follow-up changes:
 
-- HTTP upstream event handlers
+- HTTP connect/user-event handlers, webhook validation, retries, bearer authentication, and Key Vault URL references
 - Tunnel connections (`tunnel://` upstream URLs)
 - Event Hubs listeners
 - Protobuf subprotocols
 - Client message streaming
 - Production Microsoft Entra ID validation
 
-Client events require an upstream event handler. Until upstream handlers are implemented, JSON
+Client events require a response-capable upstream handler. Until user-event handlers are implemented, JSON
 events with an `ackId` receive an `InternalServerError` acknowledgement; events without an
 `ackId` are logged without closing the client connection. Raw `sendEvent` mode is not available.

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientConnectionHandler.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientConnectionHandler.cs
@@ -8,10 +8,12 @@ namespace Microsoft.Azure.WebPubSub.Emulator;
 
 internal sealed class ClientConnectionHandler
 {
+    private readonly UpstreamEventDispatcher _events;
     private readonly ILogger<ClientConnectionHandler> _logger;
 
-    public ClientConnectionHandler(ILogger<ClientConnectionHandler> logger)
+    public ClientConnectionHandler(UpstreamEventDispatcher events, ILogger<ClientConnectionHandler> logger)
     {
+        _events = events;
         _logger = logger;
     }
 
@@ -37,6 +39,7 @@ internal sealed class ClientConnectionHandler
                     if (isInitialConnection)
                     {
                         processor.OnConnected(connection);
+                        _ = _events.DispatchNotificationAsync(connection.UpstreamContext, "connected", "{}"u8.ToArray());
                     }
                     return ValueTask.CompletedTask;
                 },

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientWebSocketEndpoint.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientWebSocketEndpoint.cs
@@ -105,10 +105,10 @@ internal sealed class ClientWebSocketEndpoint
             Guid.NewGuid().ToString("N"),
             hub,
             user,
+            context.Request.Host.Host,
             rawSendToGroup,
             WebPubSubJsonV1PayloadProcessor.IsReliableSubprotocol(selectedSubprotocol),
-            selectedSubprotocol,
-            host: context.Request.Host.Host);
+            selectedSubprotocol);
         var processor = _payloadProcessorFactory.Get(selectedSubprotocol);
 
         using var webSocket = await context.WebSockets.AcceptWebSocketAsync(selectedSubprotocol);

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientWebSocketEndpoint.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientWebSocketEndpoint.cs
@@ -107,7 +107,8 @@ internal sealed class ClientWebSocketEndpoint
             user,
             rawSendToGroup,
             WebPubSubJsonV1PayloadProcessor.IsReliableSubprotocol(selectedSubprotocol),
-            selectedSubprotocol);
+            selectedSubprotocol,
+            host: context.Request.Host.Host);
         var processor = _payloadProcessorFactory.Get(selectedSubprotocol);
 
         using var webSocket = await context.WebSockets.AcceptWebSocketAsync(selectedSubprotocol);

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ConnectionManager.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ConnectionManager.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Net.WebSockets;
 using System.Security.Claims;
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Azure.WebPubSub.Emulator;
@@ -14,13 +15,16 @@ internal sealed class ConnectionManager
     private readonly ConcurrentDictionary<(string Hub, string ConnectionId), LogicalConnection> _connections = [];
     private readonly EmulatorRuntimeOptions _runtimeOptions;
     private readonly ILogger<ConnectionManager> _logger;
+    private readonly UpstreamEventDispatcher _events;
 
     public ConnectionManager(
         EmulatorRuntimeOptions runtimeOptions,
-        ILogger<ConnectionManager> logger)
+        ILogger<ConnectionManager> logger,
+        UpstreamEventDispatcher events)
     {
         _runtimeOptions = runtimeOptions;
         _logger = logger;
+        _events = events;
     }
 
     public LogicalConnection Create(
@@ -29,7 +33,8 @@ internal sealed class ConnectionManager
         ClaimsPrincipal user,
         string? rawSendToGroup = null,
         bool reliable = false,
-        string? subprotocol = null)
+        string? subprotocol = null,
+        string host = "localhost")
     {
         return new LogicalConnection(
             connectionId,
@@ -40,7 +45,8 @@ internal sealed class ConnectionManager
             _runtimeOptions,
             reliable,
             subprotocol,
-            _logger);
+            _logger,
+            host);
     }
 
     public bool TryActivate(LogicalConnection connection)
@@ -169,9 +175,14 @@ internal sealed class ConnectionManager
         }
     }
 
-    public void Remove(LogicalConnection connection)
+    public void Remove(LogicalConnection connection, string? reason = null)
     {
-        _connections.TryRemove((connection.Hub, connection.ConnectionId), out _);
+        if (_connections.TryRemove(new KeyValuePair<(string, string), LogicalConnection>(
+            (connection.Hub, connection.ConnectionId), connection)))
+        {
+            _ = _events.DispatchNotificationAsync(connection.UpstreamContext, "disconnected",
+                JsonSerializer.SerializeToUtf8Bytes(new { reason = reason ?? "The connection ended." }));
+        }
     }
 
     public void ScheduleExpiration(LogicalConnection connection, long generation)
@@ -221,7 +232,7 @@ internal sealed class ConnectionManager
             await Task.Delay(_runtimeOptions.ReconnectTimeout);
             if (connection.TryExpire(generation))
             {
-                Remove(connection);
+                Remove(connection, "The connection recovery timeout expired.");
             }
         }
         catch (Exception exception)

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ConnectionManager.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ConnectionManager.cs
@@ -31,22 +31,22 @@ internal sealed class ConnectionManager
         string connectionId,
         string hub,
         ClaimsPrincipal user,
+        string host,
         string? rawSendToGroup = null,
         bool reliable = false,
-        string? subprotocol = null,
-        string host = "localhost")
+        string? subprotocol = null)
     {
         return new LogicalConnection(
             connectionId,
             hub,
             user,
+            host,
             rawSendToGroup,
             this,
             _runtimeOptions,
             reliable,
             subprotocol,
-            _logger,
-            host);
+            _logger);
     }
 
     public bool TryActivate(LogicalConnection connection)

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/CustomerOutboundConfiguration.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/CustomerOutboundConfiguration.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Text;
+
+namespace Microsoft.Azure.WebPubSub.Emulator;
+
+internal static class CustomerOutboundConfiguration
+{
+    // Keep the allowlist aligned with the runtime's CustomerOutboundConfiguration.
+    private static readonly string[] UnicodeAllowedUpstreamHeaderNames =
+        [
+            "X-ASRS-User-Id",
+            "X-ASRS-User-Claims",
+            "X-ASRS-Event",
+            "ce-userId",
+        ];
+
+    public static SocketsHttpHandler ConfigureHttpMessageHandler()
+    {
+        return new SocketsHttpHandler
+        {
+            UseCookies = false,
+            RequestHeaderEncodingSelector = SelectRequestHeaderEncoding,
+        };
+    }
+
+    private static Encoding? SelectRequestHeaderEncoding(string headerName, HttpRequestMessage request)
+    {
+        // User IDs and claims may contain Unicode; other headers retain the default encoding.
+        return UnicodeAllowedUpstreamHeaderNames.Contains(headerName, StringComparer.OrdinalIgnoreCase)
+            ? Encoding.UTF8
+            : null;
+    }
+}

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorApplication.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorApplication.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Reflection;
-using System.Text;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Controllers;
@@ -43,12 +42,7 @@ internal static class EmulatorApplication
         builder.Services.AddSingleton<HttpUpstreamTrigger>();
         builder.Services.AddSingleton<UpstreamEventDispatcher>();
         builder.Services.AddHttpClient(HttpUpstreamTrigger.HttpClientName)
-            .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
-            {
-                UseCookies = false,
-                RequestHeaderEncodingSelector = (name, _) =>
-                    name.Equals("ce-userId", StringComparison.OrdinalIgnoreCase) ? Encoding.UTF8 : null,
-            });
+            .ConfigurePrimaryHttpMessageHandler(CustomerOutboundConfiguration.ConfigureHttpMessageHandler);
         builder.Services.AddSingleton<
             IWebPubSubConnectionLifetimeHandler,
             WebPubSubClientConnectionLifetimeHandler>();

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorApplication.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorApplication.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Reflection;
+using System.Text;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Controllers;
@@ -21,17 +22,33 @@ internal static class EmulatorApplication
         builder.Configuration[WebHostDefaults.ServerUrlsKey] ??= "http://localhost:8080";
         builder.Services
             .AddOptions<EmulatorOptions>()
-            .Bind(builder.Configuration.GetSection(EmulatorOptions.SectionName))
+            .Bind(builder.Configuration.GetSection(EmulatorOptions.SectionName),
+                options => options.ErrorOnUnknownConfiguration = true)
             .Validate(
                 options => EmulatorOptions.IsValidAccessKey(options.AccessKey),
                 "WebPubSub:AccessKey must be at least 32 UTF-8 bytes and cannot contain " +
                     "leading or trailing whitespace, semicolons, or control characters.")
+            .Validate(options => options.Hubs.Values.All(hub => hub.EventHandlers.All(handler =>
+                EventHandlerUrlTemplate.TryResolve(handler.UrlTemplate, "hub", "event", out _) &&
+                handler.SystemEvents.All(name =>
+                    string.Equals(name, "connected", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(name, "disconnected", StringComparison.OrdinalIgnoreCase)))),
+                "Event handlers currently require an HTTP(S) URL without Key Vault references and support only connected/disconnected.")
             .ValidateOnStart();
         builder.Services.AddSingleton(runtimeOptions ?? new EmulatorRuntimeOptions());
         builder.Services.AddSingleton<WebPubSubTokenService>();
         builder.Services.AddSingleton<ConnectionManager>();
         builder.Services.AddSingleton<SimpleWebSocketPayloadProcessor>();
         builder.Services.AddSingleton<WebPubSubJsonV1Protocol>();
+        builder.Services.AddSingleton<HttpUpstreamTrigger>();
+        builder.Services.AddSingleton<UpstreamEventDispatcher>();
+        builder.Services.AddHttpClient(HttpUpstreamTrigger.HttpClientName)
+            .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
+            {
+                UseCookies = false,
+                RequestHeaderEncodingSelector = (name, _) =>
+                    name.Equals("ce-userId", StringComparison.OrdinalIgnoreCase) ? Encoding.UTF8 : null,
+            });
         builder.Services.AddSingleton<
             IWebPubSubConnectionLifetimeHandler,
             WebPubSubClientConnectionLifetimeHandler>();

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorOptions.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorOptions.cs
@@ -13,6 +13,8 @@ internal sealed class EmulatorOptions
 
     public bool AllowUnvalidatedEntraTokens { get; set; }
 
+    public Dictionary<string, HubOptions> Hubs { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
     public string GetConnectionString(Uri endpoint)
     {
         return $"Endpoint={endpoint.GetLeftPart(UriPartial.Authority)};" +
@@ -26,6 +28,18 @@ internal sealed class EmulatorOptions
             !accessKey.Any(character => character == ';' || char.IsControl(character)) &&
             System.Text.Encoding.UTF8.GetByteCount(accessKey) >= 32;
     }
+}
+
+internal sealed class HubOptions
+{
+    public EventHandlerOptions[] EventHandlers { get; set; } = [];
+}
+
+internal sealed class EventHandlerOptions
+{
+    public string UrlTemplate { get; set; } = string.Empty;
+
+    public string[] SystemEvents { get; set; } = [];
 }
 
 internal sealed class EmulatorRuntimeOptions

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EventHandlerUrlTemplate.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EventHandlerUrlTemplate.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.Azure.WebPubSub.Emulator;
+
+internal static partial class EventHandlerUrlTemplate
+{
+    public static bool TryResolve(
+        string template, string hub, string eventName, [NotNullWhen(true)] out Uri? uri)
+    {
+        uri = null;
+        // Secret resolution is not implemented; do not send an unresolved secret reference.
+        if (template.Contains("{@Microsoft.KeyVault", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+        var resolved = ParameterRegex().Replace(template, match => Uri.EscapeDataString(
+            match.Value.Equals("{hub}", StringComparison.OrdinalIgnoreCase) ? hub : eventName));
+        return Uri.TryCreate(resolved, UriKind.Absolute, out uri) && uri.Scheme is "http" or "https";
+    }
+
+    [GeneratedRegex("\\{(?:hub|event)\\}", RegexOptions.IgnoreCase)]
+    private static partial Regex ParameterRegex();
+}

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/HttpUpstreamTrigger.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/HttpUpstreamTrigger.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Net;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebPubSub.Emulator;
+
+internal sealed class HttpUpstreamTrigger(
+    IHttpClientFactory clients, ILogger<HttpUpstreamTrigger> logger)
+{
+    public const string HttpClientName = "WebPubSubEventHandler";
+
+    public async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, UpstreamConnectionContext connection, CancellationToken cancellationToken)
+    {
+        var uri = request.RequestUri!;
+        var cookies = connection.Cookies.GetCookieHeader(uri);
+        if (cookies.Length > 0)
+        {
+            request.Headers.Add("Cookie", cookies);
+        }
+        using var client = clients.CreateClient(HttpClientName);
+        var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        if (response.IsSuccessStatusCode && response.Headers.TryGetValues("Set-Cookie", out var values))
+        {
+            foreach (var value in values)
+            {
+                try
+                {
+                    connection.Cookies.SetCookies(uri, value);
+                }
+                catch (CookieException exception)
+                {
+                    logger.LogWarning(exception, "The upstream returned an invalid cookie.");
+                }
+            }
+        }
+        return response;
+    }
+}

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/LogicalConnection.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/LogicalConnection.cs
@@ -47,7 +47,8 @@ internal sealed class LogicalConnection : IODataFilterModel
         EmulatorRuntimeOptions runtimeOptions,
         bool reliable = false,
         string? subprotocol = null,
-        ILogger? logger = null)
+        ILogger? logger = null,
+        string host = "localhost")
     {
         ConnectionId = connectionId;
         Hub = hub;
@@ -63,6 +64,7 @@ internal sealed class LogicalConnection : IODataFilterModel
         _reliableBufferMaxBytes = runtimeOptions.MaxReliableMessageBufferBytes;
 
         UserId = user.FindFirstValue("sub") ?? user.FindFirstValue(ClaimTypes.NameIdentifier);
+        UpstreamContext = new UpstreamConnectionContext(connectionId, hub, UserId, subprotocol, host);
 
         foreach (var group in user.FindAll("webpubsub.group").Select(claim => claim.Value))
         {
@@ -98,6 +100,8 @@ internal sealed class LogicalConnection : IODataFilterModel
     public bool IsReliable { get; }
 
     public string? Subprotocol { get; }
+
+    public UpstreamConnectionContext UpstreamContext { get; }
 
     public AckCache AckIdCache { get; } = new();
 
@@ -519,7 +523,7 @@ internal sealed class LogicalConnection : IODataFilterModel
             ClearReliableBufferLocked();
         }
 
-        _manager.Remove(this);
+        _manager.Remove(this, closeDescription);
         return true;
     }
 
@@ -539,13 +543,15 @@ internal sealed class LogicalConnection : IODataFilterModel
         return Close(
             WebSocketCloseStatus.NormalClosure,
             string.Empty,
-            processor => processor.EncodeDisconnected(message));
+            processor => processor.EncodeDisconnected(message),
+            message);
     }
 
     private SocketTransport? Close(
         WebSocketCloseStatus closeStatus,
         string closeDescription,
-        Func<IClientPayloadProcessor, WebSocketPayload?>? finalPayloadFactory)
+        Func<IClientPayloadProcessor, WebSocketPayload?>? finalPayloadFactory,
+        string? disconnectReason = null)
     {
         SocketTransport? transport;
         lock (_stateLock)
@@ -567,7 +573,7 @@ internal sealed class LogicalConnection : IODataFilterModel
             ClearReliableBufferLocked();
         }
 
-        _manager.Remove(this);
+        _manager.Remove(this, disconnectReason ?? closeDescription);
         return transport;
     }
 
@@ -639,7 +645,7 @@ internal sealed class LogicalConnection : IODataFilterModel
 
     private void FailConnection(SocketTransport? transport, string reason)
     {
-        _manager.Remove(this);
+        _manager.Remove(this, reason);
         _logger?.LogDebug(
             "Closing connection {ConnectionId}: {Reason}",
             ConnectionId,

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/LogicalConnection.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/LogicalConnection.cs
@@ -42,13 +42,13 @@ internal sealed class LogicalConnection : IODataFilterModel
         string connectionId,
         string hub,
         ClaimsPrincipal user,
+        string host,
         string? rawSendToGroup,
         ConnectionManager manager,
         EmulatorRuntimeOptions runtimeOptions,
         bool reliable = false,
         string? subprotocol = null,
-        ILogger? logger = null,
-        string host = "localhost")
+        ILogger? logger = null)
     {
         ConnectionId = connectionId;
         Hub = hub;

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/UpstreamConnectionContext.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/UpstreamConnectionContext.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Net;
+
+namespace Microsoft.Azure.WebPubSub.Emulator;
+
+internal sealed class UpstreamConnectionContext(
+    string connectionId, string hub, string? userId, string? subprotocol, string host)
+{
+    // Event 0 is reserved for connect, even when no connect handler is configured.
+    private int _eventId;
+
+    public string ConnectionId { get; } = connectionId;
+    public string Hub { get; } = hub;
+    public string? UserId { get; } = userId;
+    public string? Subprotocol { get; } = subprotocol;
+    public string Host { get; } = host;
+    public CookieContainer Cookies { get; } = new();
+
+    public int GetNextEventId() => Interlocked.Increment(ref _eventId);
+}

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/UpstreamConnectionContext.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/UpstreamConnectionContext.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 using System.Net;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace Microsoft.Azure.WebPubSub.Emulator;
 
@@ -10,6 +12,8 @@ internal sealed class UpstreamConnectionContext(
 {
     // Event 0 is reserved for connect, even when no connect handler is configured.
     private int _eventId;
+    private readonly object _signatureLock = new();
+    private (string Key, string Signature)? _signatureCache;
 
     public string ConnectionId { get; } = connectionId;
     public string Hub { get; } = hub;
@@ -19,4 +23,22 @@ internal sealed class UpstreamConnectionContext(
     public CookieContainer Cookies { get; } = new();
 
     public int GetNextEventId() => Interlocked.Increment(ref _eventId);
+
+    public string GetSignature(string accessKey)
+    {
+        // Like the runtime's GetSignatures, cache by signing key, not by event.
+        lock (_signatureLock)
+        {
+            if (_signatureCache is { } cached && cached.Key == accessKey)
+            {
+                return cached.Signature;
+            }
+
+            var hash = HMACSHA256.HashData(
+                Encoding.UTF8.GetBytes(accessKey), Encoding.UTF8.GetBytes(ConnectionId));
+            var signature = $"sha256={Convert.ToHexStringLower(hash)}";
+            _signatureCache = (accessKey, signature);
+            return signature;
+        }
+    }
 }

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/UpstreamEventDispatcher.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/UpstreamEventDispatcher.cs
@@ -4,8 +4,6 @@
 using System.Globalization;
 using System.Net;
 using System.Net.Http.Headers;
-using System.Security.Cryptography;
-using System.Text;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -52,9 +50,7 @@ internal sealed class UpstreamEventDispatcher(
             request.Headers.Add("ce-eventName", eventName);
             request.Headers.Add("WebHook-Request-Origin", connection.Host);
             request.Headers.Add("x-ms-client-request-id", Guid.NewGuid().ToString());
-            var signature = HMACSHA256.HashData(
-                Encoding.UTF8.GetBytes(options.Value.AccessKey), Encoding.UTF8.GetBytes(connection.ConnectionId));
-            request.Headers.Add("ce-signature", $"sha256={Convert.ToHexStringLower(signature)}");
+            request.Headers.Add("ce-signature", connection.GetSignature(options.Value.AccessKey));
             if (!string.IsNullOrEmpty(connection.UserId))
             {
                 request.Headers.Add("ce-userId", connection.UserId);

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/UpstreamEventDispatcher.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/UpstreamEventDispatcher.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Azure.WebPubSub.Emulator;
+
+internal sealed class UpstreamEventDispatcher(
+    IOptions<EmulatorOptions> options, HttpUpstreamTrigger trigger, ILogger<UpstreamEventDispatcher> logger)
+{
+    public async Task DispatchNotificationAsync(
+        UpstreamConnectionContext connection, string eventName, byte[] body)
+    {
+        var id = connection.GetNextEventId();
+        if (!options.Value.Hubs.TryGetValue(connection.Hub, out var hub))
+        {
+            return;
+        }
+        var handler = hub.EventHandlers.FirstOrDefault(item =>
+            item.SystemEvents.Contains(eventName, StringComparer.OrdinalIgnoreCase));
+        if (handler is null)
+        {
+            return;
+        }
+
+        try
+        {
+            if (!EventHandlerUrlTemplate.TryResolve(handler.UrlTemplate, connection.Hub, eventName, out var uri))
+            {
+                throw new InvalidDataException("Event handler URL must resolve to an HTTP or HTTPS URL without Key Vault references.");
+            }
+            using var request = new HttpRequestMessage(HttpMethod.Post, uri)
+            {
+                Version = HttpVersion.Version20,
+                Content = new ByteArrayContent(body),
+            };
+            request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+            request.Headers.Add("ce-specversion", "1.0");
+            request.Headers.Add("ce-awpsversion", "1.0");
+            request.Headers.Add("ce-type", $"azure.webpubsub.sys.{eventName}");
+            request.Headers.Add("ce-source", $"/hubs/{connection.Hub}/client/{connection.ConnectionId}");
+            request.Headers.Add("ce-id", id.ToString(CultureInfo.InvariantCulture));
+            request.Headers.Add("ce-time", DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture));
+            request.Headers.Add("ce-connectionId", connection.ConnectionId);
+            request.Headers.Add("ce-hub", connection.Hub);
+            request.Headers.Add("ce-eventName", eventName);
+            request.Headers.Add("WebHook-Request-Origin", connection.Host);
+            request.Headers.Add("x-ms-client-request-id", Guid.NewGuid().ToString());
+            var signature = HMACSHA256.HashData(
+                Encoding.UTF8.GetBytes(options.Value.AccessKey), Encoding.UTF8.GetBytes(connection.ConnectionId));
+            request.Headers.Add("ce-signature", $"sha256={Convert.ToHexStringLower(signature)}");
+            if (!string.IsNullOrEmpty(connection.UserId))
+            {
+                request.Headers.Add("ce-userId", connection.UserId);
+            }
+            if (!string.IsNullOrEmpty(connection.Subprotocol))
+            {
+                request.Headers.Add("ce-subprotocol", connection.Subprotocol);
+            }
+
+            // Notifications survive the client request ending, as in PushModeUpstreamInvoker.
+            using var response = await trigger.SendAsync(request, connection, CancellationToken.None);
+            if (!response.IsSuccessStatusCode)
+            {
+                logger.LogWarning("The {EventName} handler returned {StatusCode} for {ConnectionId}.",
+                    eventName, (int)response.StatusCode, connection.ConnectionId);
+            }
+        }
+        catch (Exception exception)
+        {
+            logger.LogWarning(exception, "Dispatching {EventName} for {ConnectionId} failed.",
+                eventName, connection.ConnectionId);
+        }
+    }
+}

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/ClientWebSocketEndpointTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/ClientWebSocketEndpointTests.cs
@@ -355,8 +355,10 @@ public class ClientWebSocketEndpointTests
         var connection = manager.Create(
             "pending-connection",
             Hub,
-            new ClaimsPrincipal(new ClaimsIdentity()));
+            new ClaimsPrincipal(new ClaimsIdentity()),
+            host: "emulator.example.test");
 
+        Assert.Equal("emulator.example.test", connection.UpstreamContext.Host);
         Assert.False(manager.TryGet(Hub, connection.ConnectionId, out _));
         Assert.True(manager.TryActivate(connection));
         Assert.True(manager.TryGet(Hub, connection.ConnectionId, out var activated));

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/CustomerOutboundConfigurationTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/CustomerOutboundConfigurationTests.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Net.Http;
+using System.Text;
+using Xunit;
+
+namespace Microsoft.Azure.WebPubSub.Emulator.Tests;
+
+public class CustomerOutboundConfigurationTests
+{
+    [Theory]
+    [InlineData("X-ASRS-User-Id", true)]
+    [InlineData("X-ASRS-User-Claims", true)]
+    [InlineData("X-ASRS-Event", true)]
+    [InlineData("ce-userId", true)]
+    [InlineData("x-asrs-user-id", true)]
+    [InlineData("x-asrs-user-claims", true)]
+    [InlineData("x-asrs-event", true)]
+    [InlineData("CE-USERID", true)]
+    [InlineData("ce-eventName", false)]
+    [InlineData("ce-hub", false)]
+    [InlineData("Authorization", false)]
+    [InlineData("X-Custom", false)]
+    public void RequestHeaderEncodingMatchesRuntimeAllowlist(string headerName, bool unicodeAllowed)
+    {
+        using var handler = CustomerOutboundConfiguration.ConfigureHttpMessageHandler();
+        using var request = new HttpRequestMessage();
+
+        Assert.False(handler.UseCookies);
+        Assert.NotNull(handler.RequestHeaderEncodingSelector);
+        Assert.Equal(unicodeAllowed ? Encoding.UTF8 : null,
+            handler.RequestHeaderEncodingSelector(headerName, request));
+    }
+}

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/EmulatorApplicationTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/EmulatorApplicationTests.cs
@@ -20,6 +20,29 @@ public class EmulatorApplicationTests
 {
     private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(30);
 
+    [Theory]
+    [InlineData("not-a-url", "connected")]
+    [InlineData("ftp://handler/events", "connected")]
+    [InlineData("https://handler/{@Microsoft.KeyVault(SecretUri=https://vault/secrets/key)}", "connected")]
+    [InlineData("https://handler/events", "connect")]
+    public async Task UnsupportedNotificationConfigurationIsRejected(string template, string eventName)
+    {
+        var builder = EmulatorApplication.CreateBuilder([
+            $"--WebPubSub:Hubs:chat:EventHandlers:0:UrlTemplate={template}",
+            $"--WebPubSub:Hubs:chat:EventHandlers:0:SystemEvents:0={eventName}"]);
+        builder.WebHost.UseTestServer();
+        await using var app = EmulatorApplication.Build(builder);
+        await Assert.ThrowsAsync<OptionsValidationException>(() => app.StartAsync());
+    }
+
+    [Fact]
+    public void NotificationUrlResolutionEscapesOnlyRecognizedParameters()
+    {
+        Assert.True(EventHandlerUrlTemplate.TryResolve(
+            "https://handler/{HUB}/{event}/{unknown}?event={EVENT}", "tenant/chat", "message sent", out var uri));
+        Assert.Equal("https://handler/tenant%2Fchat/message%20sent/{unknown}?event=message%20sent", uri.OriginalString);
+    }
+
     [Fact]
     public async Task EffectiveEndpointComesFromBoundAddress()
     {

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/LogicalConnectionTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/LogicalConnectionTests.cs
@@ -948,6 +948,7 @@ public class LogicalConnectionTests
             connectionId,
             "chat",
             new ClaimsPrincipal(new ClaimsIdentity(claims)),
+            host: "localhost",
             reliable: reliable);
     }
 

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/UpstreamConnectionContextTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/UpstreamConnectionContextTests.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Azure.WebPubSub.Emulator.Tests;
+
+public class UpstreamConnectionContextTests
+{
+    [Fact]
+    public void SignatureIsReusedForEqualKeysAndRefreshedWhenKeyChanges()
+    {
+        var connection = new UpstreamConnectionContext("connection", "chat", null, null, "localhost");
+        var key = EmulatorOptions.DefaultAccessKey;
+        var signature = connection.GetSignature(key);
+        Assert.Same(signature, connection.GetSignature(new string(key.ToCharArray())));
+
+        var changedKey = key + "-changed";
+        var changedSignature = connection.GetSignature(changedKey);
+        var hash = HMACSHA256.HashData(Encoding.UTF8.GetBytes(changedKey), Encoding.UTF8.GetBytes(connection.ConnectionId));
+        Assert.Equal($"sha256={Convert.ToHexStringLower(hash)}", changedSignature);
+        Assert.NotEqual(signature, changedSignature);
+        Assert.Same(changedSignature, connection.GetSignature(changedKey));
+        Assert.Equal(signature, connection.GetSignature(key));
+    }
+
+    [Fact]
+    public void SignatureIsScopedToConnection()
+    {
+        var first = new UpstreamConnectionContext("first", "chat", null, null, "localhost");
+        var second = new UpstreamConnectionContext("second", "chat", null, null, "localhost");
+
+        Assert.NotEqual(first.GetSignature(EmulatorOptions.DefaultAccessKey),
+            second.GetSignature(EmulatorOptions.DefaultAccessKey));
+    }
+
+    [Fact]
+    public void ConcurrentRequestsReuseTheSameSignatureInstance()
+    {
+        var connection = new UpstreamConnectionContext("connection", "chat", null, null, "localhost");
+        var signatures = new string[32];
+
+        Parallel.For(0, signatures.Length, i => signatures[i] = connection.GetSignature(EmulatorOptions.DefaultAccessKey));
+
+        Assert.All(signatures, signature => Assert.Same(signatures[0], signature));
+    }
+}

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/UpstreamNotificationTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/UpstreamNotificationTests.cs
@@ -1,0 +1,270 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Net.Http;
+using System.Net.WebSockets;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Microsoft.Azure.WebPubSub.Emulator.Tests;
+
+public class UpstreamNotificationTests
+{
+    private const string JsonProtocol = "json.webpubsub.azure.v1";
+    private const string ReliableProtocol = "json.reliable.webpubsub.azure.v1";
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(10);
+
+    [Theory]
+    [InlineData(null, "client", 200)]
+    [InlineData(JsonProtocol, "server", 200)]
+    [InlineData(JsonProtocol, "client", 503)]
+    [InlineData(JsonProtocol, "protocol", 200)]
+    [InlineData(ReliableProtocol, "client", 200)]
+    public async Task LifecycleUsesCloudEventsAndNotifiesOnlyOnce(
+        string? protocol, string closeMode, int upstreamStatus)
+    {
+        var events = Channel.CreateUnbounded<ReceivedEvent>();
+        await using var upstream = await StartUpstreamAsync(events, upstreamStatus);
+        await using var app = await StartEmulatorAsync(upstream);
+        using var socket = await ConnectAsync(app, protocol);
+        if (protocol is not null)
+        {
+            using var connectedFrame = await ReceiveJsonAsync(socket);
+            Assert.Equal("connected", connectedFrame.RootElement.GetProperty("event").GetString());
+        }
+        var connected = await events.Reader.ReadAsync().AsTask().WaitAsync(TestTimeout);
+        var id = connected.Headers["ce-connectionId"];
+        Assert.Equal("/events/chat/connected", connected.Path);
+        Assert.Equal("{}", connected.Body);
+        Assert.Equal("1", connected.Headers["ce-id"]);
+        Assert.Equal("1.0", connected.Headers["ce-specversion"]);
+        Assert.Equal("1.0", connected.Headers["ce-awpsversion"]);
+        Assert.Equal("azure.webpubsub.sys.connected", connected.Headers["ce-type"]);
+        Assert.Equal($"/hubs/chat/client/{id}", connected.Headers["ce-source"]);
+        Assert.Equal("用户", connected.Headers["ce-userId"]);
+        Assert.Equal("application/json", connected.Headers["Content-Type"]);
+        Assert.Equal("127.0.0.1", connected.Headers["WebHook-Request-Origin"]);
+        Assert.True(Guid.TryParse(connected.Headers["x-ms-client-request-id"], out _));
+        Assert.True(DateTimeOffset.TryParse(connected.Headers["ce-time"], out _));
+        Assert.Equal(protocol ?? "", connected.Headers.GetValueOrDefault("ce-subprotocol", ""));
+        var hash = HMACSHA256.HashData(Encoding.UTF8.GetBytes(EmulatorOptions.DefaultAccessKey), Encoding.UTF8.GetBytes(id));
+        Assert.Equal($"sha256={Convert.ToHexStringLower(hash)}", connected.Headers["ce-signature"]);
+
+        var manager = app.Services.GetRequiredService<ConnectionManager>();
+        Assert.True(manager.TryGet("chat", id, out var connection));
+        if (closeMode == "server")
+        {
+            manager.CloseConnection("chat", id, "test-close");
+            using var disconnectedFrame = await ReceiveJsonAsync(socket);
+            Assert.Equal("disconnected", disconnectedFrame.RootElement.GetProperty("event").GetString());
+        }
+        else if (closeMode == "protocol")
+        {
+            await socket.SendAsync(new byte[] { 1 }, WebSocketMessageType.Binary, true, CancellationToken.None).WaitAsync(TestTimeout);
+        }
+        await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "test-close", CancellationToken.None).WaitAsync(TestTimeout);
+        var disconnected = await events.Reader.ReadAsync().AsTask().WaitAsync(TestTimeout);
+        Assert.Equal("2", disconnected.Headers["ce-id"]);
+        Assert.Equal("azure.webpubsub.sys.disconnected", disconnected.Headers["ce-type"]);
+        using var body = JsonDocument.Parse(disconnected.Body);
+        Assert.Equal(closeMode switch
+            {
+                "server" => "Application server closed the connection. Reason: test-close",
+                "protocol" => "The JSON subprotocol requires text messages.",
+                _ => "test-close",
+            },
+            body.RootElement.GetProperty("reason").GetString());
+        if (upstreamStatus != 200)
+        {
+            Assert.False(disconnected.Headers.ContainsKey("Cookie"));
+        }
+        Assert.False(manager.ConnectionExists("chat", id));
+        manager.Remove(connection!);
+        Assert.Equal(3, connection!.UpstreamContext.GetNextEventId());
+        Assert.False(events.Reader.TryRead(out _));
+
+        var replacement = manager.Create(id, "chat", new ClaimsPrincipal());
+        Assert.True(manager.TryActivate(replacement));
+        manager.Remove(connection);
+        Assert.True(manager.TryGet("chat", id, out var current));
+        Assert.Same(replacement, current);
+        Assert.Equal(4, connection.UpstreamContext.GetNextEventId());
+        manager.Remove(replacement);
+        Assert.Equal("disconnected", (await events.Reader.ReadAsync().AsTask().WaitAsync(TestTimeout)).Headers["ce-eventName"]);
+        Assert.False(events.Reader.TryRead(out _));
+    }
+
+    [Fact]
+    public async Task ConnectedNotificationSurvivesClientRequestEnding()
+    {
+        var events = Channel.CreateUnbounded<ReceivedEvent>();
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var completed = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var upstream = await StartUpstreamAsync(events, afterReceive: async context =>
+        {
+            if (context.Request.Headers["ce-eventName"] == "connected")
+            {
+                await release.Task.WaitAsync(TestTimeout);
+                completed.TrySetResult(!context.RequestAborted.IsCancellationRequested);
+            }
+        });
+        await using var app = await StartEmulatorAsync(upstream);
+        using var socket = await ConnectAsync(app, null);
+        try
+        {
+            Assert.Equal("connected", (await events.Reader.ReadAsync().AsTask().WaitAsync(TestTimeout)).Headers["ce-eventName"]);
+            await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "done", CancellationToken.None).WaitAsync(TestTimeout);
+            Assert.Equal("disconnected", (await events.Reader.ReadAsync().AsTask().WaitAsync(TestTimeout)).Headers["ce-eventName"]);
+        }
+        finally
+        {
+            release.TrySetResult();
+        }
+        Assert.True(await completed.Task.WaitAsync(TestTimeout));
+    }
+
+    [Fact]
+    public async Task RealHttpCookiesAreConnectionScopedAndRoutingIsExact()
+    {
+        var events = Channel.CreateUnbounded<ReceivedEvent>();
+        await using var upstream = await StartUpstreamAsync(events);
+        await using var app = await StartEmulatorAsync(upstream);
+        using var http = app.Services.GetRequiredService<IHttpClientFactory>().CreateClient(HttpUpstreamTrigger.HttpClientName);
+        Assert.Equal(TimeSpan.FromSeconds(100), http.Timeout);
+        var dispatcher = app.Services.GetRequiredService<UpstreamEventDispatcher>();
+        var a = new UpstreamConnectionContext("a", "CHAT", "用户", null, "localhost");
+        var b = new UpstreamConnectionContext("b", "CHAT", "second", null, "localhost");
+        await dispatcher.DispatchNotificationAsync(a, "connected", "{}"u8.ToArray()).WaitAsync(TestTimeout);
+        Assert.Equal("", (await events.Reader.ReadAsync().AsTask().WaitAsync(TestTimeout)).Headers.GetValueOrDefault("Cookie", ""));
+        await dispatcher.DispatchNotificationAsync(b, "connected", "{}"u8.ToArray()).WaitAsync(TestTimeout);
+        Assert.Equal("", (await events.Reader.ReadAsync().AsTask().WaitAsync(TestTimeout)).Headers.GetValueOrDefault("Cookie", ""));
+        await dispatcher.DispatchNotificationAsync(a, "disconnected", "{}"u8.ToArray()).WaitAsync(TestTimeout);
+        Assert.Equal("affinity=a", (await events.Reader.ReadAsync().AsTask().WaitAsync(TestTimeout)).Headers["Cookie"]);
+        await dispatcher.DispatchNotificationAsync(
+            new UpstreamConnectionContext("missing", "missing", null, null, "localhost"),
+            "connected", "{}"u8.ToArray()).WaitAsync(TestTimeout);
+        Assert.False(events.Reader.TryRead(out _));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ReliableDetachNotifiesOnlyOnFinalRemoval(bool reconnect)
+    {
+        var events = Channel.CreateUnbounded<ReceivedEvent>();
+        await using var upstream = await StartUpstreamAsync(events);
+        await using var app = await StartEmulatorAsync(upstream, reconnect ? TimeSpan.FromMinutes(1) : TimeSpan.FromMilliseconds(200));
+        using var socket = await ConnectAsync(app, ReliableProtocol);
+        using var frame = await ReceiveJsonAsync(socket);
+        var id = frame.RootElement.GetProperty("connectionId").GetString()!;
+        var token = frame.RootElement.GetProperty("reconnectionToken").GetString()!;
+        Assert.Equal("1", (await events.Reader.ReadAsync().AsTask().WaitAsync(TestTimeout)).Headers["ce-id"]);
+        await socket.CloseOutputAsync(WebSocketCloseStatus.EndpointUnavailable, "detach", CancellationToken.None).WaitAsync(TestTimeout);
+        // Wait for the old transport to end before attempting recovery.
+        try
+        {
+            await socket.ReceiveAsync(new byte[4096], CancellationToken.None).WaitAsync(TestTimeout);
+        }
+        catch (WebSocketException)
+        {
+        }
+        if (reconnect)
+        {
+            var uri = new Uri($"{Endpoint(app).Replace("http:", "ws:")}/client/hubs/chat?awps_connection_id={id}&awps_reconnection_token={Uri.EscapeDataString(token)}");
+            using var recovered = await ConnectAsync(app, ReliableProtocol, uri);
+            await recovered.CloseAsync(WebSocketCloseStatus.NormalClosure, "recovered-close", CancellationToken.None).WaitAsync(TestTimeout);
+        }
+        var disconnected = await events.Reader.ReadAsync().AsTask().WaitAsync(TestTimeout);
+        Assert.Equal("disconnected", disconnected.Headers["ce-eventName"]);
+        Assert.Equal("2", disconnected.Headers["ce-id"]);
+        using var body = JsonDocument.Parse(disconnected.Body);
+        Assert.Equal(reconnect ? "recovered-close" : "The connection recovery timeout expired.",
+            body.RootElement.GetProperty("reason").GetString());
+        Assert.False(events.Reader.TryRead(out _));
+    }
+
+    private static async Task<WebApplication> StartUpstreamAsync(
+        Channel<ReceivedEvent> events, int status = 200, Func<HttpContext, Task>? afterReceive = null)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseUrls("http://127.0.0.1:0");
+        builder.WebHost.ConfigureKestrel(options => options.RequestHeaderEncodingSelector = _ => Encoding.UTF8);
+        var app = builder.Build();
+        app.Run(async context =>
+        {
+            var body = await new System.IO.StreamReader(context.Request.Body).ReadToEndAsync();
+            events.Writer.TryWrite(new ReceivedEvent(context.Request.Path.Value!,
+                context.Request.Headers.ToDictionary(p => p.Key, p => p.Value.ToString(), StringComparer.OrdinalIgnoreCase), body));
+            if (afterReceive is not null)
+            {
+                await afterReceive(context);
+            }
+            context.Response.StatusCode = status;
+            context.Response.Cookies.Append("affinity", context.Request.Headers["ce-connectionId"].ToString());
+        });
+        await app.StartAsync().WaitAsync(TestTimeout);
+        return app;
+    }
+
+    private static async Task<WebApplication> StartEmulatorAsync(WebApplication upstream, TimeSpan? reconnectTimeout = null)
+    {
+        var builder = EmulatorApplication.CreateBuilder(["--urls=http://127.0.0.1:0"],
+            new EmulatorRuntimeOptions { ReconnectTimeout = reconnectTimeout ?? TimeSpan.FromSeconds(30) });
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["WebPubSub:Hubs:chat:EventHandlers:0:UrlTemplate"] = Endpoint(upstream) + "/events/{HUB}/{event}",
+            ["WebPubSub:Hubs:chat:EventHandlers:0:SystemEvents:0"] = "connected",
+            ["WebPubSub:Hubs:chat:EventHandlers:0:SystemEvents:1"] = "disconnected",
+            ["WebPubSub:Hubs:chat:EventHandlers:1:UrlTemplate"] = Endpoint(upstream) + "/wrong-handler",
+            ["WebPubSub:Hubs:chat:EventHandlers:1:SystemEvents:0"] = "connected",
+            ["WebPubSub:Hubs:_default:EventHandlers:0:UrlTemplate"] = Endpoint(upstream) + "/wrong-default",
+            ["WebPubSub:Hubs:_default:EventHandlers:0:SystemEvents:0"] = "connected",
+        });
+        var app = EmulatorApplication.Build(builder);
+        await app.StartAsync().WaitAsync(TestTimeout);
+        return app;
+    }
+
+    private static async Task<ClientWebSocket> ConnectAsync(WebApplication app, string? protocol, Uri? uri = null)
+    {
+        var socket = new ClientWebSocket();
+        if (protocol is not null)
+        {
+            socket.Options.AddSubProtocol(protocol);
+        }
+        var token = new JwtSecurityToken(audience: Endpoint(app) + "/client/hubs/chat",
+            claims: [new Claim("sub", "用户")], expires: DateTime.UtcNow.AddHours(1),
+            signingCredentials: new SigningCredentials(new SymmetricSecurityKey(Encoding.UTF8.GetBytes(EmulatorOptions.DefaultAccessKey)), SecurityAlgorithms.HmacSha256));
+        var address = uri ?? new Uri(Endpoint(app).Replace("http:", "ws:") + "/client/hubs/chat?access_token=" + new JwtSecurityTokenHandler().WriteToken(token));
+        await socket.ConnectAsync(address, CancellationToken.None).WaitAsync(TestTimeout);
+        return socket;
+    }
+
+    private static async Task<JsonDocument> ReceiveJsonAsync(WebSocket socket)
+    {
+        var bytes = new byte[4096];
+        var result = await socket.ReceiveAsync(bytes, CancellationToken.None).WaitAsync(TestTimeout);
+        Assert.Equal(WebSocketMessageType.Text, result.MessageType);
+        return JsonDocument.Parse(bytes.AsMemory(0, result.Count));
+    }
+
+    private static string Endpoint(WebApplication app) => app.Urls.Single();
+
+    private sealed record ReceivedEvent(string Path, Dictionary<string, string> Headers, string Body);
+}

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/UpstreamNotificationTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/UpstreamNotificationTests.cs
@@ -101,7 +101,7 @@ public class UpstreamNotificationTests
         Assert.Equal(3, connection!.UpstreamContext.GetNextEventId());
         Assert.False(events.Reader.TryRead(out _));
 
-        var replacement = manager.Create(id, "chat", new ClaimsPrincipal());
+        var replacement = manager.Create(id, "chat", new ClaimsPrincipal(), host: connection.UpstreamContext.Host);
         Assert.True(manager.TryActivate(replacement));
         manager.Remove(connection);
         Assert.True(manager.TryGet("chat", id, out var current));

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/UpstreamNotificationTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/UpstreamNotificationTests.cs
@@ -82,6 +82,8 @@ public class UpstreamNotificationTests
         var disconnected = await events.Reader.ReadAsync().AsTask().WaitAsync(TestTimeout);
         Assert.Equal("2", disconnected.Headers["ce-id"]);
         Assert.Equal("azure.webpubsub.sys.disconnected", disconnected.Headers["ce-type"]);
+        Assert.Equal(connected.Headers["ce-signature"], disconnected.Headers["ce-signature"]);
+        Assert.NotEqual(connected.Headers["x-ms-client-request-id"], disconnected.Headers["x-ms-client-request-id"]);
         using var body = JsonDocument.Parse(disconnected.Body);
         Assert.Equal(closeMode switch
             {


### PR DESCRIPTION
## Summary

Extract H1 (HTTP lifecycle notifications) from the broader handler implementation in #1123 into a standalone, reviewable slice. This PR targets main and does not depend on the remaining handler work.

- Send connected and final disconnected binary-mode CloudEvents to the first matching per-hub HTTP(S) handler.
- Preserve logical-connection lifetime semantics: reliable reconnects do not emit another connected notification, and only final removal emits disconnected. Stale removal cannot delete a replacement connection.
- Include related audit fixes: connection-scoped cookies with pooled automatic cookies disabled, UTF-8 ce-userId, default 100-second HTTP timeout through response headers, and notification cancellation independent of the client request.
- Validate supported configuration and document its limitations; no new package dependencies.

## Runtime alignment and differences from #1123

- Use case-insensitive exact hub lookup without the invented _default catch-all.
- Reserve event ID 0 for connect even when no connect handler exists; connected starts at 1.
- Resolve and escape complete {hub}/{event} URL parameters; reject unsupported Key Vault references rather than sending them unresolved.
- Preserve full application-server close reasons in disconnected notifications.
- Keep routing/CloudEvents in UpstreamEventDispatcher, per-connection identity/event IDs/cookies in UpstreamConnectionContext, and HTTP transport in HttpUpstreamTrigger. Existing connection ownership remains in the handler and manager.

## Deliberately deferred

Webhook validation and retries are the next transport slice. Connect interception, user-event responses, metadata/state, bearer authentication, raw sendEvent/noEcho, and Event Hubs listeners remain separate follow-ups. This is not full handler parity. The requirement to strip client credentials remains with the future connect slice; runtime security changes are separate. This PR does not close or modify #1123.

## Validation

- Release test suite: 177 passed, 0 failed.
- Nine real Kestrel HTTP/WebSocket lifecycle tests repeated three additional times: all passed.
- Coverage includes CloudEvents/signature/UTF-8 headers, cookies and error responses, routing, normal/server/protocol closes, reliable recovery/expiration, stale-instance removal, and client-independent notification lifetime.
- Release package creation succeeded; editor diagnostics and git diff --check passed.

Scope: 14 files, +567 / -17 lines. Local verified commit: 3ef316c481b1a6b8745f62dcd15c9edecc9e7618.