### PR TITLE
Emulator: add webhook validation and HTTP retries (H2)

### DIFF
--- a/tools/emulator/Directory.Packages.props
+++ b/tools/emulator/Directory.Packages.props
@@ -9,6 +9,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Polly" Version="10.0.10" />
     <PackageVersion Include="Microsoft.OData.Core" Version="8.4.4" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.22.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />

--- a/tools/emulator/README.md
+++ b/tools/emulator/README.md
@@ -150,9 +150,25 @@ an access-key signature, and cookies isolated to each logical connection. Notifi
 are logged without rejecting the WebSocket. Reliable reconnects do not produce another connected
 notification; disconnected is sent only on final close or recovery expiration.
 
-This slice sends notifications directly, without webhook endpoint validation, retries, or bearer
-authentication. The HTTP client retains its default 100-second timeout to response headers.
-Connect interception, user-event responses, Key Vault URL references, and Event Hubs listeners
+Before sending notifications, the emulator validates the handler URL with `{event}` set to
+`validate`. The endpoint must answer OPTIONS (or GET when OPTIONS returns 404) with a 2xx status
+and `WebHook-Allowed-Origin` containing `*` or the request's `WebHook-Request-Origin` host.
+Origin matching is case-insensitive; values are matched as returned by the HTTP header parser,
+not additionally split on commas. Validation carries `ce-awpsversion: 1.0`, but no connection
+cookies or signature, and has a 10-second deadline per OPTIONS/GET operation.
+
+Validation results are cached per resolved validation URL. The first request waits for validation;
+later requests use the previous result while an expired entry refreshes. Success is cached for
+one minute. Failed validation retries on subsequent use after 1, 2, 4, 8, 16, 32, then 60 seconds
+(capped at one minute). Restart the emulator after changing handler configuration to clear the cache.
+
+Both validation and notification requests retry HTTP 408, 5xx, and eligible `HttpRequestException`
+failures after 1, 3, and 5 seconds (at most four attempts). HTTP 429, other 4xx responses,
+cancellation/timeouts, and the non-ASCII-header exception are not retried. Retries reuse the event
+identity and body, so handlers should tolerate duplicates. The notification HTTP client's default
+100-second deadline covers sending through response headers, including retry delays.
+
+Connect interception, user-event responses, bearer authentication, Key Vault URL references, and Event Hubs listeners
 are not supported yet. Unsupported handler configuration is rejected at startup.
 
 ## Local server SDK authentication

