### PR TITLE
Emulator: add HTTP user-event handling (H4)

### DIFF
--- a/tools/emulator/README.md
+++ b/tools/emulator/README.md
@@ -196,9 +196,12 @@ identity and body, so handlers should tolerate duplicates. The HTTP client's def
 JSON and reliable JSON `event` messages use `EventPattern`, independently of `SystemEvents`.
 Patterns are comma-separated and case-insensitive. A standalone `*` matches all events, including
 dotted names. Within a pattern, `*` matches zero or more non-dot characters, `?` matches one
-non-dot character, and `**` crosses dots. The existing wildcard parser limits each pattern to
-1024 characters and accepts `\*`, `\?`, and `\\` escapes. The first matching handler wins;
-there is no `_default` hub fallback. Invalid patterns are rejected at startup.
+non-dot character, and `**` crosses dots. Event patterns do not inherit the 1024-character
+permission-pattern limit. The tokenizer accepts `\*`, `\?`, and `\\` escapes. As in the runtime,
+patterns containing no unescaped wildcard use the original pattern string for literal comparison:
+`room\*` matches `room\*`, not `room*`; `room\*?` matches `room*a` through the wildcard matcher.
+A standalone `*` stops parsing the remaining list entries; invalid escapes before it are rejected
+at startup. The first matching handler wins; there is no `_default` hub fallback.
 
 Requests carry `azure.webpubsub.user.<event>` CloudEvents, the original text/JSON/binary bytes,
 and per-message `x-webpubsub-metadata-*` headers. They reuse connection identity, signature,

--- a/tools/emulator/README.md
+++ b/tools/emulator/README.md
@@ -126,7 +126,7 @@ dotnet run --project tools\emulator\src\Microsoft.Azure.WebPubSub.Emulator
 
 ## HTTP lifecycle notifications
 
-Configure per-hub `connect`, `connected`, and `disconnected` handlers through ASP.NET Core configuration:
+Configure per-hub lifecycle and user-event handlers through ASP.NET Core configuration:
 
 ```json
 {
@@ -135,7 +135,8 @@ Configure per-hub `connect`, `connected`, and `disconnected` handlers through AS
       "chat": {
         "EventHandlers": [{
           "UrlTemplate": "http://localhost:7071/events/{hub}/{event}",
-          "SystemEvents": ["connect", "connected", "disconnected"]
+          "SystemEvents": ["connect", "connected", "disconnected"],
+          "EventPattern": "*"
         }]
       }
     }
@@ -151,7 +152,7 @@ are logged without rejecting the WebSocket. Reliable reconnects do not produce a
 notification; disconnected is sent only on final close or recovery expiration.
 
 The optional `connect` handler runs after token validation and before the WebSocket upgrade or
-connection activation. Its event ID is `0`; connected and disconnected start at `1` and `2`.
+connection activation. Its event ID is `0`; later lifecycle and user events share increasing IDs starting at `1`.
 The JSON request contains `claims`, `query`, `headers` (values are arrays), `subprotocols`, and
 `clientCertificates` (empty; client-certificate authentication is not supported). Client
 `access_token` query parameters, `Authorization`, and `X-ASRS-Internal-*` headers are excluded
@@ -172,7 +173,7 @@ even when the initial protocol offer includes JSON. Successful connect cookies a
 `ce-connectionState` (including an empty value) are retained for later notifications. Reliable
 recovery reuses the original connection context and does not invoke connect again.
 
-Before sending connect events or notifications, the emulator validates the handler URL with `{event}` set to
+Before sending any handler event, the emulator validates the handler URL with `{event}` set to
 `validate`. The endpoint must answer OPTIONS (or GET when OPTIONS returns 404) with a 2xx status
 and `WebHook-Allowed-Origin` containing `*` or the request's `WebHook-Request-Origin` host.
 Origin matching is case-insensitive; values are matched as returned by the HTTP header parser,
@@ -184,13 +185,40 @@ later requests use the previous result while an expired entry refreshes. Success
 one minute. Failed validation retries on subsequent use after 1, 2, 4, 8, 16, 32, then 60 seconds
 (capped at one minute). Restart the emulator after changing handler configuration to clear the cache.
 
-Validation, connect, and notification requests retry HTTP 408, 5xx, and eligible `HttpRequestException`
+Validation and handler requests retry HTTP 408, 5xx, and eligible `HttpRequestException`
 failures after 1, 3, and 5 seconds (at most four attempts). HTTP 429, other 4xx responses,
 cancellation/timeouts, and the non-ASCII-header exception are not retried. Retries reuse the event
 identity and body, so handlers should tolerate duplicates. The HTTP client's default
 100-second deadline covers sending through response headers, including retry delays.
 
-User-event responses, bearer authentication, Key Vault URL references, and Event Hubs listeners
+### User events
+
+JSON and reliable JSON `event` messages use `EventPattern`, independently of `SystemEvents`.
+Patterns are comma-separated and case-insensitive. A standalone `*` matches all events, including
+dotted names. Within a pattern, `*` matches zero or more non-dot characters, `?` matches one
+non-dot character, and `**` crosses dots. The existing wildcard parser limits each pattern to
+1024 characters and accepts `\*`, `\?`, and `\\` escapes. The first matching handler wins;
+there is no `_default` hub fallback. Invalid patterns are rejected at startup.
+
+Requests carry `azure.webpubsub.user.<event>` CloudEvents, the original text/JSON/binary bytes,
+and per-message `x-webpubsub-metadata-*` headers. They reuse connection identity, signature,
+cookies, validation, and retries. A successful HTTP response may send a server message before
+the acknowledgement. Nonempty response bodies use `text/plain`, `application/json`, or
+`application/octet-stream`; absent Content-Type means binary. Empty bodies use text regardless
+of Content-Type and produce a message only when response metadata is present.
+
+Response metadata keys are lowercased; the last header value and its last comma-separated value
+(trimmed) win. Metadata belongs to that response, not the connection. Successful responses may
+update `ce-connectionState`, including an empty value; absent state preserves the previous value.
+Replies use the existing reliable buffer and are replayed after recovery without re-dispatching
+the event. Successful `ackId` values are cached; duplicates do not invoke the handler again.
+
+Missing handlers, non-2xx responses, unsupported nonempty response Content-Type, and response
+bodies exceeding 16 MiB yield a generic `InternalServerError` acknowledgement when `ackId` is
+present. Without `ackId`, errors are logged without closing the connection. Error response bodies
+and metadata are not forwarded for these `event` messages. Failed acknowledgements are not cached.
+
+Raw `sendEvent`/`noEcho`, protobuf responses, bearer authentication, Key Vault URL references, and Event Hubs listeners
 are not supported yet. Unsupported handler configuration is rejected at startup.
 
 ## Local server SDK authentication

--- a/tools/emulator/SUPPORTED_FEATURES.md
+++ b/tools/emulator/SUPPORTED_FEATURES.md
@@ -19,6 +19,7 @@ local Azure Web PubSub development.
 | Outbound delivery | Uses a bounded, single-writer queue for each WebSocket connection. | ✅ |
 | HTTP lifecycle handlers | Intercepts `connect` before upgrade, applies user/role/group/subprotocol overrides, and sends `connected` and final `disconnected` CloudEvents. Retains connect cookies and connection state. See [configuration and limitations](README.md#http-lifecycle-notifications). | ✅ |
 | HTTP handler validation and retries | Validates endpoints with OPTIONS/GET and cached allowed-origin results; retries HTTP 408, 5xx, and eligible network failures with 1/3/5-second delays. | ✅ |
+| HTTP user-event handlers | Routes JSON/reliable JSON events by `EventPattern`, forwards typed payloads and metadata, handles response data/metadata/state, and reuses reliable replay and acknowledgements. See [user events](README.md#user-events). | ✅ |
 | REST connection operations | Authenticated connection presence, direct text, JSON, and binary sends, close, and single-connection group membership changes for GA API versions from `2021-10-01` through `2024-12-01`. | ✅ |
 | REST group operations | Authenticated group presence and text, JSON, or binary fan-out with excluded connection IDs and OData filters. | ✅ |
 | REST broadcast | Authenticated text, JSON, or binary fan-out with excluded connection IDs and OData filters. | ✅ |
@@ -49,13 +50,13 @@ runtime's new contract and decode the original user ID path segment exactly once
 
 The following areas are planned for follow-up changes:
 
-- HTTP user-event handlers, bearer authentication, and Key Vault URL references
+- HTTP handler bearer authentication and Key Vault URL references
 - Tunnel connections (`tunnel://` upstream URLs)
 - Event Hubs listeners
 - Protobuf subprotocols
 - Client message streaming
 - Production Microsoft Entra ID validation
 
