### PR TITLE
Emulator: add pre-upgrade connect event handling (H3)

### DIFF
--- a/tools/emulator/README.md
+++ b/tools/emulator/README.md
@@ -126,7 +126,7 @@ dotnet run --project tools\emulator\src\Microsoft.Azure.WebPubSub.Emulator
 
 ## HTTP lifecycle notifications
 
-Configure per-hub `connected` and `disconnected` handlers through ASP.NET Core configuration:
+Configure per-hub `connect`, `connected`, and `disconnected` handlers through ASP.NET Core configuration:
 
 ```json
 {
@@ -135,7 +135,7 @@ Configure per-hub `connected` and `disconnected` handlers through ASP.NET Core c
       "chat": {
         "EventHandlers": [{
           "UrlTemplate": "http://localhost:7071/events/{hub}/{event}",
-          "SystemEvents": ["connected", "disconnected"]
+          "SystemEvents": ["connect", "connected", "disconnected"]
         }]
       }
     }
@@ -150,7 +150,29 @@ an access-key signature, and cookies isolated to each logical connection. Notifi
 are logged without rejecting the WebSocket. Reliable reconnects do not produce another connected
 notification; disconnected is sent only on final close or recovery expiration.
 
-Before sending notifications, the emulator validates the handler URL with `{event}` set to
+The optional `connect` handler runs after token validation and before the WebSocket upgrade or
+connection activation. Its event ID is `0`; connected and disconnected start at `1` and `2`.
+The JSON request contains `claims`, `query`, `headers` (values are arrays), `subprotocols`, and
+`clientCertificates` (empty; client-certificate authentication is not supported). Client
+`access_token` query parameters, `Authorization`, and `X-ASRS-Internal-*` headers are excluded
+from this body. Other request headers, including client cookies, remain in the JSON body;
+they are not copied to the outbound HTTP headers.
+
+A 2xx connect response accepts the connection. An empty body or JSON `null` leaves token defaults
+unchanged. A JSON object can override `userId` (including the empty string), `roles` (an empty
+array removes token roles), and `groups` (only a nonempty array replaces token groups). Invalid
+groups, malformed JSON, or responses larger than 16 MiB fail with HTTP 500. JSON parsing does
+not depend on response Content-Type. Non-2xx statuses are returned before upgrading; rejected
+connections do not emit connected/disconnected notifications. Error bodies are not forwarded.
+
+`subprotocol` selects the WebSocket protocol; if absent or null, the first supported protocol
+offered by the client is used. Handlers should select a protocol the client offered. Custom
+protocols use the raw WebSocket processor. Raw-mode query parameters are validated before connect,
+even when the initial protocol offer includes JSON. Successful connect cookies and
+`ce-connectionState` (including an empty value) are retained for later notifications. Reliable
+recovery reuses the original connection context and does not invoke connect again.
+
+Before sending connect events or notifications, the emulator validates the handler URL with `{event}` set to
 `validate`. The endpoint must answer OPTIONS (or GET when OPTIONS returns 404) with a 2xx status
 and `WebHook-Allowed-Origin` containing `*` or the request's `WebHook-Request-Origin` host.
 Origin matching is case-insensitive; values are matched as returned by the HTTP header parser,
@@ -162,13 +184,13 @@ later requests use the previous result while an expired entry refreshes. Success
 one minute. Failed validation retries on subsequent use after 1, 2, 4, 8, 16, 32, then 60 seconds
 (capped at one minute). Restart the emulator after changing handler configuration to clear the cache.
 
-Both validation and notification requests retry HTTP 408, 5xx, and eligible `HttpRequestException`
+Validation, connect, and notification requests retry HTTP 408, 5xx, and eligible `HttpRequestException`
 failures after 1, 3, and 5 seconds (at most four attempts). HTTP 429, other 4xx responses,
 cancellation/timeouts, and the non-ASCII-header exception are not retried. Retries reuse the event
-identity and body, so handlers should tolerate duplicates. The notification HTTP client's default
+identity and body, so handlers should tolerate duplicates. The HTTP client's default
 100-second deadline covers sending through response headers, including retry delays.
 
-Connect interception, user-event responses, bearer authentication, Key Vault URL references, and Event Hubs listeners
+User-event responses, bearer authentication, Key Vault URL references, and Event Hubs listeners
 are not supported yet. Unsupported handler configuration is rejected at startup.
 
 ## Local server SDK authentication

--- a/tools/emulator/SUPPORTED_FEATURES.md
+++ b/tools/emulator/SUPPORTED_FEATURES.md
@@ -17,7 +17,7 @@ local Azure Web PubSub development.
 | Connection state | Tracks active connections and temporarily retains reliable logical connections after unexpected disconnects. | ✅ |
 | Groups and roles | Supports connection-scoped token groups and authorized join, leave, and group send, including wildcard roles. | ✅ |
 | Outbound delivery | Uses a bounded, single-writer queue for each WebSocket connection. | ✅ |
-| HTTP lifecycle notifications | Sends `connected` and final `disconnected` CloudEvents to per-hub HTTP handlers; no connect interception or user events yet. See [configuration and limitations](README.md#http-lifecycle-notifications). | ⚠️ |
+| HTTP lifecycle handlers | Intercepts `connect` before upgrade, applies user/role/group/subprotocol overrides, and sends `connected` and final `disconnected` CloudEvents. Retains connect cookies and connection state. See [configuration and limitations](README.md#http-lifecycle-notifications). | ✅ |
 | HTTP handler validation and retries | Validates endpoints with OPTIONS/GET and cached allowed-origin results; retries HTTP 408, 5xx, and eligible network failures with 1/3/5-second delays. | ✅ |
 | REST connection operations | Authenticated connection presence, direct text, JSON, and binary sends, close, and single-connection group membership changes for GA API versions from `2021-10-01` through `2024-12-01`. | ✅ |
 | REST group operations | Authenticated group presence and text, JSON, or binary fan-out with excluded connection IDs and OData filters. | ✅ |
@@ -49,7 +49,7 @@ runtime's new contract and decode the original user ID path segment exactly once
 
 The following areas are planned for follow-up changes:
 
-- HTTP connect/user-event handlers, bearer authentication, and Key Vault URL references
+- HTTP user-event handlers, bearer authentication, and Key Vault URL references
 - Tunnel connections (`tunnel://` upstream URLs)
 - Event Hubs listeners
 - Protobuf subprotocols

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientWebSocketEndpoint.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientWebSocketEndpoint.cs
@@ -18,6 +18,7 @@ internal sealed class ClientWebSocketEndpoint
     private readonly ConnectionManager _connections;
     private readonly ClientPayloadProcessorFactory _payloadProcessorFactory;
     private readonly ClientConnectionHandler _connectionHandler;