--- a/tools/emulator/SUPPORTED_FEATURES.md
+++ b/tools/emulator/SUPPORTED_FEATURES.md
@@ -18,6 +18,7 @@ local Azure Web PubSub development.
 | Groups and roles | Supports connection-scoped token groups and authorized join, leave, and group send, including wildcard roles. | ✅ |
 | Outbound delivery | Uses a bounded, single-writer queue for each WebSocket connection. | ✅ |
 | HTTP lifecycle notifications | Sends `connected` and final `disconnected` CloudEvents to per-hub HTTP handlers; no connect interception or user events yet. See [configuration and limitations](README.md#http-lifecycle-notifications). | ⚠️ |
+| HTTP handler validation and retries | Validates endpoints with OPTIONS/GET and cached allowed-origin results; retries HTTP 408, 5xx, and eligible network failures with 1/3/5-second delays. | ✅ |
 | REST connection operations | Authenticated connection presence, direct text, JSON, and binary sends, close, and single-connection group membership changes for GA API versions from `2021-10-01` through `2024-12-01`. | ✅ |
 | REST group operations | Authenticated group presence and text, JSON, or binary fan-out with excluded connection IDs and OData filters. | ✅ |
 | REST broadcast | Authenticated text, JSON, or binary fan-out with excluded connection IDs and OData filters. | ✅ |
@@ -48,7 +49,7 @@ runtime's new contract and decode the original user ID path segment exactly once
 
 The following areas are planned for follow-up changes:
 
-- HTTP connect/user-event handlers, webhook validation, retries, bearer authentication, and Key Vault URL references
+- HTTP connect/user-event handlers, bearer authentication, and Key Vault URL references
 - Tunnel connections (`tunnel://` upstream URLs)
 - Event Hubs listeners
 - Protobuf subprotocols

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/AbuseProtector.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/AbuseProtector.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Concurrent;
+using System.Net;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebPubSub.Emulator;
+
+internal sealed class AbuseProtector(IHttpClientFactory clients, TimeProvider timeProvider, ILogger<AbuseProtector> logger)
+{
+    private static readonly TimeSpan MaxValidateInterval = TimeSpan.FromMinutes(1);
+    private static readonly TimeSpan MinValidateInterval = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan ValidateTimeout = TimeSpan.FromSeconds(10);
+    private readonly ConcurrentDictionary<Uri, ValidationRecord> _records = new();
+
+    public Task<bool> ValidateAsync(Uri uri, string host)
+    {
+        var record = _records.GetOrAdd(uri, _ => new ValidationRecord());
+        lock (record)
+        {
+            if (timeProvider.GetUtcNow() >= record.NextValidation && record.Refresh is not { IsCompleted: false })
+            {
+                record.Refresh = RefreshAsync(record, uri, host);
+            }
+
+            // Like runtime, block initial validation; later refreshes use the last known result.
+            return record.Initialized ? Task.FromResult(record.Success) : record.Refresh!;
+        }
+    }
+
+    private async Task<bool> RefreshAsync(ValidationRecord record, Uri uri, string host)
+    {
+        var success = false;
+        try
+        {
+            var result = await SendValidationAsync(uri, HttpMethod.Options, host);
+            if (result.StatusCode == HttpStatusCode.NotFound)
+            {
+                result = await SendValidationAsync(uri, HttpMethod.Get, host);
+            }
+            success = result.Allowed;
+        }
+        catch (Exception exception)
+        {
+            logger.LogWarning(exception, "Upstream webhook validation failed.");
+        }
+
+        lock (record)
+        {
+            record.Interval = success ? MaxValidateInterval : record.Success ? MinValidateInterval :
+                TimeSpan.FromTicks(Math.Min(record.Interval.Ticks * 2, MaxValidateInterval.Ticks));
+            record.Success = success;
+            record.Initialized = true;
+            record.NextValidation = timeProvider.GetUtcNow() + record.Interval;
+        }
+        return success;
+    }
+
+    private async Task<(HttpStatusCode StatusCode, bool Allowed)> SendValidationAsync(Uri uri, HttpMethod method, string host)
+    {
+        using var client = clients.CreateClient(HttpUpstreamTrigger.HttpClientName);
+        using var request = new HttpRequestMessage(method, uri) { Version = HttpVersion.Version20 };
+        request.Headers.Add("WebHook-Request-Origin", host);
+        request.Headers.Add("ce-awpsversion", "1.0");
+        using var timeout = new CancellationTokenSource(ValidateTimeout, timeProvider);
+        using var response = await client.SendAsync(request, timeout.Token);
+        var allowed = response.IsSuccessStatusCode &&
+            response.Headers.TryGetValues("WebHook-Allowed-Origin", out var origins) &&
+            origins.Any(origin => origin == "*" || string.Equals(origin, host, StringComparison.OrdinalIgnoreCase));
+        return (response.StatusCode, allowed);
+    }
+
+    private sealed class ValidationRecord
+    {
+        public bool Initialized;
+        public bool Success = true;
+        public TimeSpan Interval = MinValidateInterval;
+        public DateTimeOffset NextValidation;
+        public Task<bool>? Refresh;
+    }
+}

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/CustomerOutboundConfiguration.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/CustomerOutboundConfiguration.cs
@@ -2,11 +2,16 @@
 // Licensed under the MIT License.
 
 using System.Text;
+using Polly;
+using Polly.Extensions.Http;
 
 namespace Microsoft.Azure.WebPubSub.Emulator;
 
 internal static class CustomerOutboundConfiguration
 {
+    private static readonly TimeSpan[] RetryDelays =
+        [TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(5)];
+
     // Keep the allowlist aligned with the runtime's CustomerOutboundConfiguration.
     private static readonly string[] UnicodeAllowedUpstreamHeaderNames =
         [
@@ -23,6 +28,14 @@ internal static class CustomerOutboundConfiguration
             UseCookies = false,
             RequestHeaderEncodingSelector = SelectRequestHeaderEncoding,
         };
+    }
+
+    public static IAsyncPolicy<HttpResponseMessage> CreateRetryPolicy()
+    {
+        return Policy<HttpResponseMessage>
+            .Handle<HttpRequestException>(exception => exception.Message != "Request headers must contain only ASCII characters.")
+            .OrTransientHttpStatusCode()
+            .WaitAndRetryAsync(RetryDelays, (result, _) => result.Result?.Dispose());
     }
 
     private static Encoding? SelectRequestHeaderEncoding(string headerName, HttpRequestMessage request)

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorApplication.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorApplication.cs
@@ -40,8 +40,11 @@ internal static class EmulatorApplication
         builder.Services.AddSingleton<SimpleWebSocketPayloadProcessor>();
         builder.Services.AddSingleton<WebPubSubJsonV1Protocol>();
         builder.Services.AddSingleton<HttpUpstreamTrigger>();
+        builder.Services.AddSingleton(TimeProvider.System);
+        builder.Services.AddSingleton<AbuseProtector>();
         builder.Services.AddSingleton<UpstreamEventDispatcher>();
         builder.Services.AddHttpClient(HttpUpstreamTrigger.HttpClientName)
+            .AddPolicyHandler(CustomerOutboundConfiguration.CreateRetryPolicy())
             .ConfigurePrimaryHttpMessageHandler(CustomerOutboundConfiguration.ConfigureHttpMessageHandler);
         builder.Services.AddSingleton<
             IWebPubSubConnectionLifetimeHandler,

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/HttpUpstreamTrigger.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/HttpUpstreamTrigger.cs
@@ -7,13 +7,17 @@ using Microsoft.Extensions.Logging;
 namespace Microsoft.Azure.WebPubSub.Emulator;
 
 internal sealed class HttpUpstreamTrigger(
-    IHttpClientFactory clients, ILogger<HttpUpstreamTrigger> logger)
+    IHttpClientFactory clients, AbuseProtector abuseProtector, ILogger<HttpUpstreamTrigger> logger)
 {
     public const string HttpClientName = "WebPubSubEventHandler";
 
     public async Task<HttpResponseMessage> SendAsync(
-        HttpRequestMessage request, UpstreamConnectionContext connection, CancellationToken cancellationToken)
+        HttpRequestMessage request, Uri validationUri, UpstreamConnectionContext connection, CancellationToken cancellationToken)
     {
+        if (!await abuseProtector.ValidateAsync(validationUri, connection.Host))
+        {
+            throw new HttpRequestException("The upstream endpoint did not allow the WebHook-Request-Origin.");
+        }
         var uri = request.RequestUri!;
         var cookies = connection.Cookies.GetCookieHeader(uri);
         if (cookies.Length > 0)

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/Microsoft.Azure.WebPubSub.Emulator.csproj
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/Microsoft.Azure.WebPubSub.Emulator.csproj
@@ -26,6 +26,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" />
     <PackageReference Include="Microsoft.OData.Core" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
   </ItemGroup>

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/SocketTransport.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/SocketTransport.cs
@@ -193,12 +193,21 @@ internal sealed class SocketTransport : IDisposable
     public async Task CloseAsync(WebSocketCloseStatus status, string description)
     {
         CloseOutput(status, description);
+        using var closeCancellation = CancellationTokenSource.CreateLinkedTokenSource(_abortToken);
+        closeCancellation.CancelAfter(CloseDrainTimeout);
         try
         {
-            await _writeLoop.WaitAsync(CloseDrainTimeout).ConfigureAwait(false);
+            await _writeLoop.WaitAsync(closeCancellation.Token).ConfigureAwait(false);
+            if (WebSocket.State == WebSocketState.CloseSent)
+            {
+                // Sending the close frame alone is not a completed handshake. Wait for
+                // the peer before the request disposes (and aborts) the transport.
+                // CloseAsync does not send a second close frame in CloseSent state.
+                await WebSocket.CloseAsync(status, description, closeCancellation.Token)
+                    .ConfigureAwait(false);
+            }
         }
-        catch (Exception exception) when (
-            exception is TimeoutException or OperationCanceledException)
+        catch (OperationCanceledException)
         {
             Abort();
         }

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/UpstreamEventDispatcher.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/UpstreamEventDispatcher.cs
@@ -29,7 +29,8 @@ internal sealed class UpstreamEventDispatcher(
 
         try
         {
-            if (!EventHandlerUrlTemplate.TryResolve(handler.UrlTemplate, connection.Hub, eventName, out var uri))
+            if (!EventHandlerUrlTemplate.TryResolve(handler.UrlTemplate, connection.Hub, eventName, out var uri) ||
+                !EventHandlerUrlTemplate.TryResolve(handler.UrlTemplate, connection.Hub, "validate", out var validationUri))
             {
                 throw new InvalidDataException("Event handler URL must resolve to an HTTP or HTTPS URL without Key Vault references.");
             }
@@ -61,7 +62,7 @@ internal sealed class UpstreamEventDispatcher(
             }
 
             // Notifications survive the client request ending, as in PushModeUpstreamInvoker.
-            using var response = await trigger.SendAsync(request, connection, CancellationToken.None);
+            using var response = await trigger.SendAsync(request, validationUri, connection, CancellationToken.None);
             if (!response.IsSuccessStatusCode)
             {
                 logger.LogWarning("The {EventName} handler returned {StatusCode} for {ConnectionId}.",

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/CustomerOutboundConfigurationTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/CustomerOutboundConfigurationTests.cs
@@ -1,14 +1,61 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Net.Http;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.Azure.WebPubSub.Emulator.Tests;
 
 public class CustomerOutboundConfigurationTests
 {
+    [Theory]
+    [InlineData("network", 2)]
+    [InlineData("ascii", 1)]
+    [InlineData("cancellation", 1)]
+    public async Task RetryExceptionTypesMatchRuntime(string failure, int expectedAttempts)
+    {
+        var attempts = 0;
+        var policy = CustomerOutboundConfiguration.CreateRetryPolicy();
+        var exception = await Record.ExceptionAsync(async () =>
+        {
+            using var response = await policy.ExecuteAsync(() =>
+            {
+                if (++attempts == 1)
+                {
+                    throw failure switch
+                    {
+                        "ascii" => new HttpRequestException("Request headers must contain only ASCII characters."),
+                        "cancellation" => new OperationCanceledException(),
+                        _ => new HttpRequestException("Connection reset."),
+                    };
+                }
+                return Task.FromResult(new HttpResponseMessage());
+            });
+        });
+        Assert.Equal(expectedAttempts, attempts);
+        if (expectedAttempts == 2) Assert.Null(exception);
+        else Assert.NotNull(exception);
+    }
+
+    [Fact]
+    public async Task CancellationStopsRetryDelay()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var attempts = 0;
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            CustomerOutboundConfiguration.CreateRetryPolicy().ExecuteAsync(token =>
+            {
+                attempts++;
+                cancellation.Cancel();
+                return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.ServiceUnavailable));
+            }, cancellation.Token));
+        Assert.Equal(1, attempts);
+    }
+
     [Theory]
     [InlineData("X-ASRS-User-Id", true)]
     [InlineData("X-ASRS-User-Claims", true)]

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/HttpUpstreamTriggerTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/HttpUpstreamTriggerTests.cs
@@ -1,0 +1,332 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Microsoft.Azure.WebPubSub.Emulator.Tests;
+
+public class HttpUpstreamTriggerTests
+{
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(20);
+
+    [Theory]
+    [InlineData(200, "*", true)]
+    [InlineData(202, "EMULATOR.EXAMPLE.TEST", true)]
+    [InlineData(404, "*", true)]
+    [InlineData(405, "*", false)]
+    [InlineData(200, null, false)]
+    [InlineData(200, "other.example.test", false)]
+    [InlineData(200, "other.example.test, emulator.example.test", false)]
+    public async Task ValidationGatesPostsAndCachesOutcome(int status, string? allowedOrigin, bool allowed)
+    {
+        var methods = new List<string>();
+        var posts = 0;
+        await using var fixture = await Fixture.StartAsync(context =>
+        {
+            if (HttpMethods.IsPost(context.Request.Method))
+            {
+                Interlocked.Increment(ref posts);
+                Assert.False(context.Request.Headers.ContainsKey("Cookie"));
+            }
+            else
+            {
+                methods.Add(context.Request.Method);
+                Assert.Equal("/events/chat/validate", context.Request.Path);
+                Assert.Equal("emulator.example.test", context.Request.Headers["WebHook-Request-Origin"].ToString());
+                Assert.Equal("1.0", context.Request.Headers["ce-awpsversion"].ToString());
+                Assert.False(context.Request.Headers.ContainsKey("ce-signature"));
+                Assert.False(context.Request.Headers.ContainsKey("Authorization"));
+                Assert.False(context.Request.Headers.ContainsKey("Cookie"));
+                context.Response.StatusCode = HttpMethods.IsGet(context.Request.Method) ? 200 : status;
+                if (allowedOrigin is not null) context.Response.Headers["WebHook-Allowed-Origin"] = allowedOrigin;
+                context.Response.Cookies.Append("validation-only", "ignored");
+            }
+            return Task.CompletedTask;
+        });
+        for (var i = 0; i < 2; i++)
+        {
+            if (allowed)
+            {
+                using var response = await fixture.SendAsync().WaitAsync(TestTimeout);
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            }
+            else
+            {
+                await Assert.ThrowsAsync<HttpRequestException>(() => fixture.SendAsync().WaitAsync(TestTimeout));
+            }
+        }
+        Assert.Equal(status == 404 ? new[] { "OPTIONS", "GET" } : new[] { "OPTIONS" }, methods);
+        Assert.Equal(allowed ? 2 : 0, posts);
+    }
+
+    [Fact]
+    public async Task ValidationUsesRetryPolicyAndCachesByResolvedUri()
+    {
+        var validations = 0;
+        var posts = 0;
+        await using var fixture = await Fixture.StartAsync(context =>
+        {
+            if (HttpMethods.IsOptions(context.Request.Method))
+            {
+                context.Response.StatusCode = Interlocked.Increment(ref validations) == 1 ? 503 : 200;
+                context.Response.Headers["WebHook-Allowed-Origin"] = "*";
+            }
+            else Interlocked.Increment(ref posts);
+            return Task.CompletedTask;
+        });
+        using var first = await fixture.SendAsync().WaitAsync(TestTimeout);
+        Assert.Equal(2, validations);
+        using var second = await fixture.SendAsync().WaitAsync(TestTimeout);
+        Assert.Equal(2, validations);
+        using var other = await fixture.SendAsync(new Uri(fixture.ValidationUri + "?handler=other")).WaitAsync(TestTimeout);
+        Assert.Equal(3, validations);
+        Assert.Equal(3, posts);
+    }
+
+    [Fact]
+    public async Task ValidationTimeoutDoesNotSendPostOrRetryCancellation()
+    {
+        var validations = 0;
+        var posts = 0;
+        var timer = Stopwatch.StartNew();
+        await using var fixture = await Fixture.StartAsync(async context =>
+        {
+            if (HttpMethods.IsOptions(context.Request.Method))
+            {
+                Interlocked.Increment(ref validations);
+                try { await Task.Delay(Timeout.InfiniteTimeSpan, context.RequestAborted); }
+                catch (OperationCanceledException) { }
+            }
+            else Interlocked.Increment(ref posts);
+        });
+        await Assert.ThrowsAsync<HttpRequestException>(() => fixture.SendAsync().WaitAsync(TestTimeout));
+        Assert.True(timer.Elapsed >= TimeSpan.FromSeconds(9.5));
+        Assert.Equal(1, validations);
+        Assert.Equal(0, posts);
+    }
+
+    [Fact]
+    public async Task FirstValidationIsSharedAndBlocksConcurrentPosts()
+    {
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var validations = 0;
+        var posts = 0;
+        await using var fixture = await Fixture.StartAsync(async context =>
+        {
+            if (HttpMethods.IsOptions(context.Request.Method))
+            {
+                Interlocked.Increment(ref validations);
+                entered.TrySetResult();
+                await release.Task.WaitAsync(TestTimeout);
+                context.Response.Headers["WebHook-Allowed-Origin"] = "*";
+            }
+            else Interlocked.Increment(ref posts);
+        });
+        var requests = Enumerable.Range(0, 8).Select(_ => fixture.SendAsync()).ToArray();
+        try
+        {
+            await entered.Task.WaitAsync(TestTimeout);
+            Assert.All(requests, request => Assert.False(request.IsCompleted));
+            Assert.Equal(0, Volatile.Read(ref posts));
+            Assert.Equal(1, Volatile.Read(ref validations));
+        }
+        finally { release.TrySetResult(); }
+        foreach (var response in await Task.WhenAll(requests).WaitAsync(TestTimeout)) response.Dispose();
+        Assert.Equal(8, posts);
+        Assert.Equal(1, validations);
+    }
+
+    [Fact]
+    public async Task ValidationCacheRefreshesWithRuntimeIntervals()
+    {
+        var clock = new TestClock();
+        var gates = Channel.CreateUnbounded<TaskCompletionSource>();
+        var attempts = Channel.CreateUnbounded<bool>();
+        var allow = true;
+        await using var fixture = await Fixture.StartAsync(async context =>
+        {
+            attempts.Writer.TryWrite(true);
+            var gate = await gates.Reader.ReadAsync();
+            await gate.Task.WaitAsync(TestTimeout);
+            if (allow) context.Response.Headers["WebHook-Allowed-Origin"] = "*";
+        }, clock);
+        var protector = fixture.App.Services.GetRequiredService<AbuseProtector>();
+        Task<bool> Validate() => protector.ValidateAsync(fixture.ValidationUri, "emulator.example.test");
+        TaskCompletionSource Queue(bool released)
+        {
+            var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            if (released) gate.SetResult();
+            gates.Writer.TryWrite(gate);
+            return gate;
+        }
+        Queue(true);
+        Assert.True(await Validate().WaitAsync(TestTimeout));
+        Assert.True(attempts.Reader.TryRead(out _));
+        clock.Advance(TimeSpan.FromSeconds(59));
+        Assert.True(await Validate());
+        Assert.False(attempts.Reader.TryRead(out _));
+
+        // Successful entries expire after one minute; refresh is non-blocking.
+        allow = false;
+        clock.Advance(TimeSpan.FromSeconds(1));
+        var refreshGate = Queue(false);
+        Assert.True(await Validate().WaitAsync(TestTimeout));
+        await attempts.Reader.ReadAsync().AsTask().WaitAsync(TestTimeout);
+        refreshGate.SetResult();
+        await WaitForResultAsync(Validate, false);
+
+        // Failure after success retries in 1s, then 2/4/8/16/32/60s, capped at 60s.
+        foreach (var seconds in new[] { 1, 2, 4, 8, 16, 32, 60, 60 })
+        {
+            clock.Advance(TimeSpan.FromSeconds(seconds) - TimeSpan.FromMilliseconds(1));
+            Assert.False(await Validate());
+            Assert.False(attempts.Reader.TryRead(out _));
+            var gate = Queue(false);
+            clock.Advance(TimeSpan.FromMilliseconds(1));
+            Assert.False(await Validate());
+            await attempts.Reader.ReadAsync().AsTask().WaitAsync(TestTimeout);
+            var reads = clock.ReadCount;
+            gate.SetResult();
+            await clock.WaitForReadAsync(reads);
+            Assert.False(await Validate());
+        }
+        allow = true;
+        Queue(true);
+        clock.Advance(TimeSpan.FromMinutes(1));
+        await Validate();
+        await WaitForResultAsync(Validate, true);
+    }
+
+    [Theory]
+    [InlineData(408, 2)]
+    [InlineData(503, 2)]
+    [InlineData(599, 2)]
+    [InlineData(400, 1)]
+    [InlineData(401, 1)]
+    [InlineData(404, 1)]
+    [InlineData(429, 1)]
+    public async Task RetryStatusCodesMatchRuntime(int status, int expectedAttempts)
+    {
+        var attempts = 0;
+        await using var fixture = await Fixture.StartAsync(context =>
+        {
+            if (HttpMethods.IsOptions(context.Request.Method)) context.Response.Headers["WebHook-Allowed-Origin"] = "*";
+            else context.Response.StatusCode = Interlocked.Increment(ref attempts) == 1 ? status : 200;
+            return Task.CompletedTask;
+        });
+        using var response = await fixture.SendAsync().WaitAsync(TestTimeout);
+        Assert.Equal(expectedAttempts, attempts);
+        Assert.Equal(expectedAttempts == 2 ? 200 : status, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task RetryExhaustionUsesOneThreeFiveSecondsAndReplaysRequest()
+    {
+        var times = new List<TimeSpan>();
+        var timer = Stopwatch.StartNew();
+        await using var fixture = await Fixture.StartAsync(async context =>
+        {
+            if (HttpMethods.IsOptions(context.Request.Method))
+            {
+                context.Response.Headers["WebHook-Allowed-Origin"] = "*";
+                return;
+            }
+            times.Add(timer.Elapsed);
+            Assert.Equal("stable-request-id", context.Request.Headers["x-ms-client-request-id"].ToString());
+            Assert.Equal("{\"message\":\"hello\"}", await new System.IO.StreamReader(context.Request.Body).ReadToEndAsync());
+            context.Response.StatusCode = 503;
+        });
+        using var response = await fixture.SendAsync().WaitAsync(TestTimeout);
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+        Assert.Equal(4, times.Count);
+        for (var i = 1; i < times.Count; i++) Assert.True(times[i] - times[i - 1] >= TimeSpan.FromSeconds(2 * i - 1) - TimeSpan.FromMilliseconds(100));
+    }
+
+    private static async Task WaitForResultAsync(Func<Task<bool>> validate, bool expected)
+    {
+        using var timeout = new CancellationTokenSource(TestTimeout);
+        while (await validate() != expected)
+        {
+            timeout.Token.ThrowIfCancellationRequested();
+            await Task.Yield();
+        }
+    }
+
+    private sealed class TestClock : TimeProvider
+    {
+        private long _ticks = DateTimeOffset.UtcNow.Ticks;
+        private int _reads;
+        public int ReadCount => Volatile.Read(ref _reads);
+        public override DateTimeOffset GetUtcNow()
+        {
+            var now = new DateTimeOffset(Interlocked.Read(ref _ticks), TimeSpan.Zero);
+            Interlocked.Increment(ref _reads);
+            return now;
+        }
+        public void Advance(TimeSpan duration) => Interlocked.Add(ref _ticks, duration.Ticks);
+        public async Task WaitForReadAsync(int previous)
+        {
+            using var timeout = new CancellationTokenSource(TestTimeout);
+            while (ReadCount == previous)
+            {
+                timeout.Token.ThrowIfCancellationRequested();
+                await Task.Yield();
+            }
+        }
+    }
+
+    private sealed class Fixture(WebApplication upstream, WebApplication app) : IAsyncDisposable
+    {
+        public WebApplication App { get; } = app;
+        public Uri ValidationUri => new(upstream.Urls.Single() + "/events/chat/validate");
+
+        public static async Task<Fixture> StartAsync(RequestDelegate handle, TimeProvider? clock = null)
+        {
+            var builder = WebApplication.CreateBuilder();
+            builder.Logging.ClearProviders();
+            builder.WebHost.UseUrls("http://127.0.0.1:0");
+            var upstream = builder.Build();
+            upstream.Run(handle);
+            await upstream.StartAsync().WaitAsync(TestTimeout);
+            var emulatorBuilder = EmulatorApplication.CreateBuilder(["--urls=http://127.0.0.1:0"]);
+            emulatorBuilder.Logging.ClearProviders();
+            if (clock is not null) emulatorBuilder.Services.AddSingleton(clock);
+            var app = EmulatorApplication.Build(emulatorBuilder);
+            await app.StartAsync().WaitAsync(TestTimeout);
+            return new Fixture(upstream, app);
+        }
+
+        public async Task<HttpResponseMessage> SendAsync(Uri? validationUri = null)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Post, new Uri(upstream.Urls.Single() + "/events/chat/connected"))
+            {
+                Content = new StringContent("{\"message\":\"hello\"}", Encoding.UTF8, "application/json"),
+            };
+            request.Headers.Add("x-ms-client-request-id", "stable-request-id");
+            var connection = new UpstreamConnectionContext(Guid.NewGuid().ToString(), "chat", null, null, "emulator.example.test");
+            return await App.Services.GetRequiredService<HttpUpstreamTrigger>().SendAsync(request, validationUri ?? ValidationUri, connection, CancellationToken.None);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await App.DisposeAsync();
+            await upstream.DisposeAsync();
+        }
+    }
+}

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/LogicalConnectionTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/LogicalConnectionTests.cs
@@ -411,6 +411,36 @@ public class LogicalConnectionTests
         Assert.False(manager.TryGet(connection.Hub, connection.ConnectionId, out _));
     }
 
+    [Theory]
+    [InlineData("acknowledge")]
+    [InlineData("abort")]
+    [InlineData("timeout")]
+    public async Task TransportCloseWaitsForPeerOrAborts(string outcome)
+    {
+        using var socket = new GatedCloseWebSocket();
+        using var transport = new SocketTransport(socket, 4096, 4, 16384);
+        var closing = transport.CloseAsync(WebSocketCloseStatus.InvalidMessageType, "invalid");
+
+        await Task.WhenAny(closing, socket.CloseStarted.Task).WaitAsync(TestTimeout);
+        Assert.True(socket.CloseStarted.Task.IsCompleted, "The transport must wait for the peer close before returning.");
+        Assert.False(closing.IsCompleted);
+        Assert.Equal(WebSocketState.CloseSent, socket.State);
+
+        if (outcome == "acknowledge")
+        {
+            socket.Acknowledge.TrySetResult();
+        }
+        else if (outcome == "abort")
+        {
+            transport.Abort();
+        }
+
+        await closing.WaitAsync(TestTimeout);
+        Assert.Equal(outcome == "acknowledge" ? WebSocketState.Closed : WebSocketState.Aborted, socket.State);
+        Assert.Equal(outcome != "acknowledge", transport.Aborted.IsCancellationRequested);
+        Assert.Equal(1, socket.CloseOutputCount);
+    }
+
     [Fact]
     public async Task ReliableNonNormalCloseCanReconnect()
     {
@@ -651,16 +681,21 @@ public class LogicalConnectionTests
         originalSocket.Release.TrySetResult();
         await processor.Started.Task.WaitAsync(TestTimeout);
 
-        var recoveredSocket = new TestWebSocket();
+        var recoveredSocket = new GatedCloseWebSocket();
         using var recovered = await connection.TryReconnectAsync(
             recoveredSocket,
             processor,
             CancellationToken.None).AsTask().WaitAsync(TestTimeout);
         Assert.NotNull(recovered);
         processor.Release.TrySetResult();
+        await Task.WhenAny(handlerTask, recoveredSocket.CloseStarted.Task).WaitAsync(TestTimeout);
+        Assert.True(recoveredSocket.CloseStarted.Task.IsCompleted);
+        Assert.False(handlerTask.IsCompleted);
+        Assert.Equal(WebSocketState.CloseSent, recoveredSocket.State);
+        recoveredSocket.Acknowledge.TrySetResult();
         await handlerTask.WaitAsync(TestTimeout);
 
-        Assert.Equal(WebSocketState.CloseSent, recoveredSocket.State);
+        Assert.Equal(WebSocketState.Closed, recoveredSocket.State);
         Assert.False(manager.TryGet(connection.Hub, connection.ConnectionId, out _));
     }
 
@@ -1217,6 +1252,36 @@ public class LogicalConnectionTests
             CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
+        }
+    }
+
+    private sealed class GatedCloseWebSocket : TestWebSocket
+    {
+        public TaskCompletionSource CloseStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource Acknowledge { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int CloseOutputCount { get; private set; }
+
+        public override Task CloseOutputAsync(
+            WebSocketCloseStatus closeStatus,
+            string? statusDescription,
+            CancellationToken cancellationToken)
+        {
+            CloseOutputCount++;
+            return base.CloseOutputAsync(closeStatus, statusDescription, cancellationToken);
+        }
+
+        public override async Task CloseAsync(
+            WebSocketCloseStatus closeStatus,
+            string? statusDescription,
+            CancellationToken cancellationToken)
+        {
+            CloseStarted.TrySetResult();
+            await Acknowledge.Task.WaitAsync(cancellationToken);
+            await base.CloseAsync(closeStatus, statusDescription, cancellationToken);
         }
     }
 

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/UpstreamNotificationTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/UpstreamNotificationTests.cs
@@ -77,8 +77,17 @@ public class UpstreamNotificationTests
         else if (closeMode == "protocol")
         {
             await socket.SendAsync(new byte[] { 1 }, WebSocketMessageType.Binary, true, CancellationToken.None).WaitAsync(TestTimeout);
+            // Protocol failure is a server-initiated close. Sending another close here
+            // races the server ending the transport with unread client data.
+            var close = await socket.ReceiveAsync(new byte[4096], CancellationToken.None).WaitAsync(TestTimeout);
+            Assert.Equal(WebSocketMessageType.Close, close.MessageType);
+            Assert.Equal(WebSocketCloseStatus.InvalidMessageType, close.CloseStatus);
+            Assert.Equal("The JSON subprotocol requires text messages.", close.CloseStatusDescription);
         }
-        await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "test-close", CancellationToken.None).WaitAsync(TestTimeout);
+        if (closeMode != "protocol")
+        {
+            await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "test-close", CancellationToken.None).WaitAsync(TestTimeout);
+        }
         var disconnected = await events.Reader.ReadAsync().AsTask().WaitAsync(TestTimeout);
         Assert.Equal("2", disconnected.Headers["ce-id"]);
         Assert.Equal("azure.webpubsub.sys.disconnected", disconnected.Headers["ce-type"]);

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/UpstreamNotificationTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/UpstreamNotificationTests.cs
@@ -33,7 +33,7 @@ public class UpstreamNotificationTests
     [Theory]
     [InlineData(null, "client", 200)]
     [InlineData(JsonProtocol, "server", 200)]