-Client events require a response-capable upstream handler. Until user-event handlers are implemented, JSON
+Client events require a matching response-capable upstream handler. Without one, JSON
 events with an `ackId` receive an `InternalServerError` acknowledgement; events without an
 `ackId` are logged without closing the client connection. Raw `sendEvent` mode is not available.

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorApplication.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorApplication.cs
@@ -33,7 +33,11 @@ internal static class EmulatorApplication
                     string.Equals(name, "connect", StringComparison.OrdinalIgnoreCase) ||
                     string.Equals(name, "connected", StringComparison.OrdinalIgnoreCase) ||
                     string.Equals(name, "disconnected", StringComparison.OrdinalIgnoreCase)))),
-                "Event handlers currently require an HTTP(S) URL without Key Vault references and support only connect/connected/disconnected.")
+                "Event handlers require an HTTP(S) URL without Key Vault references; supported system events are connect/connected/disconnected.")
+            .Validate(options => options.Hubs.Values.All(hub => hub.EventHandlers.All(handler =>
+                handler.EventPattern?.Split(',').All(pattern => string.IsNullOrWhiteSpace(pattern) ||
+                    WildcardPattern.TryCreate(pattern.Trim(), out _)) != false)),
+                "EventPattern must contain comma-separated wildcard patterns of at most 1024 characters with valid escapes.")
             .ValidateOnStart();
         builder.Services.AddSingleton(runtimeOptions ?? new EmulatorRuntimeOptions());
         builder.Services.AddSingleton<WebPubSubTokenService>();

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorApplication.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorApplication.cs
@@ -35,9 +35,10 @@ internal static class EmulatorApplication
                     string.Equals(name, "disconnected", StringComparison.OrdinalIgnoreCase)))),
                 "Event handlers require an HTTP(S) URL without Key Vault references; supported system events are connect/connected/disconnected.")
             .Validate(options => options.Hubs.Values.All(hub => hub.EventHandlers.All(handler =>
-                handler.EventPattern?.Split(',').All(pattern => string.IsNullOrWhiteSpace(pattern) ||
-                    WildcardPattern.TryCreate(pattern.Trim(), out _)) != false)),
-                "EventPattern must contain comma-separated wildcard patterns of at most 1024 characters with valid escapes.")
+                handler.EventPattern?.Split(',').TakeWhile(pattern => pattern.Trim() != "*")
+                    .All(pattern => string.IsNullOrWhiteSpace(pattern) ||
+                        WildcardPattern.TryCreate(pattern.Trim(), out _, maximumLength: null)) != false)),
+                "EventPattern must contain comma-separated wildcard patterns with valid escapes before any standalone *.")
             .ValidateOnStart();
         builder.Services.AddSingleton(runtimeOptions ?? new EmulatorRuntimeOptions());
         builder.Services.AddSingleton<WebPubSubTokenService>();

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorOptions.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorOptions.cs
@@ -47,8 +47,10 @@ internal sealed class EventHandlerOptions
     {
         var pattern = value.Trim();
         // Unlike a wildcard within a pattern, a standalone * also matches dots.
-        return pattern == "*" || string.Equals(pattern, eventName, StringComparison.OrdinalIgnoreCase) ||
-            WildcardPattern.TryCreate(pattern, out var matcher) && matcher!.Matches(eventName, ignoreCase: true);
+        return pattern == "*" || WildcardPattern.TryCreate(pattern, out var matcher, maximumLength: null) &&
+            // EventHandlerTemplateItem retains the original string for its literal fast path.
+            (matcher!.IsLiteral ? string.Equals(pattern, eventName, StringComparison.OrdinalIgnoreCase) :
+                matcher.Matches(eventName, ignoreCase: true));
     }) == true;
 }
 

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorOptions.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/EmulatorOptions.cs
@@ -40,6 +40,16 @@ internal sealed class EventHandlerOptions
     public string UrlTemplate { get; set; } = string.Empty;
 
     public string[] SystemEvents { get; set; } = [];