+    private readonly UpstreamEventDispatcher _events;
     private readonly WebPubSubTokenService _tokenService;
     private readonly ILogger<ClientWebSocketEndpoint> _logger;
 
@@ -25,12 +26,14 @@ internal sealed class ClientWebSocketEndpoint
         ConnectionManager connections,
         ClientPayloadProcessorFactory payloadProcessorFactory,
         ClientConnectionHandler connectionHandler,
+        UpstreamEventDispatcher events,
         WebPubSubTokenService tokenService,
         ILogger<ClientWebSocketEndpoint> logger)
     {
         _connections = connections;
         _payloadProcessorFactory = payloadProcessorFactory;
         _connectionHandler = connectionHandler;
+        _events = events;
         _tokenService = tokenService;
         _logger = logger;
     }
@@ -91,9 +94,7 @@ internal sealed class ClientWebSocketEndpoint
             return;
         }
 
-        string? rawSendToGroup = null;
-        if (selectedSubprotocol is null &&
-            !TryGetRawSendToGroup(context, out rawSendToGroup, out var error))
+        if (!TryGetRawSendToGroup(context, out var rawSendToGroup, out var error))
         {
             context.Response.StatusCode = StatusCodes.Status400BadRequest;
             await context.Response.WriteAsync(error);
@@ -101,14 +102,33 @@ internal sealed class ClientWebSocketEndpoint
         }
 
         var hub = rawHub.ToLowerInvariant();
+        var upstreamContext = new UpstreamConnectionContext(Guid.NewGuid().ToString("N"), hub,
+            user.FindFirstValue("sub") ?? user.FindFirstValue(ClaimTypes.NameIdentifier), null, context.Request.Host.Host);
+        var (status, response) = await _events.DispatchConnectAsync(
+            upstreamContext, new ConnectEventRequest(context.Request, user), context.RequestAborted);
+        if ((int)status is < 200 or >= 300)
+        {
+            context.Response.StatusCode = (int)status;
+            await context.Response.WriteAsync("The connect event handler rejected the connection.", context.RequestAborted);
+            return;
+        }
+        selectedSubprotocol = response?.Subprotocol ?? selectedSubprotocol;
+        upstreamContext.UserId = response?.UserId ?? upstreamContext.UserId;
+        upstreamContext.Subprotocol = selectedSubprotocol;
+        if (response is not null)
+        {
+            var claims = user.Claims.Where(claim =>
+                !(response.Roles is not null && claim.Type is "role" or ClaimTypes.Role) &&
+                !(response.Groups is { Length: > 0 } && claim.Type == "webpubsub.group"));
+            claims = claims.Concat(response.Roles?.Select(role => new Claim("role", role)) ?? []);
+            claims = claims.Concat(response.Groups?.Select(group => new Claim("webpubsub.group", group)) ?? []);
+            user = new ClaimsPrincipal(new ClaimsIdentity(claims));
+        }
         var connection = _connections.Create(
-            Guid.NewGuid().ToString("N"),
-            hub,
+            upstreamContext,
             user,
-            context.Request.Host.Host,
             rawSendToGroup,
-            WebPubSubJsonV1PayloadProcessor.IsReliableSubprotocol(selectedSubprotocol),
-            selectedSubprotocol);
+            WebPubSubJsonV1PayloadProcessor.IsReliableSubprotocol(selectedSubprotocol));
         var processor = _payloadProcessorFactory.Get(selectedSubprotocol);
 
         using var webSocket = await context.WebSockets.AcceptWebSocketAsync(selectedSubprotocol);

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientWebSocketEndpoint.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientWebSocketEndpoint.cs
@@ -102,7 +102,7 @@ internal sealed class ClientWebSocketEndpoint
         }
 
         var hub = rawHub.ToLowerInvariant();
-        var upstreamContext = UpstreamConnectionContext.FromUser(
+        var upstreamContext = UpstreamConnectionContext.Create(
             Guid.NewGuid().ToString("N"), hub, user, null, context.Request.Host.Host);
         var (status, response) = await _events.DispatchConnectAsync(
             upstreamContext, new ConnectEventRequest(context.Request, user), context.RequestAborted);

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientWebSocketEndpoint.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ClientWebSocketEndpoint.cs
@@ -102,8 +102,8 @@ internal sealed class ClientWebSocketEndpoint
         }
 
         var hub = rawHub.ToLowerInvariant();