-    [InlineData(JsonProtocol, "client", 503)]
+    [InlineData(JsonProtocol, "client", 400)]
     [InlineData(JsonProtocol, "protocol", 200)]
     [InlineData(ReliableProtocol, "client", 200)]
     public async Task LifecycleUsesCloudEventsAndNotifiesOnlyOnce(
@@ -210,6 +210,13 @@ public class UpstreamNotificationTests
         var app = builder.Build();
         app.Run(async context =>
         {
+            if (HttpMethods.IsOptions(context.Request.Method))
+            {
+                Assert.Equal("/events/chat/validate", context.Request.Path.Value, ignoreCase: true);
+                Assert.Equal("1.0", context.Request.Headers["ce-awpsversion"].ToString());
+                context.Response.Headers["WebHook-Allowed-Origin"] = "*";
+                return;
+            }
             var body = await new System.IO.StreamReader(context.Request.Body).ReadToEndAsync();
             events.Writer.TryWrite(new ReceivedEvent(context.Request.Path.Value!,
                 context.Request.Headers.ToDictionary(p => p.Key, p => p.Value.ToString(), StringComparer.OrdinalIgnoreCase), body));

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/UpstreamNotificationTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/UpstreamNotificationTests.cs
@@ -77,12 +77,13 @@ public class UpstreamNotificationTests
         else if (closeMode == "protocol")
         {
             await socket.SendAsync(new byte[] { 1 }, WebSocketMessageType.Binary, true, CancellationToken.None).WaitAsync(TestTimeout);
-            // Protocol failure is a server-initiated close. Sending another close here
-            // races the server ending the transport with unread client data.
+            // Verify the server's error close before acknowledging it.
             var close = await socket.ReceiveAsync(new byte[4096], CancellationToken.None).WaitAsync(TestTimeout);
             Assert.Equal(WebSocketMessageType.Close, close.MessageType);
             Assert.Equal(WebSocketCloseStatus.InvalidMessageType, close.CloseStatus);
             Assert.Equal("The JSON subprotocol requires text messages.", close.CloseStatusDescription);
+            await socket.CloseAsync(close.CloseStatus.Value, close.CloseStatusDescription, CancellationToken.None).WaitAsync(TestTimeout);
+            Assert.Equal(WebSocketState.Closed, socket.State);
         }
         if (closeMode != "protocol")
         {


### PR DESCRIPTION
## Summary

H2 follows merged #1124 and continues splitting the broader HTTP handler work in #1123. This PR targets main and adds only webhook endpoint validation and HTTP retries.

- Resolve the validation URL from the handler template with event=validate. Send OPTIONS; fall back to GET only for HTTP 404. Require a successful response with WebHook-Allowed-Origin matching the request host (case-insensitive) or an exact wildcard.
- Cache validation by resolved URI. Concurrent initial requests share and await validation; later requests use the previous result while refreshing. Success lasts 60 seconds; failures back off from 1 second to a 60-second cap. Each OPTIONS/GET operation has a 10-second deadline.
- Apply the runtime Polly policy to both validation and notification requests: retry eligible HttpRequestException failures, HTTP 408, and 5xx after 1/3/5 seconds, for at most four attempts. Do not retry HTTP 429, cancellation, or the exact non-ASCII-header exception.
- Keep validation separate from notification cookies/signatures; preserve event identity and body across retries. Dispose intermediate retry responses.

## Architecture and scope

- AbuseProtector owns endpoint validation and cached outcomes.
- CustomerOutboundConfiguration owns the shared retry policy; HttpUpstreamTrigger gates sending on validation.
- UpstreamEventDispatcher resolves the notification and validation URLs without changing connection lifetime ownership.
- Add Microsoft.Extensions.Http.Polly 10.0.10, matching the runtime dependency, restored through the approved repository feed.

Compared with #1123, this adds missing validation and retry behavior rather than carrying forward its full handler implementation. Connect interception, user-event responses, bearer authentication, raw modes, Key Vault references, tunnels, and Event Hubs remain separate follow-ups. Runtime code is unchanged. Emulator configuration hot reload is not implemented; restarting clears validation records. Intermediate response disposal is an explicit ownership improvement.

## Validation

- Full Release suite: 215 passed, 0 failed.
- Additional concurrency/cache and lifecycle regression run: 11 passed.
- Real Kestrel HTTP tests cover OPTIONS/GET, origin checks, blocked POSTs, concurrent initial validation, URI cache isolation, cache expiry/backoff, request replay, actual 1/3/5-second delays, and the 10-second validation timeout.
- Policy tests cover exception classification and cancellation during retry delay.
- Release package creation, editor diagnostics, and git diff --check passed.

Scope: 12 files, +517/-9 lines. Verified commit: 3057ec93755e66f9005aa0f9082679842e5f9802.