+
+    public string? EventPattern { get; set; }
+
+    public bool MatchesUserEvent(string eventName) => EventPattern?.Split(',').Any(value =>
+    {
+        var pattern = value.Trim();
+        // Unlike a wildcard within a pattern, a standalone * also matches dots.
+        return pattern == "*" || string.Equals(pattern, eventName, StringComparison.OrdinalIgnoreCase) ||
+            WildcardPattern.TryCreate(pattern, out var matcher) && matcher!.Matches(eventName, ignoreCase: true);
+    }) == true;
 }
 
 internal sealed class EmulatorRuntimeOptions

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/UpstreamEventDispatcher.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/UpstreamEventDispatcher.cs
@@ -13,6 +13,51 @@ namespace Microsoft.Azure.WebPubSub.Emulator;
 internal sealed class UpstreamEventDispatcher(
     IOptions<EmulatorOptions> options, HttpUpstreamTrigger trigger, ILogger<UpstreamEventDispatcher> logger)
 {
+    private const string MetadataHeaderPrefix = "x-webpubsub-metadata-";
+
+    public async Task<UpstreamEventResult> DispatchUserEventAsync(
+        UpstreamConnectionContext connection, ClientMessagePayload message, CancellationToken cancellationToken)
+    {
+        var id = connection.GetNextEventId();
+        var handler = options.Value.Hubs.TryGetValue(connection.Hub, out var settings)
+            ? settings.EventHandlers.FirstOrDefault(item => item.MatchesUserEvent(message.EventName))
+            : null;
+        if (handler is null)
+        {
+            throw new InvalidOperationException("No event handler is configured for this user event.");
+        }
+
+        using var response = await SendAsync(handler, connection, message.EventName, id,
+            message.Data.Bytes.ToArray(), cancellationToken, message.Data);
+        response.EnsureSuccessStatusCode();
+        await response.Content.LoadIntoBufferAsync(16 * 1024 * 1024, cancellationToken);
+        var bytes = await response.Content.ReadAsByteArrayAsync(cancellationToken);
+        // Runtime treats empty bodies as text, regardless of their Content-Type.
+        var type = bytes.Length == 0 ? MessageDataType.Text :
+            response.Content.Headers.ContentType?.MediaType?.ToLowerInvariant() switch
+            {
+                null or "application/octet-stream" => MessageDataType.Binary,
+                "text/plain" => MessageDataType.Text,
+                "application/json" => MessageDataType.Json,
+                _ => throw new InvalidDataException("Unsupported event handler response content type."),
+            };
+        Dictionary<string, string>? metadata = null;
+        foreach (var header in response.Headers)
+        {
+            if (!header.Key.StartsWith(MetadataHeaderPrefix, StringComparison.OrdinalIgnoreCase)) continue;
+            var key = header.Key[MetadataHeaderPrefix.Length..].ToLowerInvariant();
+            if (key.Length == 0) continue;
+            var value = header.Value.LastOrDefault() ?? string.Empty;
+            metadata ??= new(StringComparer.Ordinal);
+            metadata[key] = value[(value.LastIndexOf(',') + 1)..].Trim();
+        }
+        if (response.Headers.TryGetValues("ce-connectionState", out var state))
+        {
+            connection.ConnectionState = state.LastOrDefault();
+        }
+        return new(bytes.Length == 0 && metadata is null ? null : new MessageData(type, bytes, metadata));
+    }
+
     public async Task<(HttpStatusCode Status, ConnectEventResponse? Response)> DispatchConnectAsync(
         UpstreamConnectionContext connection, ConnectEventRequest body, CancellationToken cancellationToken)
     {
@@ -94,7 +139,7 @@ internal sealed class UpstreamEventDispatcher(
 
     private async Task<HttpResponseMessage> SendAsync(
         EventHandlerOptions handler, UpstreamConnectionContext connection, string eventName, int id,
-        byte[] body, CancellationToken cancellationToken)
+        byte[] body, CancellationToken cancellationToken, MessageData? userData = null)
     {
         if (!EventHandlerUrlTemplate.TryResolve(handler.UrlTemplate, connection.Hub, eventName, out var uri) ||
             !EventHandlerUrlTemplate.TryResolve(handler.UrlTemplate, connection.Hub, "validate", out var validationUri))
@@ -106,10 +151,24 @@ internal sealed class UpstreamEventDispatcher(
             Version = HttpVersion.Version20,
             Content = new ByteArrayContent(body),
         };
-        request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+        request.Content.Headers.ContentType = MediaTypeHeaderValue.Parse(userData?.Type switch
+        {
+            MessageDataType.Text => "text/plain; charset=utf-8",
+            MessageDataType.Binary => "application/octet-stream",
+            _ => "application/json",
+        });
+        if (userData?.Metadata is { } metadata)
+        {
+            var normalized = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var item in metadata) normalized[item.Key] = item.Value;
+            foreach (var item in normalized)
+            {
+                request.Headers.TryAddWithoutValidation(MetadataHeaderPrefix + item.Key.ToLowerInvariant(), item.Value);
+            }
+        }
         request.Headers.Add("ce-specversion", "1.0");
         request.Headers.Add("ce-awpsversion", "1.0");
-        request.Headers.Add("ce-type", $"azure.webpubsub.sys.{eventName}");
+        request.Headers.Add("ce-type", $"azure.webpubsub.{(userData is null ? "sys" : "user")}.{eventName}");
         request.Headers.Add("ce-source", $"/hubs/{connection.Hub}/client/{connection.ConnectionId}");
         request.Headers.Add("ce-id", id.ToString(CultureInfo.InvariantCulture));
         request.Headers.Add("ce-time", DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture));

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubClientConnectionLifetimeHandler.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WebPubSubClientConnectionLifetimeHandler.cs
@@ -17,7 +17,7 @@ internal sealed record ClientMessagePayload(
 
 internal sealed record UpstreamEventResult(MessageData? Response = null);
 
-internal sealed class WebPubSubClientConnectionLifetimeHandler :
+internal sealed class WebPubSubClientConnectionLifetimeHandler(UpstreamEventDispatcher events) :
     IWebPubSubConnectionLifetimeHandler
 {
     public Task<UpstreamEventResult> SendMessageAsync(
@@ -25,7 +25,6 @@ internal sealed class WebPubSubClientConnectionLifetimeHandler :
         ClientMessagePayload message,
         CancellationToken cancellationToken = default)
     {
-        throw new NotImplementedException(
-            "HTTP upstream event handlers are not implemented.");
+        return events.DispatchUserEventAsync(connection.UpstreamContext, message, cancellationToken);
     }
 }

--- a/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WildcardPattern.cs
+++ b/tools/emulator/src/Microsoft.Azure.WebPubSub.Emulator/WildcardPattern.cs
@@ -13,13 +13,16 @@ internal sealed class WildcardPattern
         _tokens = tokens;
     }
 
+    public bool IsLiteral => Array.TrueForAll(_tokens, token => token.Type == PatternTokenType.Literal);
+
     public static bool TryCreate(
         string pattern,
         out WildcardPattern? result,
-        int? maximumAsteriskCount = null)
+        int? maximumAsteriskCount = null,
+        int? maximumLength = MaxLength)
     {
         result = null;
-        if (string.IsNullOrEmpty(pattern) || pattern.Length > MaxLength)
+        if (string.IsNullOrEmpty(pattern) || pattern.Length > maximumLength)
         {
             return false;
         }

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/EmulatorApplicationTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/EmulatorApplicationTests.cs
@@ -43,6 +43,20 @@ public class EmulatorApplicationTests
         Assert.Equal("https://handler/tenant%2Fchat/message%20sent/{unknown}?event=message%20sent", uri.OriginalString);
     }
 