-        var upstreamContext = new UpstreamConnectionContext(Guid.NewGuid().ToString("N"), hub,
-            user.FindFirstValue("sub") ?? user.FindFirstValue(ClaimTypes.NameIdentifier), null, context.Request.Host.Host);
+        var upstreamContext = UpstreamConnectionContext.FromUser(
+            Guid.NewGuid().ToString("N"), hub, user, null, context.Request.Host.Host);
         var (status, response) = await _events.DispatchConnectAsync(
             upstreamContext, new ConnectEventRequest(context.Request, user), context.RequestAborted);
         if ((int)status is < 200 or >= 300)

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ConnectEventRequest.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ConnectEventRequest.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Security.Claims;
+
+namespace Microsoft.Azure.WebPubSub.Emulator;
+
+internal sealed class ConnectEventRequest(HttpRequest request, ClaimsPrincipal user)
+{
+    public Dictionary<string, string[]> Claims { get; } = user.Claims
+        .GroupBy(claim => claim.Type).ToDictionary(group => group.Key, group => group.Select(claim => claim.Value).ToArray());
+    public Dictionary<string, string?[]> Query { get; } = request.Query
+        .Where(pair => !pair.Key.Equals("access_token", StringComparison.OrdinalIgnoreCase))
+        .ToDictionary(pair => pair.Key, pair => pair.Value.ToArray());
+    public Dictionary<string, string?[]> Headers { get; } = request.Headers
+        .Where(pair => !pair.Key.Equals("Authorization", StringComparison.OrdinalIgnoreCase) &&
+            !pair.Key.StartsWith("X-ASRS-Internal-", StringComparison.OrdinalIgnoreCase))
+        .ToDictionary(pair => pair.Key, pair => pair.Value.ToArray());
+    public IList<string> Subprotocols { get; } = request.HttpContext.WebSockets.WebSocketRequestedProtocols;
+    public object[] ClientCertificates { get; } = [];
+}
+
+internal sealed record ConnectEventResponse(string? UserId, string[]? Roles, string[]? Groups, string? Subprotocol);

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ConnectionManager.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ConnectionManager.cs
@@ -36,8 +36,7 @@ internal sealed class ConnectionManager
         bool reliable = false,
         string? subprotocol = null)
     {
-        var context = new UpstreamConnectionContext(connectionId, hub,
-            user.FindFirstValue("sub") ?? user.FindFirstValue(ClaimTypes.NameIdentifier), subprotocol, host);
+        var context = UpstreamConnectionContext.FromUser(connectionId, hub, user, subprotocol, host);
         return Create(context, user, rawSendToGroup, reliable);
     }
 

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ConnectionManager.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ConnectionManager.cs
@@ -36,7 +36,7 @@ internal sealed class ConnectionManager
         bool reliable = false,
         string? subprotocol = null)
     {
-        var context = UpstreamConnectionContext.FromUser(connectionId, hub, user, subprotocol, host);
+        var context = UpstreamConnectionContext.Create(connectionId, hub, user, subprotocol, host);
         return Create(context, user, rawSendToGroup, reliable);
     }
 

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ConnectionManager.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/ConnectionManager.cs
@@ -36,16 +36,21 @@ internal sealed class ConnectionManager
         bool reliable = false,
         string? subprotocol = null)
     {
+        var context = new UpstreamConnectionContext(connectionId, hub,
+            user.FindFirstValue("sub") ?? user.FindFirstValue(ClaimTypes.NameIdentifier), subprotocol, host);
+        return Create(context, user, rawSendToGroup, reliable);
+    }
+
+    public LogicalConnection Create(
+        UpstreamConnectionContext context, ClaimsPrincipal user, string? rawSendToGroup = null, bool reliable = false)
+    {
         return new LogicalConnection(
-            connectionId,
-            hub,
+            context,
             user,
-            host,
             rawSendToGroup,
             this,
             _runtimeOptions,
             reliable,
-            subprotocol,
             _logger);
     }
 

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorApplication.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorApplication.cs
@@ -30,9 +30,10 @@ internal static class EmulatorApplication
             .Validate(options => options.Hubs.Values.All(hub => hub.EventHandlers.All(handler =>
                 EventHandlerUrlTemplate.TryResolve(handler.UrlTemplate, "hub", "event", out _) &&
                 handler.SystemEvents.All(name =>
+                    string.Equals(name, "connect", StringComparison.OrdinalIgnoreCase) ||
                     string.Equals(name, "connected", StringComparison.OrdinalIgnoreCase) ||
                     string.Equals(name, "disconnected", StringComparison.OrdinalIgnoreCase)))),
-                "Event handlers currently require an HTTP(S) URL without Key Vault references and support only connected/disconnected.")
+                "Event handlers currently require an HTTP(S) URL without Key Vault references and support only connect/connected/disconnected.")
             .ValidateOnStart();
         builder.Services.AddSingleton(runtimeOptions ?? new EmulatorRuntimeOptions());
         builder.Services.AddSingleton<WebPubSubTokenService>();

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/LogicalConnection.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/LogicalConnection.cs
@@ -39,22 +39,19 @@ internal sealed class LogicalConnection : IODataFilterModel
     private bool _reconnecting;
 
     public LogicalConnection(
-        string connectionId,
-        string hub,
+        UpstreamConnectionContext upstreamContext,
         ClaimsPrincipal user,
-        string host,
         string? rawSendToGroup,
         ConnectionManager manager,
         EmulatorRuntimeOptions runtimeOptions,
         bool reliable = false,
-        string? subprotocol = null,
         ILogger? logger = null)
     {
-        ConnectionId = connectionId;
-        Hub = hub;
+        ConnectionId = upstreamContext.ConnectionId;
+        Hub = upstreamContext.Hub;
         RawSendToGroup = rawSendToGroup;
         IsReliable = reliable;
-        Subprotocol = subprotocol;
+        Subprotocol = upstreamContext.Subprotocol;
         _manager = manager;
         _logger = logger;
         _runtimeOptions = runtimeOptions;
@@ -63,8 +60,8 @@ internal sealed class LogicalConnection : IODataFilterModel
         _reliableBufferCapacity = runtimeOptions.ReliableMessageBufferCapacity;
         _reliableBufferMaxBytes = runtimeOptions.MaxReliableMessageBufferBytes;
 
-        UserId = user.FindFirstValue("sub") ?? user.FindFirstValue(ClaimTypes.NameIdentifier);
-        UpstreamContext = new UpstreamConnectionContext(connectionId, hub, UserId, subprotocol, host);
+        UserId = upstreamContext.UserId;
+        UpstreamContext = upstreamContext;
 
         foreach (var group in user.FindAll("webpubsub.group").Select(claim => claim.Value))
         {

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/UpstreamConnectionContext.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/UpstreamConnectionContext.cs
@@ -24,7 +24,7 @@ internal sealed class UpstreamConnectionContext(
     public string Host { get; } = host;
     public CookieContainer Cookies { get; } = new();
 
-    public static UpstreamConnectionContext FromUser(
+    public static UpstreamConnectionContext Create(
         string connectionId, string hub, ClaimsPrincipal user, string? subprotocol, string host) =>
         new(connectionId, hub,
             user.FindFirstValue("sub") ?? user.FindFirstValue(ClaimTypes.NameIdentifier), subprotocol, host);

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/UpstreamConnectionContext.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/UpstreamConnectionContext.cs
@@ -17,8 +17,9 @@ internal sealed class UpstreamConnectionContext(
 
     public string ConnectionId { get; } = connectionId;
     public string Hub { get; } = hub;
-    public string? UserId { get; } = userId;
-    public string? Subprotocol { get; } = subprotocol;
+    public string? UserId { get; set; } = userId;
+    public string? Subprotocol { get; set; } = subprotocol;
+    public string? ConnectionState { get; set; }
     public string Host { get; } = host;
     public CookieContainer Cookies { get; } = new();
 

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/UpstreamConnectionContext.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/UpstreamConnectionContext.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Net;
+using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -22,6 +23,11 @@ internal sealed class UpstreamConnectionContext(
     public string? ConnectionState { get; set; }
     public string Host { get; } = host;
     public CookieContainer Cookies { get; } = new();
+
+    public static UpstreamConnectionContext FromUser(
+        string connectionId, string hub, ClaimsPrincipal user, string? subprotocol, string host) =>
+        new(connectionId, hub,
+            user.FindFirstValue("sub") ?? user.FindFirstValue(ClaimTypes.NameIdentifier), subprotocol, host);
 
     public int GetNextEventId() => Interlocked.Increment(ref _eventId);
 

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/UpstreamEventDispatcher.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/UpstreamEventDispatcher.cs
@@ -4,6 +4,7 @@
 using System.Globalization;
 using System.Net;
 using System.Net.Http.Headers;
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -12,16 +13,58 @@ namespace Microsoft.Azure.WebPubSub.Emulator;
 internal sealed class UpstreamEventDispatcher(
     IOptions<EmulatorOptions> options, HttpUpstreamTrigger trigger, ILogger<UpstreamEventDispatcher> logger)
 {
+    public async Task<(HttpStatusCode Status, ConnectEventResponse? Response)> DispatchConnectAsync(
+        UpstreamConnectionContext connection, ConnectEventRequest body, CancellationToken cancellationToken)
+    {
+        var handler = GetHandler(connection.Hub, "connect");
+        if (handler is null)
+        {
+            return (HttpStatusCode.OK, null);
+        }
+        try
+        {
+            using var response = await SendAsync(handler, connection, "connect", 0,
+                JsonSerializer.SerializeToUtf8Bytes(body, JsonSerializerOptions.Web), cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                return (response.StatusCode, null);
+            }
+
+            const int limit = 16 * 1024 * 1024;
+            await response.Content.LoadIntoBufferAsync(limit, cancellationToken);
+            var bytes = await response.Content.ReadAsByteArrayAsync(cancellationToken);
+            var payload = bytes.Length == 0 ? null :
+                JsonSerializer.Deserialize<ConnectEventResponse>(bytes, JsonSerializerOptions.Web);
+            if (payload?.Groups?.Any(group => !WebPubSubNameValidator.IsValidGroupName(group)) == true)
+            {
+                throw new InvalidDataException("The connect response contains an invalid group.");
+            }
+            if (payload?.Roles?.Any(role => role is null) == true)
+            {
+                throw new InvalidDataException("The connect response contains a null role.");
+            }
+            if (response.Headers.TryGetValues("ce-connectionState", out var state))
+            {
+                connection.ConnectionState = state.LastOrDefault();
+            }
+            return (response.StatusCode, payload);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception) when (exception is JsonException or InvalidDataException or IOException or HttpRequestException or OperationCanceledException)
+        {
+            logger.LogWarning(exception, "Dispatching connect for {ConnectionId} failed.", connection.ConnectionId);
+            return (HttpStatusCode.InternalServerError, null);
+        }
+    }
+
     public async Task DispatchNotificationAsync(
         UpstreamConnectionContext connection, string eventName, byte[] body)
     {
         var id = connection.GetNextEventId();
-        if (!options.Value.Hubs.TryGetValue(connection.Hub, out var hub))
-        {
-            return;
-        }
-        var handler = hub.EventHandlers.FirstOrDefault(item =>
-            item.SystemEvents.Contains(eventName, StringComparer.OrdinalIgnoreCase));
+        var handler = GetHandler(connection.Hub, eventName);
         if (handler is null)
         {
             return;
@@ -29,40 +72,8 @@ internal sealed class UpstreamEventDispatcher(
 
         try
         {
-            if (!EventHandlerUrlTemplate.TryResolve(handler.UrlTemplate, connection.Hub, eventName, out var uri) ||
-                !EventHandlerUrlTemplate.TryResolve(handler.UrlTemplate, connection.Hub, "validate", out var validationUri))
-            {
-                throw new InvalidDataException("Event handler URL must resolve to an HTTP or HTTPS URL without Key Vault references.");
-            }
-            using var request = new HttpRequestMessage(HttpMethod.Post, uri)
-            {
-                Version = HttpVersion.Version20,
-                Content = new ByteArrayContent(body),
-            };
-            request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
-            request.Headers.Add("ce-specversion", "1.0");
-            request.Headers.Add("ce-awpsversion", "1.0");
-            request.Headers.Add("ce-type", $"azure.webpubsub.sys.{eventName}");
-            request.Headers.Add("ce-source", $"/hubs/{connection.Hub}/client/{connection.ConnectionId}");
-            request.Headers.Add("ce-id", id.ToString(CultureInfo.InvariantCulture));
-            request.Headers.Add("ce-time", DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture));
-            request.Headers.Add("ce-connectionId", connection.ConnectionId);
-            request.Headers.Add("ce-hub", connection.Hub);
-            request.Headers.Add("ce-eventName", eventName);
-            request.Headers.Add("WebHook-Request-Origin", connection.Host);
-            request.Headers.Add("x-ms-client-request-id", Guid.NewGuid().ToString());
-            request.Headers.Add("ce-signature", connection.GetSignature(options.Value.AccessKey));
-            if (!string.IsNullOrEmpty(connection.UserId))
-            {
-                request.Headers.Add("ce-userId", connection.UserId);
-            }
-            if (!string.IsNullOrEmpty(connection.Subprotocol))
-            {
-                request.Headers.Add("ce-subprotocol", connection.Subprotocol);
-            }
-
             // Notifications survive the client request ending, as in PushModeUpstreamInvoker.
-            using var response = await trigger.SendAsync(request, validationUri, connection, CancellationToken.None);
+            using var response = await SendAsync(handler, connection, eventName, id, body, CancellationToken.None);
             if (!response.IsSuccessStatusCode)
             {
                 logger.LogWarning("The {EventName} handler returned {StatusCode} for {ConnectionId}.",
@@ -74,5 +85,52 @@ internal sealed class UpstreamEventDispatcher(
             logger.LogWarning(exception, "Dispatching {EventName} for {ConnectionId} failed.",
                 eventName, connection.ConnectionId);
         }
+    }
+
+    private EventHandlerOptions? GetHandler(string hub, string eventName) =>
+        options.Value.Hubs.TryGetValue(hub, out var settings)
+            ? settings.EventHandlers.FirstOrDefault(item => item.SystemEvents.Contains(eventName, StringComparer.OrdinalIgnoreCase))
+            : null;
+
+    private async Task<HttpResponseMessage> SendAsync(
+        EventHandlerOptions handler, UpstreamConnectionContext connection, string eventName, int id,
+        byte[] body, CancellationToken cancellationToken)
+    {
+        if (!EventHandlerUrlTemplate.TryResolve(handler.UrlTemplate, connection.Hub, eventName, out var uri) ||
+            !EventHandlerUrlTemplate.TryResolve(handler.UrlTemplate, connection.Hub, "validate", out var validationUri))
+        {
+            throw new InvalidDataException("Event handler URL must resolve to an HTTP or HTTPS URL without Key Vault references.");
+        }
+        using var request = new HttpRequestMessage(HttpMethod.Post, uri)
+        {
+            Version = HttpVersion.Version20,
+            Content = new ByteArrayContent(body),
+        };
+        request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+        request.Headers.Add("ce-specversion", "1.0");
+        request.Headers.Add("ce-awpsversion", "1.0");
+        request.Headers.Add("ce-type", $"azure.webpubsub.sys.{eventName}");
+        request.Headers.Add("ce-source", $"/hubs/{connection.Hub}/client/{connection.ConnectionId}");
+        request.Headers.Add("ce-id", id.ToString(CultureInfo.InvariantCulture));
+        request.Headers.Add("ce-time", DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture));
+        request.Headers.Add("ce-connectionId", connection.ConnectionId);
+        request.Headers.Add("ce-hub", connection.Hub);
+        request.Headers.Add("ce-eventName", eventName);
+        request.Headers.Add("WebHook-Request-Origin", connection.Host);
+        request.Headers.Add("x-ms-client-request-id", Guid.NewGuid().ToString());
+        request.Headers.Add("ce-signature", connection.GetSignature(options.Value.AccessKey));
+        if (!string.IsNullOrEmpty(connection.UserId))
+        {
+            request.Headers.Add("ce-userId", connection.UserId);
+        }
+        if (!string.IsNullOrEmpty(connection.Subprotocol))
+        {
+            request.Headers.Add("ce-subprotocol", connection.Subprotocol);
+        }
+        if (connection.ConnectionState is not null)
+        {
+            request.Headers.Add("ce-connectionState", connection.ConnectionState);
+        }
+        return await trigger.SendAsync(request, validationUri, connection, cancellationToken);
     }
 }

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/EmulatorApplicationTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/EmulatorApplicationTests.cs
@@ -24,7 +24,7 @@ public class EmulatorApplicationTests
     [InlineData("not-a-url", "connected")]
     [InlineData("ftp://handler/events", "connected")]
     [InlineData("https://handler/{@Microsoft.KeyVault(SecretUri=https://vault/secrets/key)}", "connected")]
-    [InlineData("https://handler/events", "connect")]
+    [InlineData("https://handler/events", "joinedGroups")]
     public async Task UnsupportedNotificationConfigurationIsRejected(string template, string eventName)
     {
         var builder = EmulatorApplication.CreateBuilder([

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/UpstreamConnectTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/UpstreamConnectTests.cs
@@ -1,0 +1,304 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.WebSockets;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Microsoft.Azure.WebPubSub.Emulator.Tests;
+
+public class UpstreamConnectTests
+{
+    private const string JsonProtocol = "json.webpubsub.azure.v1";
+    private const string ReliableProtocol = "json.reliable.webpubsub.azure.v1";
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(15);
+
+    [Theory]
+    [InlineData("state", false)]
+    [InlineData("", true)]
+    public async Task ConnectGatesUpgradeStripsCredentialsAndPreservesContext(string state, bool bearerOnly)
+    {
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var fixture = await Fixture.StartAsync(async context =>
+        {
+            await release.Task.WaitAsync(TestTimeout);
+            context.Response.Headers["ce-connectionState"] = state;
+            context.Response.Cookies.Append("affinity", "connect");
+            await context.Response.WriteAsync("{\"userId\":\"用户\",\"roles\":[],\"groups\":[\"new-room\"]}");
+        });
+        using var socket = new ClientWebSocket();
+        socket.Options.AddSubProtocol(JsonProtocol);
+        socket.Options.SetRequestHeader("Authorization", "Bearer " + fixture.Token);
+        socket.Options.SetRequestHeader("X-ASRS-Internal-Test", "private");
+        socket.Options.SetRequestHeader("X-Custom", "value");
+        var connecting = socket.ConnectAsync(fixture.ClientUri(bearerOnly: bearerOnly), CancellationToken.None);
+        var connect = await fixture.ReadAsync("connect");
+        try
+        {
+            Assert.False(connecting.IsCompleted);
+            Assert.False(fixture.Manager.ConnectionExists("chat", connect.Id));
+            Assert.Equal("0", connect.Headers["ce-id"]);
+            Assert.Equal("token-user", connect.Headers["ce-userId"]);
+            Assert.False(connect.Headers.ContainsKey("ce-subprotocol"));
+            Assert.False(connect.Headers.ContainsKey("Authorization"));
+            Assert.False(connect.Headers.ContainsKey("Cookie"));
+            Assert.Equal("application/json", connect.Headers["Content-Type"]);
+            using var body = JsonDocument.Parse(connect.Body);
+            var root = body.RootElement;
+            Assert.Equal(new[] { "one", "two" }, root.GetProperty("claims").GetProperty("custom").EnumerateArray().Select(x => x.GetString()));
+            Assert.Equal(new[] { "a", "b" }, root.GetProperty("query").GetProperty("tag").EnumerateArray().Select(x => x.GetString()));
+            Assert.DoesNotContain(root.GetProperty("query").EnumerateObject(), p => p.Name.Equals("access_token", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(root.GetProperty("headers").EnumerateObject(), p => p.Name.Equals("Authorization", StringComparison.OrdinalIgnoreCase) || p.Name.StartsWith("X-ASRS-Internal-", StringComparison.OrdinalIgnoreCase));
+            Assert.Equal("value", root.GetProperty("headers").GetProperty("X-Custom")[0].GetString());
+            Assert.Equal(JsonProtocol, root.GetProperty("subprotocols")[0].GetString());
+            Assert.Equal(0, root.GetProperty("clientCertificates").GetArrayLength());
+            Assert.DoesNotContain(fixture.Token, connect.Body);
+        }
+        finally
+        {
+            release.TrySetResult();
+        }
+        await connecting.WaitAsync(TestTimeout);
+        var connected = await fixture.ReadAsync("connected");
+        Assert.Equal(connect.Id, connected.Id);
+        Assert.Equal("1", connected.Headers["ce-id"]);
+        Assert.Equal("用户", connected.Headers["ce-userId"]);
+        Assert.Equal(JsonProtocol, connected.Headers["ce-subprotocol"]);
+        Assert.Equal(state, connected.Headers["ce-connectionState"]);
+        Assert.Equal("affinity=connect", connected.Headers["Cookie"]);
+        Assert.Equal(connect.Headers["ce-signature"], connected.Headers["ce-signature"]);
+        Assert.True(fixture.Manager.TryGet("chat", connect.Id, out var connection));
+        Assert.Equal("用户", connection.UserId);
+        Assert.Equal(new[] { "new-room" }, connection.Groups.Keys);
+        Assert.False(connection.CanJoinLeaveGroup("room"));
+        await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "done", CancellationToken.None).WaitAsync(TestTimeout);
+        var disconnected = await fixture.ReadAsync("disconnected");
+        Assert.Equal("2", disconnected.Headers["ce-id"]);
+        Assert.Equal(state, disconnected.Headers["ce-connectionState"]);
+    }
+
+    [Theory]
+    [InlineData("", 204, "token-user", true, "room", JsonProtocol)]
+    [InlineData("null", 200, "token-user", true, "room", JsonProtocol)]
+    [InlineData("{\"groups\":[],\"roles\":null}", 202, "token-user", true, "room", JsonProtocol)]
+    [InlineData("{\"userId\":\"\",\"roles\":[]}", 200, "", false, "room", JsonProtocol)]
+    [InlineData("{\"userId\":null,\"groups\":[\"new-room\"],\"roles\":[\"webpubsub.joinLeaveGroup\"]}", 200, "token-user", true, "new-room", JsonProtocol)]
+    [InlineData("{\"subprotocol\":\"custom.protocol\"}", 200, "token-user", true, "room", "custom.protocol")]
+    [InlineData("{\"subprotocol\":\"json.reliable.webpubsub.azure.v1\"}", 200, "token-user", true, "room", ReliableProtocol)]
+    public async Task ResponseOverridesUseRuntimeSemantics(string body, int status, string userId, bool canJoin, string group, string protocol)
+    {
+        await using var fixture = await Fixture.StartAsync(context =>
+        {
+            context.Response.StatusCode = status;
+            // Connect payload parsing is independent of Content-Type.
+            context.Response.ContentType = "text/plain";
+            return context.Response.WriteAsync(body);
+        });
+        using var socket = new ClientWebSocket();
+        socket.Options.AddSubProtocol(JsonProtocol);
+        socket.Options.AddSubProtocol(protocol == JsonProtocol ? "custom.protocol" : protocol);
+        await socket.ConnectAsync(fixture.ClientUri(), CancellationToken.None).WaitAsync(TestTimeout);
+        var connect = await fixture.ReadAsync("connect");
+        await fixture.ReadAsync("connected");
+        Assert.Equal(protocol, socket.SubProtocol);
+        Assert.True(fixture.Manager.TryGet("chat", connect.Id, out var connection));
+        Assert.Equal(userId, connection.UserId);
+        Assert.Equal(canJoin, connection.CanJoinLeaveGroup("room"));
+        Assert.Equal(new[] { group }, connection.Groups.Keys);
+        Assert.Equal(protocol == ReliableProtocol, connection.IsReliable);
+        if (protocol == "custom.protocol")
+        {
+            fixture.Manager.SendToConnection("chat", connect.Id, new MessageData(MessageDataType.Binary, new byte[] { 1, 2 }));
+            var buffer = new byte[8];
+            var message = await socket.ReceiveAsync(buffer, CancellationToken.None).WaitAsync(TestTimeout);
+            Assert.Equal(WebSocketMessageType.Binary, message.MessageType);
+            Assert.Equal(new byte[] { 1, 2 }, buffer[..message.Count]);
+        }
+        await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, "done", CancellationToken.None).WaitAsync(TestTimeout);
+        await fixture.ReadAsync("disconnected");
+    }
+
+    [Theory]
+    [InlineData(401, "denied", 401)]
+    [InlineData(403, "denied", 403)]
+    [InlineData(429, "busy", 429)]
+    [InlineData(200, "not-json", 500)]
+    [InlineData(200, "{\"groups\":[null]}", 500)]
+    [InlineData(200, "{\"groups\":[\" \"]}", 500)]
+    [InlineData(200, "{\"roles\":[null]}", 500)]
+    public async Task FailedConnectNeverActivatesOrNotifies(int status, string body, int expected)
+    {
+        await using var fixture = await Fixture.StartAsync(context =>
+        {
+            context.Response.StatusCode = status;
+            return context.Response.WriteAsync(body);
+        });
+        using var response = await fixture.UpgradeAsync();
+        Assert.Equal(expected, (int)response.StatusCode);
+        var connect = await fixture.ReadAsync("connect");
+        Assert.False(fixture.Manager.ConnectionExists("chat", connect.Id));
+        Assert.False(fixture.Events.Reader.TryRead(out _));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task OversizedResponseIsRejectedWithOrWithoutContentLength(bool knownLength)
+    {
+        await using var fixture = await Fixture.StartAsync(async context =>
+        {
+            if (knownLength) context.Response.ContentLength = 16 * 1024 * 1024 + 1;
+            var block = new byte[64 * 1024];
+            for (var i = 0; i < 257; i++)
+            {
+                await context.Response.Body.WriteAsync(block, context.RequestAborted);
+            }
+        });
+        using var response = await fixture.UpgradeAsync();
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+        var connect = await fixture.ReadAsync("connect");
+        Assert.False(fixture.Manager.ConnectionExists("chat", connect.Id));
+        Assert.False(fixture.Events.Reader.TryRead(out _));
+    }
+
+    [Fact]
+    public async Task ConnectRetriesReuseEventAndRecoverySkipsConnect()
+    {
+        var attempts = 0;
+        await using var fixture = await Fixture.StartAsync(context =>
+        {
+            context.Response.StatusCode = ++attempts == 1 ? 503 : 200;
+            return Task.CompletedTask;
+        });
+        using var socket = new ClientWebSocket();
+        socket.Options.AddSubProtocol(ReliableProtocol);
+        await socket.ConnectAsync(fixture.ClientUri(), CancellationToken.None).WaitAsync(TestTimeout);
+        var first = await fixture.ReadAsync("connect");
+        var retry = await fixture.ReadAsync("connect");
+        Assert.Equal(first.Id, retry.Id);
+        Assert.Equal(first.Body, retry.Body);
+        Assert.Equal(first.Headers["x-ms-client-request-id"], retry.Headers["x-ms-client-request-id"]);
+        Assert.Equal("0", retry.Headers["ce-id"]);
+        await fixture.ReadAsync("connected");
+        var buffer = new byte[4096];
+        var frame = await socket.ReceiveAsync(buffer, CancellationToken.None).WaitAsync(TestTimeout);
+        using var connected = JsonDocument.Parse(buffer.AsMemory(0, frame.Count));
+        var token = connected.RootElement.GetProperty("reconnectionToken").GetString();
+        socket.Abort();
+        using var recovered = new ClientWebSocket();
+        recovered.Options.AddSubProtocol(ReliableProtocol);
+        await recovered.ConnectAsync(new Uri(fixture.ClientUri().GetLeftPart(UriPartial.Path) +
+            $"?awps_connection_id={first.Id}&awps_reconnection_token={Uri.EscapeDataString(token!)}"), CancellationToken.None).WaitAsync(TestTimeout);
+        await recovered.CloseAsync(WebSocketCloseStatus.NormalClosure, "done", CancellationToken.None).WaitAsync(TestTimeout);
+        var disconnected = await fixture.ReadAsync("disconnected");
+        Assert.Equal("2", disconnected.Headers["ce-id"]);
+        Assert.Equal(2, attempts);
+        Assert.False(fixture.Events.Reader.TryRead(out _));
+    }
+
+    [Fact]
+    public async Task FailedValidationDoesNotSendConnect()
+    {
+        await using var fixture = await Fixture.StartAsync(_ => throw new InvalidOperationException("Must not dispatch connect."), allowOrigin: false);
+        using var response = await fixture.UpgradeAsync();
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+        Assert.False(fixture.Manager.UserExists("chat", "token-user"));
+        Assert.False(fixture.Events.Reader.TryRead(out _));
+    }
+
+    private sealed class Fixture(WebApplication upstream, WebApplication app, Channel<Received> events) : IAsyncDisposable
+    {
+        public Channel<Received> Events => events;
+        public ConnectionManager Manager => app.Services.GetRequiredService<ConnectionManager>();
+        public string Token { get; } = new JwtSecurityTokenHandler().WriteToken(new JwtSecurityToken(
+            audience: app.Urls.Single() + "/client/hubs/chat",
+            claims: [new Claim("sub", "token-user"), new Claim("role", "webpubsub.joinLeaveGroup"),
+                new Claim("webpubsub.group", "room"), new Claim("custom", "one"), new Claim("custom", "two")],
+            expires: DateTime.UtcNow.AddHours(1), signingCredentials: new SigningCredentials(
+                new SymmetricSecurityKey(Encoding.UTF8.GetBytes(EmulatorOptions.DefaultAccessKey)), SecurityAlgorithms.HmacSha256)));
+
+        public Uri ClientUri(bool bearerOnly = false) => new(app.Urls.Single().Replace("http:", "ws:") +
+            "/client/hubs/chat?tag=a&tag=b" + (bearerOnly ? "" : "&ACCESS_TOKEN=" + Token));
+
+        public async Task<Received> ReadAsync(string name)
+        {
+            var received = await events.Reader.ReadAsync().AsTask().WaitAsync(TestTimeout);
+            Assert.Equal(name, received.Headers["ce-eventName"]);
+            return received;
+        }
+
+        public async Task<HttpResponseMessage> UpgradeAsync()
+        {
+            using var client = new HttpClient();
+            using var request = new HttpRequestMessage(HttpMethod.Get, ClientUri().ToString().Replace("ws:", "http:"));
+            request.Headers.Add("Connection", "Upgrade");
+            request.Headers.Add("Upgrade", "websocket");
+            request.Headers.Add("Sec-WebSocket-Version", "13");
+            request.Headers.Add("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==");
+            return await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead).WaitAsync(TestTimeout);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await app.DisposeAsync();
+            await upstream.DisposeAsync();
+        }
+
+        public static async Task<Fixture> StartAsync(Func<HttpContext, Task> onConnect, bool allowOrigin = true)
+        {
+            var events = Channel.CreateUnbounded<Received>();
+            var builder = WebApplication.CreateBuilder(["--urls=http://127.0.0.1:0"]);
+            builder.Logging.ClearProviders();
+            var upstream = builder.Build();
+            upstream.Run(async context =>
+            {
+                if (HttpMethods.IsOptions(context.Request.Method))
+                {
+                    Assert.Equal("/events/chat/validate", context.Request.Path.Value);
+                    if (allowOrigin) context.Response.Headers["WebHook-Allowed-Origin"] = "*";
+                    return;
+                }
+                var body = await new StreamReader(context.Request.Body).ReadToEndAsync();
+                events.Writer.TryWrite(new Received(body, context.Request.Headers.ToDictionary(
+                    h => h.Key, h => h.Value.ToString(), StringComparer.OrdinalIgnoreCase)));
+                if (context.Request.Headers["ce-eventName"] == "connect") await onConnect(context);
+            });
+            await upstream.StartAsync().WaitAsync(TestTimeout);
+            var emulator = EmulatorApplication.CreateBuilder(["--urls=http://127.0.0.1:0"]);
+            emulator.Logging.ClearProviders();
+            emulator.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["WebPubSub:Hubs:chat:EventHandlers:0:UrlTemplate"] = upstream.Urls.Single() + "/events/{hub}/{event}",
+                ["WebPubSub:Hubs:chat:EventHandlers:0:SystemEvents:0"] = "connect",
+                ["WebPubSub:Hubs:chat:EventHandlers:0:SystemEvents:1"] = "connected",
+                ["WebPubSub:Hubs:chat:EventHandlers:0:SystemEvents:2"] = "disconnected",
+            });
+            var app = EmulatorApplication.Build(emulator);
+            await app.StartAsync().WaitAsync(TestTimeout);
+            return new Fixture(upstream, app, events);
+        }
+    }
+
+    private sealed record Received(string Body, Dictionary<string, string> Headers)
+    {
+        public string Id => Headers["ce-connectionId"];
+    }
+}

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/UpstreamConnectionContextTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/UpstreamConnectionContextTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
@@ -11,6 +12,28 @@ namespace Microsoft.Azure.WebPubSub.Emulator.Tests;
 
 public class UpstreamConnectionContextTests
 {
+    [Theory]
+    [InlineData("subject", "name", "subject")]
+    [InlineData("subject", null, "subject")]
+    [InlineData(null, "name", "name")]
+    [InlineData(null, null, null)]
+    [InlineData("", "name", "")]
+    public void FromUserPreservesUserIdPrecedence(string? subject, string? nameIdentifier, string? expected)
+    {
+        var identity = new ClaimsIdentity();
+        if (subject is not null) identity.AddClaim(new Claim("sub", subject));
+        if (nameIdentifier is not null) identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, nameIdentifier));
+
+        var context = UpstreamConnectionContext.FromUser(
+            "connection", "chat", new ClaimsPrincipal(identity), "custom.protocol", "example.test");
+
+        Assert.Equal(expected, context.UserId);
+        Assert.Equal("connection", context.ConnectionId);
+        Assert.Equal("chat", context.Hub);
+        Assert.Equal("custom.protocol", context.Subprotocol);
+        Assert.Equal("example.test", context.Host);
+    }
+
     [Fact]
     public void SignatureIsReusedForEqualKeysAndRefreshedWhenKeyChanges()
     {

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/UpstreamConnectionContextTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/UpstreamConnectionContextTests.cs
@@ -18,13 +18,13 @@ public class UpstreamConnectionContextTests
     [InlineData(null, "name", "name")]
     [InlineData(null, null, null)]
     [InlineData("", "name", "")]
-    public void FromUserPreservesUserIdPrecedence(string? subject, string? nameIdentifier, string? expected)
+    public void CreatePreservesUserIdPrecedence(string? subject, string? nameIdentifier, string? expected)
     {
         var identity = new ClaimsIdentity();
         if (subject is not null) identity.AddClaim(new Claim("sub", subject));
         if (nameIdentifier is not null) identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, nameIdentifier));
 
-        var context = UpstreamConnectionContext.FromUser(
+        var context = UpstreamConnectionContext.Create(
             "connection", "chat", new ClaimsPrincipal(identity), "custom.protocol", "example.test");
 
         Assert.Equal(expected, context.UserId);


### PR DESCRIPTION
## Summary

H3 slice of #1123, following the merged lifecycle notifications (#1124) and webhook validation/retries (#1126).

- Dispatch the HTTP connect event before WebSocket upgrade and connection activation.
- Send claims, query, headers, and offered subprotocols; apply user ID, roles, groups, and subprotocol response overrides.
- Preserve the same upstream context, cookies, signature, and connection state through connected/disconnected events; reliable recovery skips connect.
- Reuse the existing dispatcher, HTTP trigger, validation, and retry layers. Centralize initial user ID resolution in UpstreamConnectionContext.Create.

## Runtime alignment and intentional differences

- Connect uses event ID 0; successful empty/null responses preserve defaults. Response bodies are limited to 16 MiB, including responses without Content-Length.
- Empty roles clear roles; empty groups preserve token groups. An absent selected protocol falls back to the first supported offer; custom selected protocols use the existing raw processor.
- Preserve runtime connection-state behavior; do not merge connect response metadata.
- Intentionally always strip access_token and Authorization from the connect payload, rather than making credential stripping conditional.
- Return a generic safe error body instead of forwarding upstream error content. Client certificates remain an empty array because certificate authentication is unsupported.

## Scope and follow-up

This PR extracts connect interception from umbrella #1123 without bringing in its full handler implementation. User-event dispatch and response metadata/body handling, bearer authentication, raw sendEvent/noEcho, and Event Hubs listeners remain deferred. Later slices extend the existing context/dispatcher/trigger boundaries.

## Validation

- Local Release build and full emulator suite: 243/243 tests passed on Windows at HEAD 7d58b847.
- Real HTTP/WebSocket coverage for pre-upgrade gating, credential filtering, overrides, validation failures, retry identity, state/cookies, recovery, and oversized responses.
- Five user ID precedence/fallback cases; modified-file diagnostics clean; git diff --check passed.
- Remote CI results are not yet verified.