+    [Theory]
+    [InlineData("room\\")]
+    [InlineData("room\\x")]
+    public async Task InvalidEventPatternIsRejectedAtStartup(string pattern)
+    {
+        var builder = EmulatorApplication.CreateBuilder([
+            "--WebPubSub:Hubs:chat:EventHandlers:0:UrlTemplate=https://handler/events",
+            $"--WebPubSub:Hubs:chat:EventHandlers:0:EventPattern={pattern}"]);
+        builder.WebHost.UseTestServer();
+        await using var app = EmulatorApplication.Build(builder);
+        var error = await Assert.ThrowsAsync<OptionsValidationException>(() => app.StartAsync());
+        Assert.Contains("EventPattern", error.Message);
+    }
+
     [Fact]
     public async Task EffectiveEndpointComesFromBoundAddress()
     {

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/EmulatorApplicationTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/EmulatorApplicationTests.cs
@@ -46,6 +46,7 @@ public class EmulatorApplicationTests
     [Theory]
     [InlineData("room\\")]
     [InlineData("room\\x")]
+    [InlineData("room\\x,*")]
     public async Task InvalidEventPatternIsRejectedAtStartup(string pattern)
     {
         var builder = EmulatorApplication.CreateBuilder([
@@ -55,6 +56,38 @@ public class EmulatorApplicationTests
         await using var app = EmulatorApplication.Build(builder);
         var error = await Assert.ThrowsAsync<OptionsValidationException>(() => app.StartAsync());
         Assert.Contains("EventPattern", error.Message);
+    }
+
+    [Theory]
+    [InlineData(@"room\*", "room*", false)]
+    [InlineData(@"room\*", @"room\*", true)]
+    [InlineData(@"room\?", "room?", false)]
+    [InlineData(@"room\?", @"room\?", true)]
+    [InlineData(@"room\\", @"room\", false)]
+    [InlineData(@"room\\", @"room\\", true)]
+    [InlineData(@"room\*?", "room*a", true)]
+    [InlineData(@"room\?*", "room?abc", true)]
+    [InlineData(@"room\\*", @"room\abc", true)]
+    [InlineData(@"*,room\x", "any.event", true)]
+    public void EventPatternPreservesRuntimeLiteralAndWildcardPaths(string pattern, string input, bool expected)
+    {
+        Assert.Equal(expected, new EventHandlerOptions { EventPattern = pattern }.MatchesUserEvent(input));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task EventPatternsDoNotInheritPermissionLengthLimit(bool wildcard)
+    {
+        var pattern = new string('a', 1025) + (wildcard ? "*" : "");
+        Assert.False(WildcardPattern.TryCreate(pattern, out _)); // Existing permission callers retain their limit.
+        Assert.True(new EventHandlerOptions { EventPattern = pattern }.MatchesUserEvent(new string('a', wildcard ? 1026 : 1025)));
+        var builder = EmulatorApplication.CreateBuilder([
+            "--WebPubSub:Hubs:chat:EventHandlers:0:UrlTemplate=https://handler/events",
+            $"--WebPubSub:Hubs:chat:EventHandlers:0:EventPattern={pattern},*,ignored\\x"]);
+        builder.WebHost.UseTestServer();
+        await using var app = EmulatorApplication.Build(builder);
+        await app.StartAsync();
     }
 
     [Fact]

--- a/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/UpstreamUserEventTests.cs
+++ b/tools/emulator/tests/Microsoft.Azure.WebPubSub.Emulator.Tests/UpstreamUserEventTests.cs
@@ -1,0 +1,357 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Microsoft.Azure.WebPubSub.Emulator.Tests;
+
+public class UpstreamUserEventTests
+{
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(15);
+
+    [Theory]
+    [InlineData("*", "room.message", true)]
+    [InlineData("join, ROOM.*", "room.message", true)]
+    [InlineData("room.*", "room.message.more", false)]
+    [InlineData("room.**", "room.message.more", true)]
+    [InlineData("room.?", "room.a", true)]
+    [InlineData("room.?", "room..", false)]
+    [InlineData("CONNECTED", "connected", true)]
+    [InlineData(null, "connected", false)]
+    public async Task RoutesUserEventsSeparatelyFromSystemEvents(string? pattern, string name, bool matches)
+    {
+        await using var fixture = await Fixture.StartAsync(_ => Task.CompletedTask, pattern);
+        using var socket = await fixture.ConnectAsync();
+        await SendAsync(socket, name);
+        using var ack = await ReceiveAsync(socket);
+        Assert.Equal(matches, ack.RootElement.GetProperty("success").GetBoolean());
+        if (matches)
+        {
+            var received = await fixture.ReadAsync();
+            Assert.Equal("azure.webpubsub.user." + name, received.Headers["ce-type"]);
+        }
+        else
+        {
+            Assert.False(fixture.Events.Reader.TryRead(out _));
+            Assert.Equal("InternalServerError", ack.RootElement.GetProperty("error").GetProperty("name").GetString());
+        }
+    }
+
+    [Theory]
+    [InlineData("text/plain", "hello", "text")]
+    [InlineData("text/plain; charset=utf-8", "你好", "text")]
+    [InlineData("application/json", "{\"answer\":42}", "json")]
+    [InlineData("application/octet-stream", "hello", "binary")]
+    [InlineData(null, "hello", "binary")]
+    [InlineData("unsupported/type", "", "text")]
+    public async Task ResponseBodyAndMetadataPrecedeAck(string? contentType, string body, string expectedType)
+    {
+        await using var fixture = await Fixture.StartAsync(async context =>
+        {
+            context.Response.ContentType = contentType;
+            context.Response.Headers["X-WebPubSub-Metadata-Trace"] = new[] { "first", " middle, last " };
+            context.Response.Headers["X-WebPubSub-Metadata-"] = "ignored";
+            await context.Response.Body.WriteAsync(Encoding.UTF8.GetBytes(body));
+        });
+        using var socket = await fixture.ConnectAsync();
+        await SendAsync(socket, "message");
+        using var data = await ReceiveAsync(socket);
+        Assert.Equal("message", data.RootElement.GetProperty("type").GetString());
+        Assert.Equal("server", data.RootElement.GetProperty("from").GetString());
+        Assert.Equal(expectedType, data.RootElement.GetProperty("dataType").GetString());
+        Assert.Equal("last", data.RootElement.GetProperty("metadata").GetProperty("trace").GetString());
+        Assert.Single(data.RootElement.GetProperty("metadata").EnumerateObject());
+        Assert.Equal(expectedType switch
+        {
+            "binary" => Convert.ToBase64String(Encoding.UTF8.GetBytes(body)),
+            "json" => body,
+            _ => body,
+        }, expectedType == "json" ? data.RootElement.GetProperty("data").GetRawText() : data.RootElement.GetProperty("data").GetString());
+        using var ack = await ReceiveAsync(socket);
+        Assert.True(ack.RootElement.GetProperty("success").GetBoolean());
+    }
+
+    [Theory]
+    [InlineData("text", "\"你好\"", "你好", "text/plain; charset=utf-8")]
+    [InlineData("json", "{\"value\":1}", "{\"value\":1}", "application/json")]
+    [InlineData("binary", "\"AP8=\"", null, "application/octet-stream")]
+    public async Task RequestCarriesTypedBytesAndMetadata(string type, string data, string? text, string contentType)
+    {
+        await using var fixture = await Fixture.StartAsync(_ => Task.CompletedTask);
+        using var socket = await fixture.ConnectAsync();
+        await socket.SendAsync(Encoding.UTF8.GetBytes($$$"""{"type":"event","event":"message","ackId":1,"dataType":"{{{type}}}","data":{{{data}}},"metadata":{"Trace":"value"}}"""), WebSocketMessageType.Text, true, CancellationToken.None);
+        using var ack = await ReceiveAsync(socket);
+        Assert.True(ack.RootElement.GetProperty("success").GetBoolean());
+        var received = await fixture.ReadAsync();
+        Assert.Equal(text is null ? new byte[] { 0, 255 } : Encoding.UTF8.GetBytes(text), received.Body);
+        Assert.Equal(contentType, received.Headers["Content-Type"]);
+        Assert.Equal("value", received.Headers["x-webpubsub-metadata-trace"]);
+        Assert.Equal("2", received.Headers["ce-id"]);
+        Assert.False(received.Headers.ContainsKey("Authorization"));
+    }
+
+    [Fact]
+    public async Task RetryReusesIdentityAndSuccessfulStatePersistsWithoutDuplicateDispatch()
+    {
+        var attempts = 0;
+        await using var fixture = await Fixture.StartAsync(context =>
+        {
+            context.Response.StatusCode = ++attempts == 1 ? 503 : 200;
+            context.Response.Headers["ce-connectionState"] = "";
+            context.Response.Cookies.Append("affinity", "user");
+            return Task.CompletedTask;
+        });
+        using var socket = await fixture.ConnectAsync(reliable: true);
+        await SendAsync(socket, "message");
+        using var ack = await ReceiveAsync(socket);
+        Assert.True(ack.RootElement.GetProperty("success").GetBoolean());
+        var first = await fixture.ReadAsync();
+        var retry = await fixture.ReadAsync();
+        Assert.Equal(first.Headers["ce-id"], retry.Headers["ce-id"]);
+        Assert.Equal(first.Headers["x-ms-client-request-id"], retry.Headers["x-ms-client-request-id"]);
+        Assert.Equal(first.Body, retry.Body);
+        Assert.Equal("initial", first.Headers["ce-connectionState"]);
+        await SendAsync(socket, "message");
+        using var duplicate = await ReceiveAsync(socket);
+        Assert.Equal("Duplicate", duplicate.RootElement.GetProperty("error").GetProperty("name").GetString());
+        Assert.Equal(2, attempts);
+        await SendAsync(socket, "message", 2);
+        using var nextAck = await ReceiveAsync(socket);
+        var next = await fixture.ReadAsync();
+        Assert.Equal("3", next.Headers["ce-id"]);
+        Assert.Equal("", next.Headers["ce-connectionState"]);
+        Assert.Equal("affinity=user", next.Headers["Cookie"]);
+        Assert.Equal(first.Headers["ce-signature"], next.Headers["ce-signature"]);
+    }
+
+    [Theory]
+    [InlineData(400, "text/plain", "private upstream error")]
+    [InlineData(429, "text/plain", "private upstream error")]
+    [InlineData(200, "unsupported/type", "nonempty")]
+    public async Task FailureDoesNotUpdateStateOrCacheAck(int status, string contentType, string body)
+    {
+        var count = 0;
+        await using var fixture = await Fixture.StartAsync(async context =>
+        {
+            if (++count > 1) return;
+            context.Response.StatusCode = status;
+            context.Response.ContentType = contentType;
+            context.Response.Headers["ce-connectionState"] = "must-not-apply";
+            context.Response.Headers["x-webpubsub-metadata-error"] = "must-not-forward";
+            await context.Response.WriteAsync(body);
+        });
+        using var socket = await fixture.ConnectAsync();
+        await SendAsync(socket, "message");
+        using var failed = await ReceiveAsync(socket);
+        Assert.False(failed.RootElement.GetProperty("success").GetBoolean());
+        Assert.False(failed.RootElement.TryGetProperty("metadata", out _));
+        Assert.Equal("Internal server error", failed.RootElement.GetProperty("error").GetProperty("message").GetString());
+        await fixture.ReadAsync();
+        await SendAsync(socket, "message");
+        using var success = await ReceiveAsync(socket);
+        Assert.True(success.RootElement.GetProperty("success").GetBoolean());
+        Assert.Equal("initial", (await fixture.ReadAsync()).Headers["ce-connectionState"]);
+        Assert.Equal(2, count);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task OversizedResponseFailsWithOrWithoutContentLength(bool knownLength)
+    {
+        await using var fixture = await Fixture.StartAsync(async context =>
+        {
+            if (knownLength) context.Response.ContentLength = 16 * 1024 * 1024 + 1;
+            var block = new byte[64 * 1024];
+            for (var i = 0; i < 257; i++) await context.Response.Body.WriteAsync(block, context.RequestAborted);
+        });
+        using var socket = await fixture.ConnectAsync();
+        await SendAsync(socket, "message");
+        using var ack = await ReceiveAsync(socket);
+        Assert.False(ack.RootElement.GetProperty("success").GetBoolean());
+    }
+
+    [Fact]
+    public async Task FirstMatchingHandlerWinsWithoutDefaultHubFallback()
+    {
+        await using var fixture = await Fixture.StartAsync(context =>
+        {
+            context.Response.ContentType = "text/plain";
+            return context.Response.WriteAsync(context.Request.Path);
+        }, extraSettings: new Dictionary<string, string?>
+        {
+            ["WebPubSub:Hubs:chat:EventHandlers:1:UrlTemplate"] = "http://127.0.0.1:1/must-not-call",
+            ["WebPubSub:Hubs:chat:EventHandlers:1:EventPattern"] = "*",
+            ["WebPubSub:Hubs:_default:EventHandlers:0:UrlTemplate"] = "http://127.0.0.1:1/must-not-call",
+            ["WebPubSub:Hubs:_default:EventHandlers:0:EventPattern"] = "*",
+        });
+        using var socket = await fixture.ConnectAsync();
+        await SendAsync(socket, "message");
+        using var data = await ReceiveAsync(socket);
+        Assert.Equal("/events/chat/message", data.RootElement.GetProperty("data").GetString());
+        using var ack = await ReceiveAsync(socket);
+        Assert.True(ack.RootElement.GetProperty("success").GetBoolean());
+        await Assert.ThrowsAsync<InvalidOperationException>(() => fixture.Dispatcher.DispatchUserEventAsync(
+            new UpstreamConnectionContext("missing", "unconfigured", null, null, "localhost"),
+            new ClientMessagePayload("message", new MessageData(MessageDataType.Text, ReadOnlyMemory<byte>.Empty)), CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ValidationFailureNeverDispatchesUserEvent()
+    {
+        await using var fixture = await Fixture.StartAsync(_ => Task.CompletedTask, allowOrigin: false);
+        await Assert.ThrowsAsync<HttpRequestException>(() => fixture.Dispatcher.DispatchUserEventAsync(
+            new UpstreamConnectionContext("blocked", "chat", null, null, "localhost"),
+            new ClientMessagePayload("message", new MessageData(MessageDataType.Text, ReadOnlyMemory<byte>.Empty)), CancellationToken.None));
+        Assert.False(fixture.Events.Reader.TryRead(out _));
+    }
+
+    [Fact]
+    public async Task ReliableResponseWithoutAckIsReplayedAfterRecovery()
+    {
+        await using var fixture = await Fixture.StartAsync(context =>
+        {
+            context.Response.ContentType = "text/plain";
+            return context.Response.WriteAsync("reply");
+        });
+        using var socket = await fixture.ConnectAsync(reliable: true);
+        await socket.SendAsync("{\"type\":\"event\",\"event\":\"message\",\"dataType\":\"text\",\"data\":\"hello\"}"u8.ToArray(),
+            WebSocketMessageType.Text, true, CancellationToken.None);
+        using var data = await ReceiveAsync(socket);
+        Assert.Equal(1, data.RootElement.GetProperty("sequenceId").GetInt32());
+        Assert.Equal("reply", data.RootElement.GetProperty("data").GetString());
+        var received = await fixture.ReadAsync();
+        socket.Abort();
+        using var recovered = new ClientWebSocket();
+        recovered.Options.AddSubProtocol("json.reliable.webpubsub.azure.v1");
+        await recovered.ConnectAsync(fixture.RecoveryUri(received.Headers["ce-connectionId"]), CancellationToken.None).WaitAsync(Timeout);
+        using var replay = await ReceiveAsync(recovered);
+        Assert.Equal(data.RootElement.GetRawText(), replay.RootElement.GetRawText());
+        Assert.False(fixture.Events.Reader.TryRead(out _));
+    }
+
+    [Fact]
+    public async Task CancellationReachesHttpRequest()
+    {
+        var aborted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using var fixture = await Fixture.StartAsync(async context =>
+        {
+            using var registration = context.RequestAborted.Register(() => aborted.TrySetResult());
+            await aborted.Task.WaitAsync(Timeout);
+        });
+        using var cancellation = new CancellationTokenSource();
+        var context = new UpstreamConnectionContext("connection", "chat", null, null, "localhost");
+        var sending = fixture.Dispatcher.DispatchUserEventAsync(context,
+            new ClientMessagePayload("message", new MessageData(MessageDataType.Text, "hello"u8.ToArray())), cancellation.Token);
+        await fixture.ReadAsync();
+        cancellation.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => sending);
+        await aborted.Task.WaitAsync(Timeout);
+    }
+
+    private static Task SendAsync(ClientWebSocket socket, string name, int ackId = 1) => socket.SendAsync(
+        Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new { type = "event", @event = name, ackId, dataType = "text", data = "hello" })),
+        WebSocketMessageType.Text, true, CancellationToken.None);
+
+    private static async Task<JsonDocument> ReceiveAsync(ClientWebSocket socket)
+    {
+        var buffer = new byte[4096];
+        var result = await socket.ReceiveAsync(buffer, CancellationToken.None).WaitAsync(Timeout);
+        Assert.Equal(WebSocketMessageType.Text, result.MessageType);
+        Assert.True(result.EndOfMessage);
+        return JsonDocument.Parse(buffer.AsMemory(0, result.Count));
+    }
+
+    private sealed record Received(byte[] Body, Dictionary<string, string> Headers);
+
+    private sealed class Fixture(WebApplication upstream, WebApplication app, Channel<Received> events) : IAsyncDisposable
+    {
+        public Channel<Received> Events => events;
+        public UpstreamEventDispatcher Dispatcher => app.Services.GetRequiredService<UpstreamEventDispatcher>();
+        public Task<Received> ReadAsync() => events.Reader.ReadAsync().AsTask().WaitAsync(Timeout);
+        private string? _reconnectionToken;
+
+        public Uri RecoveryUri(string connectionId) => new(app.Urls.Single().Replace("http:", "ws:") +
+            $"/client/hubs/chat?awps_connection_id={connectionId}&awps_reconnection_token={Uri.EscapeDataString(_reconnectionToken!)}");
+
+        public async Task<ClientWebSocket> ConnectAsync(bool reliable = false)
+        {
+            var endpoint = app.Urls.Single() + "/client/hubs/chat";
+            var token = new JwtSecurityTokenHandler().WriteToken(new JwtSecurityToken(
+                audience: endpoint, expires: DateTime.UtcNow.AddHours(1), signingCredentials: new SigningCredentials(
+                    new SymmetricSecurityKey(Encoding.UTF8.GetBytes(EmulatorOptions.DefaultAccessKey)), SecurityAlgorithms.HmacSha256)));
+            var socket = new ClientWebSocket();
+            socket.Options.AddSubProtocol(reliable ? "json.reliable.webpubsub.azure.v1" : "json.webpubsub.azure.v1");
+            await socket.ConnectAsync(new Uri(endpoint.Replace("http:", "ws:") + "?access_token=" + token), CancellationToken.None).WaitAsync(Timeout);
+            using var connected = await ReceiveAsync(socket);
+            Assert.Equal("connected", connected.RootElement.GetProperty("event").GetString());
+            if (reliable) _reconnectionToken = connected.RootElement.GetProperty("reconnectionToken").GetString();
+            return socket;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await app.DisposeAsync();
+            await upstream.DisposeAsync();
+        }
+
+        public static async Task<Fixture> StartAsync(Func<HttpContext, Task> onEvent, string? pattern = "*",
+            Dictionary<string, string?>? extraSettings = null, bool allowOrigin = true)
+        {
+            var events = Channel.CreateUnbounded<Received>();
+            var builder = WebApplication.CreateBuilder(["--urls=http://127.0.0.1:0"]);
+            builder.Logging.ClearProviders();
+            var upstream = builder.Build();
+            upstream.Run(async context =>
+            {
+                if (HttpMethods.IsOptions(context.Request.Method))
+                {
+                    if (allowOrigin) context.Response.Headers["WebHook-Allowed-Origin"] = "*";
+                    return;
+                }
+                if (context.Request.Headers["ce-type"].ToString().StartsWith("azure.webpubsub.sys.", StringComparison.Ordinal))
+                {
+                    context.Response.Headers["ce-connectionState"] = "initial";
+                    return;
+                }
+                using var body = new MemoryStream();
+                await context.Request.Body.CopyToAsync(body);
+                events.Writer.TryWrite(new Received(body.ToArray(), context.Request.Headers.ToDictionary(
+                    h => h.Key, h => h.Value.ToString(), StringComparer.OrdinalIgnoreCase)));
+                await onEvent(context);
+            });
+            await upstream.StartAsync();
+            var emulator = EmulatorApplication.CreateBuilder(["--urls=http://127.0.0.1:0"]);
+            emulator.Logging.ClearProviders();
+            emulator.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["WebPubSub:Hubs:chat:EventHandlers:0:UrlTemplate"] = upstream.Urls.Single() + "/events/{hub}/{event}",
+                ["WebPubSub:Hubs:chat:EventHandlers:0:SystemEvents:0"] = "connect",
+                ["WebPubSub:Hubs:chat:EventHandlers:0:SystemEvents:1"] = "connected",
+                ["WebPubSub:Hubs:chat:EventHandlers:0:EventPattern"] = pattern,
+            });
+            if (extraSettings is not null) emulator.Configuration.AddInMemoryCollection(extraSettings);
+            var app = EmulatorApplication.Build(emulator);
+            await app.StartAsync();
+            return new Fixture(upstream, app, events);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

H4 slice of #1123, based on the merged connect-handshake slice #1129 (following #1124 and #1126).

- Route JSON and reliable JSON user events by per-hub EventPattern, independently of SystemEvents.
- Forward text/JSON/binary payloads and per-message metadata through the existing lifetime handler, dispatcher, and HTTP trigger; reuse validation, retries, identity, signatures, cookies, and connection state.
- Handle bounded response bodies and metadata-only responses; send server data before acknowledgement through the existing client processor and reliable replay buffer.
- Failed events return the existing generic InternalServerError acknowledgement without caching the ack ID or updating connection state.

## Runtime alignment and review correction

- First matching handler wins; no _default hub fallback. A standalone * matches all events and stops parsing later list entries; embedded */? exclude dots and ** crosses dots.
- Event patterns do not inherit the permission-pattern 1024-character limit. Existing permission callers retain that limit.
- Preserve EventHandlerTemplateItem literal behavior: all-literal token sequences compare the original pattern string, including escape characters; mixed wildcard patterns use tokenized matching. Invalid escapes before a standalone * are rejected.
- Nonempty responses without Content-Type are binary; empty bodies use text regardless of Content-Type. Response metadata uses lowercase keys and the trimmed final comma-separated value of the last header value.
- Metadata is per-message, not persistent connection metadata. Ordinary event failures do not forward upstream error bodies or metadata; invocation error responses are outside this slice.

## Comparison with umbrella #1123 / scope

Extracts only user-event request/response behavior, keeping the H1-H3 architecture rather than copying the umbrella HTTP/auth implementation. Corrects standalone-star matching, response content-type defaults, metadata parsing, and empty connection-state handling. No extra upstream metadata validation is introduced beyond the runtime event path.

Deferred: handler bearer authentication, raw sendEvent/noEcho, Event Hubs listeners, protobuf responses, streaming and invocation support. Subsequent slices extend the same dispatcher/trigger/context boundaries.

## Validation

- Latest local full Release suite on Windows: 285/285 passed at 8c822baa.
- 27 real HTTP/WebSocket user-event tests cover routing, payload types, metadata-only responses, validation, retry identity, state/cookies, failures, bounded responses, cancellation, and reliable recovery/replay.
- These 27 integration cases passed three additional rounds before the pattern review correction; the full 285-test run includes that correction and its regression cases.
- Latest HEAD Release build and package generation passed; modified-file diagnostics and git diff --check passed.
- 9 files, +531/-17. No dependencies added. Remote CI is not yet verified.